### PR TITLE
Triage the list of allowed lints, addressing most of them.

### DIFF
--- a/src/cfg.rs
+++ b/src/cfg.rs
@@ -149,7 +149,7 @@ impl ControlFlowGraph {
 
     fn traverse(
         &self,
-        func_at_region: FuncAt<ControlRegion>,
+        func_at_region: FuncAt<'_, ControlRegion>,
         incoming_edge_counts: &mut EntityOrientedDenseMap<ControlRegion, IncomingEdgeCount>,
         pre_order_visit: &mut impl FnMut(ControlRegion),
         post_order_visit: &mut impl FnMut(ControlRegion),

--- a/src/cfg.rs
+++ b/src/cfg.rs
@@ -770,8 +770,7 @@ impl<'a> Structurizer<'a> {
                         inputs: [].into_iter().collect(),
                         children: EntityList::empty(),
                         outputs: [].into_iter().collect(),
-                    }
-                    .into(),
+                    },
                 );
                 self.func_def_body
                     .unstructured_cfg
@@ -1235,8 +1234,7 @@ impl<'a> Structurizer<'a> {
                             inputs: [].into_iter().collect(),
                             children: EntityList::empty(),
                             outputs: [].into_iter().collect(),
-                        }
-                        .into(),
+                        },
                     );
                     control_source = Some(new_empty_region);
                     Some((new_empty_region, [].into_iter().collect()))

--- a/src/cfg.rs
+++ b/src/cfg.rs
@@ -743,7 +743,7 @@ impl<'a> Structurizer<'a> {
                 ControlInstKind::Branch => {
                     assert_eq!((inputs.len(), child_regions.len()), (0, 1));
 
-                    Ok(child_regions.into_iter().nth(0).unwrap())
+                    Ok(child_regions.into_iter().next().unwrap())
                 }
 
                 ControlInstKind::SelectBranch(kind) => {

--- a/src/context.rs
+++ b/src/context.rs
@@ -365,6 +365,7 @@ impl<K: Copy + Eq + Hash, V: Default> SmallFxHashMap<K, V> {
     }
 
     fn get(&self, k: K) -> Option<&V> {
+        #[allow(clippy::match_same_arms)]
         match self {
             Self::Empty => None,
             Self::One(old_k, old_v) if *old_k == k => Some(old_v),
@@ -374,6 +375,7 @@ impl<K: Copy + Eq + Hash, V: Default> SmallFxHashMap<K, V> {
     }
 
     fn get_mut(&mut self, k: K) -> Option<&mut V> {
+        #[allow(clippy::match_same_arms)]
         match self {
             Self::Empty => None,
             Self::One(old_k, old_v) if *old_k == k => Some(old_v),

--- a/src/func_at.rs
+++ b/src/func_at.rs
@@ -59,7 +59,7 @@ impl<'a> IntoIterator for FuncAt<'a, EntityList<ControlNode>> {
 impl<'a> Iterator for FuncAt<'a, EntityListIter<ControlNode>> {
     type Item = FuncAt<'a, ControlNode>;
     fn next(&mut self) -> Option<Self::Item> {
-        let (next, rest) = self.position.split_first(&self.control_nodes)?;
+        let (next, rest) = self.position.split_first(self.control_nodes)?;
         self.position = rest;
         Some(self.at(next))
     }
@@ -82,7 +82,7 @@ impl<'a> IntoIterator for FuncAt<'a, EntityList<DataInst>> {
 impl<'a> Iterator for FuncAt<'a, EntityListIter<DataInst>> {
     type Item = FuncAt<'a, DataInst>;
     fn next(&mut self) -> Option<Self::Item> {
-        let (next, rest) = self.position.split_first(&self.data_insts)?;
+        let (next, rest) = self.position.split_first(self.data_insts)?;
         self.position = rest;
         Some(self.at(next))
     }
@@ -167,7 +167,7 @@ impl<'a> FuncAtMut<'a, EntityList<ControlNode>> {
 // HACK(eddyb) can't implement `Iterator` because `next` borrows `self`.
 impl FuncAtMut<'_, EntityListIter<ControlNode>> {
     pub fn next(&mut self) -> Option<FuncAtMut<'_, ControlNode>> {
-        let (next, rest) = self.position.split_first(&self.control_nodes)?;
+        let (next, rest) = self.position.split_first(self.control_nodes)?;
         self.position = rest;
         Some(self.reborrow().at(next))
     }
@@ -190,7 +190,7 @@ impl<'a> FuncAtMut<'a, EntityList<DataInst>> {
 // HACK(eddyb) can't implement `Iterator` because `next` borrows `self`.
 impl FuncAtMut<'_, EntityListIter<DataInst>> {
     pub fn next(&mut self) -> Option<FuncAtMut<'_, DataInst>> {
-        let (next, rest) = self.position.split_first(&self.data_insts)?;
+        let (next, rest) = self.position.split_first(self.data_insts)?;
         self.position = rest;
         Some(self.reborrow().at(next))
     }

--- a/src/func_at.rs
+++ b/src/func_at.rs
@@ -8,6 +8,9 @@
 //!     without going through `P` (as `EntityDefs` requires keys for any access)
 //! * they're dedicated types with inherent methods and trait `impl`s
 
+// NOTE(eddyb) wrong wrt lifetimes (https://github.com/rust-lang/rust-clippy/issues/5004).
+#![allow(clippy::should_implement_trait)]
+
 use crate::{
     Context, ControlNode, ControlNodeDef, ControlRegion, ControlRegionDef, DataInst, DataInstDef,
     EntityDefs, EntityList, EntityListIter, FuncDefBody, Type, Value,

--- a/src/func_at.rs
+++ b/src/func_at.rs
@@ -204,7 +204,7 @@ impl<'a> FuncAtMut<'a, DataInst> {
 
 impl FuncDefBody {
     /// Start immutably traversing the function at `position`.
-    pub fn at<'a, P: Copy>(&'a self, position: P) -> FuncAt<'a, P> {
+    pub fn at<P: Copy>(&self, position: P) -> FuncAt<'_, P> {
         FuncAt {
             control_regions: &self.control_regions,
             control_nodes: &self.control_nodes,
@@ -214,7 +214,7 @@ impl FuncDefBody {
     }
 
     /// Start mutably traversing the function at `position`.
-    pub fn at_mut<'a, P: Copy>(&'a mut self, position: P) -> FuncAtMut<'a, P> {
+    pub fn at_mut<P: Copy>(&mut self, position: P) -> FuncAtMut<'_, P> {
         FuncAtMut {
             control_regions: &mut self.control_regions,
             control_nodes: &mut self.control_nodes,
@@ -224,12 +224,12 @@ impl FuncDefBody {
     }
 
     /// Shorthand for `func_def_body.at(func_def_body.body)`.
-    pub fn at_body<'a>(&'a self) -> FuncAt<'a, ControlRegion> {
+    pub fn at_body(&self) -> FuncAt<'_, ControlRegion> {
         self.at(self.body)
     }
 
     /// Shorthand for `func_def_body.at_mut(func_def_body.body)`.
-    pub fn at_mut_body<'a>(&'a mut self) -> FuncAtMut<'a, ControlRegion> {
+    pub fn at_mut_body(&mut self) -> FuncAtMut<'_, ControlRegion> {
         self.at_mut(self.body)
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -92,8 +92,11 @@
     // NOTE(eddyb) ignored for readability (`match` used when `if let` is too long).
     clippy::single_match_else,
 
-    // FIXME(eddyb) review all of these (some of them are intentional, sadly).
+    // NOTE(eddyb) ignored because it's misguided to suggest `let mut s = ...;`
+    // and `s.push_str(...);` when `+` is equivalent and does not require `let`.
     clippy::string_add,
+
+    // FIXME(eddyb) review all of these (some of them are intentional, sadly).
     clippy::unimplemented,
     clippy::unnested_or_patterns,
     clippy::unused_self,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -90,7 +90,6 @@
 // crate-specific exceptions:
 #![allow(
     // FIXME(eddyb) review all of these (some of them are intentional, sadly).
-    clippy::comparison_to_empty,
     clippy::get_first,
     clippy::iter_nth_zero,
     clippy::map_err_ignore,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -90,7 +90,6 @@
 // crate-specific exceptions:
 #![allow(
     // FIXME(eddyb) review all of these (some of them are intentional, sadly).
-    clippy::redundant_closure,
     clippy::redundant_closure_call,
     clippy::redundant_field_names,
     clippy::semicolon_if_nothing_returned,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -97,7 +97,6 @@
     clippy::string_add,
 
     // FIXME(eddyb) review all of these (some of them are intentional, sadly).
-    clippy::vtable_address_comparisons,
     elided_lifetimes_in_paths,
 )]
 // NOTE(eddyb) this is stronger than the "Embark standard lints" above, because

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -95,9 +95,6 @@
     // NOTE(eddyb) ignored because it's misguided to suggest `let mut s = ...;`
     // and `s.push_str(...);` when `+` is equivalent and does not require `let`.
     clippy::string_add,
-
-    // FIXME(eddyb) review all of these (some of them are intentional, sadly).
-    elided_lifetimes_in_paths,
 )]
 // NOTE(eddyb) this is stronger than the "Embark standard lints" above, because
 // we almost never need `unsafe` code and this is a further "speed bump" to it.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -90,7 +90,6 @@
 // crate-specific exceptions:
 #![allow(
     // FIXME(eddyb) review all of these (some of them are intentional, sadly).
-    clippy::should_implement_trait,
     clippy::single_match,
     clippy::single_match_else,
     clippy::string_add,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -97,7 +97,6 @@
     clippy::string_add,
 
     // FIXME(eddyb) review all of these (some of them are intentional, sadly).
-    clippy::useless_conversion,
     clippy::vtable_address_comparisons,
     elided_lifetimes_in_paths,
 )]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -89,8 +89,10 @@
 // END - Embark standard lints v6 for Rust 1.55+
 // crate-specific exceptions:
 #![allow(
-    // FIXME(eddyb) review all of these (some of them are intentional, sadly).
+    // NOTE(eddyb) ignored for readability (`match` used when `if let` is too long).
     clippy::single_match_else,
+
+    // FIXME(eddyb) review all of these (some of them are intentional, sadly).
     clippy::string_add,
     clippy::unimplemented,
     clippy::unnested_or_patterns,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -97,7 +97,6 @@
     clippy::string_add,
 
     // FIXME(eddyb) review all of these (some of them are intentional, sadly).
-    clippy::unused_self,
     clippy::useless_conversion,
     clippy::vtable_address_comparisons,
     elided_lifetimes_in_paths,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -90,7 +90,6 @@
 // crate-specific exceptions:
 #![allow(
     // FIXME(eddyb) review all of these (some of them are intentional, sadly).
-    clippy::match_same_arms,
     clippy::match_wildcard_for_single_variants,
     clippy::needless_borrow,
     clippy::needless_lifetimes,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -90,7 +90,6 @@
 // crate-specific exceptions:
 #![allow(
     // FIXME(eddyb) review all of these (some of them are intentional, sadly).
-    clippy::redundant_closure_call,
     clippy::redundant_field_names,
     clippy::semicolon_if_nothing_returned,
     clippy::should_implement_trait,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -97,7 +97,6 @@
     clippy::string_add,
 
     // FIXME(eddyb) review all of these (some of them are intentional, sadly).
-    clippy::unnested_or_patterns,
     clippy::unused_self,
     clippy::useless_conversion,
     clippy::vtable_address_comparisons,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -90,7 +90,6 @@
 // crate-specific exceptions:
 #![allow(
     // FIXME(eddyb) review all of these (some of them are intentional, sadly).
-    clippy::get_first,
     clippy::iter_nth_zero,
     clippy::map_err_ignore,
     clippy::match_same_arms,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -90,7 +90,6 @@
 // crate-specific exceptions:
 #![allow(
     // FIXME(eddyb) review all of these (some of them are intentional, sadly).
-    clippy::needless_borrow,
     clippy::needless_lifetimes,
     clippy::nonminimal_bool,
     clippy::redundant_closure,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -90,7 +90,6 @@
 // crate-specific exceptions:
 #![allow(
     // FIXME(eddyb) review all of these (some of them are intentional, sadly).
-    clippy::needless_lifetimes,
     clippy::nonminimal_bool,
     clippy::redundant_closure,
     clippy::redundant_closure_call,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -90,7 +90,6 @@
 // crate-specific exceptions:
 #![allow(
     // FIXME(eddyb) review all of these (some of them are intentional, sadly).
-    clippy::map_err_ignore,
     clippy::match_same_arms,
     clippy::match_wildcard_for_single_variants,
     clippy::needless_borrow,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -97,7 +97,6 @@
     clippy::string_add,
 
     // FIXME(eddyb) review all of these (some of them are intentional, sadly).
-    clippy::unimplemented,
     clippy::unnested_or_patterns,
     clippy::unused_self,
     clippy::useless_conversion,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -90,7 +90,6 @@
 // crate-specific exceptions:
 #![allow(
     // FIXME(eddyb) review all of these (some of them are intentional, sadly).
-    clippy::single_match,
     clippy::single_match_else,
     clippy::string_add,
     clippy::unimplemented,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -90,7 +90,6 @@
 // crate-specific exceptions:
 #![allow(
     // FIXME(eddyb) review all of these (some of them are intentional, sadly).
-    clippy::collapsible_if,
     clippy::comparison_to_empty,
     clippy::get_first,
     clippy::iter_nth_zero,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -90,7 +90,6 @@
 // crate-specific exceptions:
 #![allow(
     // FIXME(eddyb) review all of these (some of them are intentional, sadly).
-    clippy::iter_nth_zero,
     clippy::map_err_ignore,
     clippy::match_same_arms,
     clippy::match_wildcard_for_single_variants,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -90,7 +90,6 @@
 // crate-specific exceptions:
 #![allow(
     // FIXME(eddyb) review all of these (some of them are intentional, sadly).
-    clippy::redundant_field_names,
     clippy::semicolon_if_nothing_returned,
     clippy::should_implement_trait,
     clippy::single_match,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -90,7 +90,6 @@
 // crate-specific exceptions:
 #![allow(
     // FIXME(eddyb) review all of these (some of them are intentional, sadly).
-    clippy::nonminimal_bool,
     clippy::redundant_closure,
     clippy::redundant_closure_call,
     clippy::redundant_field_names,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -90,7 +90,6 @@
 // crate-specific exceptions:
 #![allow(
     // FIXME(eddyb) review all of these (some of them are intentional, sadly).
-    clippy::semicolon_if_nothing_returned,
     clippy::should_implement_trait,
     clippy::single_match,
     clippy::single_match_else,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -90,7 +90,6 @@
 // crate-specific exceptions:
 #![allow(
     // FIXME(eddyb) review all of these (some of them are intentional, sadly).
-    clippy::match_wildcard_for_single_variants,
     clippy::needless_borrow,
     clippy::needless_lifetimes,
     clippy::nonminimal_bool,

--- a/src/passes/link.rs
+++ b/src/passes/link.rs
@@ -37,10 +37,8 @@ pub fn minimize_exports(module: &mut Module, is_root: impl Fn(&ExportKey) -> boo
         seen_funcs: FxHashSet::default(),
     };
     for (export_key, &exportee) in &module.exports {
-        if is_root(export_key) {
-            if collector.live_exports.insert(export_key.clone()) {
-                exportee.inner_visit_with(&mut collector);
-            }
+        if is_root(export_key) && collector.live_exports.insert(export_key.clone()) {
+            exportee.inner_visit_with(&mut collector);
         }
     }
     module.exports = collector

--- a/src/print/mod.rs
+++ b/src/print/mod.rs
@@ -351,24 +351,18 @@ impl<'a> Visitor<'a> for Plan<'a> {
     }
 
     fn visit_global_var_use(&mut self, gv: GlobalVar) {
-        match self.current_module {
-            Some(module) => {
-                self.use_node(Node::GlobalVar(gv), &module.global_vars[gv]);
-            }
-
+        if let Some(module) = self.current_module {
+            self.use_node(Node::GlobalVar(gv), &module.global_vars[gv]);
+        } else {
             // FIXME(eddyb) should this be a hard error?
-            None => {}
         }
     }
 
     fn visit_func_use(&mut self, func: Func) {
-        match self.current_module {
-            Some(module) => {
-                self.use_node(Node::Func(func), &module.funcs[func]);
-            }
-
+        if let Some(module) = self.current_module {
+            self.use_node(Node::Func(func), &module.funcs[func]);
+        } else {
             // FIXME(eddyb) should this be a hard error?
-            None => {}
         }
     }
 

--- a/src/print/mod.rs
+++ b/src/print/mod.rs
@@ -1383,7 +1383,7 @@ impl Print for Module {
                     .iter()
                     .map(|(export_key, exportee)| {
                         pretty::Fragment::new([
-                            export_key.print(printer).into(),
+                            export_key.print(printer),
                             ": ".into(),
                             exportee.print(printer),
                         ])
@@ -1995,31 +1995,27 @@ impl Print for ConstDef {
 
         AttrsAndDef {
             attrs: attrs.print(printer),
-            def_without_name: if let Some(def) = compact_def {
-                def.into()
-            } else {
-                match *ctor {
-                    ConstCtor::PtrToGlobalVar(gv) => {
-                        pretty::Fragment::new(["&".into(), gv.print(printer)])
-                    }
-                    ConstCtor::SpvInst(spv::Inst { opcode, ref imms }) => printer.pretty_spv_inst(
-                        printer.declarative_keyword_style(),
-                        opcode,
-                        imms,
-                        ctor_args,
-                        Print::print,
-                        Some(*ty),
-                    ),
-                    ConstCtor::SpvStringLiteralForExtInst(s) => pretty::Fragment::new([
-                        printer.declarative_keyword_style().apply("OpString"),
-                        "<".into(),
-                        printer
-                            .string_literal_style()
-                            .apply(format!("{:?}", &printer.cx[s])),
-                        ">".into(),
-                    ]),
+            def_without_name: compact_def.unwrap_or_else(|| match *ctor {
+                ConstCtor::PtrToGlobalVar(gv) => {
+                    pretty::Fragment::new(["&".into(), gv.print(printer)])
                 }
-            },
+                ConstCtor::SpvInst(spv::Inst { opcode, ref imms }) => printer.pretty_spv_inst(
+                    printer.declarative_keyword_style(),
+                    opcode,
+                    imms,
+                    ctor_args,
+                    Print::print,
+                    Some(*ty),
+                ),
+                ConstCtor::SpvStringLiteralForExtInst(s) => pretty::Fragment::new([
+                    printer.declarative_keyword_style().apply("OpString"),
+                    "<".into(),
+                    printer
+                        .string_literal_style()
+                        .apply(format!("{:?}", &printer.cx[s])),
+                    ">".into(),
+                ]),
+            }),
         }
     }
 }
@@ -2130,7 +2126,7 @@ impl Print for FuncDecl {
 
         let def_without_name = match def {
             DeclDef::Imported(import) => {
-                pretty::Fragment::new([sig, " = ".into(), import.print(printer).into()])
+                pretty::Fragment::new([sig, " = ".into(), import.print(printer)])
             }
 
             // FIXME(eddyb) this can probably go into `impl Print for FuncDefBody`.

--- a/src/print/mod.rs
+++ b/src/print/mod.rs
@@ -1340,7 +1340,7 @@ impl Print for Plan<'_> {
             });
 
         // Unversioned, flatten the nodes.
-        if num_versions == 1 && self.per_version_name_and_node_defs[0].0 == "" {
+        if num_versions == 1 && self.per_version_name_and_node_defs[0].0.is_empty() {
             Versions::Single(pretty::Fragment::new(
                 per_node_versions_with_repeat_count
                     .map(|mut versions_with_repeat_count| {

--- a/src/print/mod.rs
+++ b/src/print/mod.rs
@@ -915,10 +915,14 @@ impl<'a> Printer<'a> {
     pub fn cx(&self) -> &'a Context {
         self.cx
     }
+}
 
-    // Styles for a variety of syntactic categories.
-    // FIXME(eddyb) this is a somewhat inefficient way of declaring these.
-
+// Styles for a variety of syntactic categories.
+// FIXME(eddyb) this is a somewhat inefficient way of declaring these.
+//
+// NOTE(eddyb) these methods take `self` so they can become configurable in the future.
+#[allow(clippy::unused_self)]
+impl Printer<'_> {
     fn error_style(&self) -> pretty::Styles {
         pretty::Styles::color(pretty::palettes::simple::MAGENTA)
     }
@@ -963,7 +967,9 @@ impl<'a> Printer<'a> {
             ..Default::default()
         }
     }
+}
 
+impl<'a> Printer<'a> {
     /// Pretty-print a `: T` style "type ascription" suffix.
     ///
     /// This should be used everywhere some type ascription notation is needed,

--- a/src/print/mod.rs
+++ b/src/print/mod.rs
@@ -319,8 +319,9 @@ impl<'a> Plan<'a> {
         let (_, node_defs) = self.per_version_name_and_node_defs.last_mut().unwrap();
         match node_defs.entry(node) {
             Entry::Occupied(entry) => {
+                let dyn_data_ptr = |r| (r as *const dyn DynNodeDef).cast::<()>();
                 assert!(
-                    std::ptr::eq(*entry.get(), node_def),
+                    std::ptr::eq(dyn_data_ptr(*entry.get()), dyn_data_ptr(node_def)),
                     "print: same `{}` node has multiple distinct definitions in `Plan`",
                     node.category().unwrap_or_else(|s| s)
                 );

--- a/src/print/mod.rs
+++ b/src/print/mod.rs
@@ -1191,7 +1191,7 @@ impl Use {
                     let func_category = func.category();
                     let func_idx = match printer.use_styles[&func] {
                         UseStyle::Anon { idx, .. } => idx,
-                        _ => unreachable!(),
+                        UseStyle::Inline => unreachable!(),
                     };
                     format!("{func_category}{func_idx}.{name}")
                 } else {

--- a/src/print/mod.rs
+++ b/src/print/mod.rs
@@ -2560,7 +2560,7 @@ impl Print for cfg::ControlInst {
 
             cfg::ControlInstKind::Branch => {
                 assert_eq!((targets.len(), inputs.len()), (1, 0));
-                targets.nth(0).unwrap()
+                targets.next().unwrap()
             }
 
             cfg::ControlInstKind::SelectBranch(kind) => {

--- a/src/print/mod.rs
+++ b/src/print/mod.rs
@@ -319,7 +319,7 @@ impl<'a> Plan<'a> {
         let (_, node_defs) = self.per_version_name_and_node_defs.last_mut().unwrap();
         match node_defs.entry(node) {
             Entry::Occupied(entry) => {
-                let dyn_data_ptr = |r| (r as *const dyn DynNodeDef).cast::<()>();
+                let dyn_data_ptr = |r| (r as *const dyn DynNodeDef<'_>).cast::<()>();
                 assert!(
                     std::ptr::eq(dyn_data_ptr(*entry.get()), dyn_data_ptr(node_def)),
                     "print: same `{}` node has multiple distinct definitions in `Plan`",
@@ -450,7 +450,7 @@ pub enum Versions<PF> {
 }
 
 impl fmt::Display for Versions<pretty::FragmentPostLayout> {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Self::Single(fragment) => fragment.fmt(f),
             Self::Multiple {
@@ -846,7 +846,7 @@ impl<'a> Printer<'a> {
                 });
 
             for func_def_body in func_def_bodies_across_versions {
-                let visit_region = |func_at_region: FuncAt<ControlRegion>| {
+                let visit_region = |func_at_region: FuncAt<'_, ControlRegion>| {
                     let region = func_at_region.position;
 
                     define_label_or_value(Use::ControlRegionLabel(region));

--- a/src/print/pretty.rs
+++ b/src/print/pretty.rs
@@ -145,11 +145,10 @@ impl fmt::Display for FragmentPostLayout {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         let mut result = Ok(());
         self.0.render_to_line_ops(
-            &mut LineOp::interpret_with(|op| match op {
-                TextOp::Text(text) => {
+            &mut LineOp::interpret_with(|op| {
+                if let TextOp::Text(text) = op {
                     result = result.and_then(|_| f.write_str(text));
                 }
-                _ => {}
             }),
             false,
         );

--- a/src/print/pretty.rs
+++ b/src/print/pretty.rs
@@ -277,7 +277,7 @@ impl FragmentPostLayout {
                     let tag = special_tags.next().unwrap_or("span");
                     if let Some(other_tag) = special_tags.next() {
                         // FIXME(eddyb) support by opening/closing multiple tags.
-                        unimplemented!("`<{tag}>` conflicts with `<{other_tag}>`");
+                        panic!("`<{tag}>` conflicts with `<{other_tag}>`");
                     }
 
                     body += "<";

--- a/src/print/pretty.rs
+++ b/src/print/pretty.rs
@@ -466,6 +466,8 @@ impl Node {
                 ApproxLayout::Inline { worst_width: width }
             }
         };
+
+        #[allow(clippy::match_same_arms)]
         match self {
             Self::Text(text) => text_approx_rigid_layout(text),
             Self::StyledText(styles_and_text) => text_approx_rigid_layout(&styles_and_text.1),

--- a/src/print/pretty.rs
+++ b/src/print/pretty.rs
@@ -142,7 +142,7 @@ impl Fragment {
 pub struct FragmentPostLayout(Fragment);
 
 impl fmt::Display for FragmentPostLayout {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let mut result = Ok(());
         self.0.render_to_line_ops(
             &mut LineOp::interpret_with(|op| {

--- a/src/spv/lift.rs
+++ b/src/spv/lift.rs
@@ -209,6 +209,7 @@ impl Visitor<'_> for NeedsIdsCollector<'_> {
     }
 
     fn visit_data_inst_def(&mut self, data_inst_def: &DataInstDef) {
+        #[allow(clippy::match_same_arms)]
         match data_inst_def.kind {
             DataInstKind::FuncCall(_) => {}
 
@@ -1069,6 +1070,7 @@ impl LazyInst<'_, '_> {
     ) -> (Option<spv::Id>, AttrSet, Option<Import>) {
         let cx = module.cx_ref();
 
+        #[allow(clippy::match_same_arms)]
         match self {
             Self::Global(global) => {
                 let (attrs, import) = match global {

--- a/src/spv/lift.rs
+++ b/src/spv/lift.rs
@@ -362,7 +362,7 @@ impl<'a> NeedsIdsCollector<'a> {
                 .map(|func| {
                     Ok((
                         func,
-                        FuncLifting::from_func_decl(cx, &module.funcs[func], || alloc_id())?,
+                        FuncLifting::from_func_decl(cx, &module.funcs[func], &mut alloc_id)?,
                     ))
                 })
                 .collect::<Result<_, _>>()?,

--- a/src/spv/lift.rs
+++ b/src/spv/lift.rs
@@ -849,7 +849,7 @@ impl<'a> FuncLifting<'a> {
                 for region in cfg.rev_post_order(func_def_body) {
                     func_def_body
                         .at(region)
-                        .rev_post_order_try_for_each(&mut visit_cfg_point)?
+                        .rev_post_order_try_for_each(&mut visit_cfg_point)?;
                 }
             }
         }

--- a/src/spv/lift.rs
+++ b/src/spv/lift.rs
@@ -962,7 +962,7 @@ impl<'a> FuncLifting<'a> {
         }
 
         // Remove now-unused blocks.
-        blocks.retain(|point, _| use_counts[&point] > 0);
+        blocks.retain(|point, _| use_counts[point] > 0);
 
         // Collect `OpPhi`s from other blocks' edges into each block.
         //
@@ -1507,7 +1507,7 @@ impl Module {
                         } = block;
 
                         iter::once(LazyInst::OpLabel {
-                            label_id: func_lifting.label_ids[&point],
+                            label_id: func_lifting.label_ids[point],
                         })
                         .chain(phis.iter().map(|phi| LazyInst::OpPhi {
                             parent_func: func_lifting,
@@ -1602,7 +1602,7 @@ impl Module {
         let mut decoration_insts = vec![];
 
         for lazy_inst in global_and_func_insts.clone() {
-            let (result_id, attrs, import) = lazy_inst.result_id_attrs_and_import(self, &ids);
+            let (result_id, attrs, import) = lazy_inst.result_id_attrs_and_import(self, ids);
 
             for attr in cx[attrs].attrs.iter() {
                 match attr {
@@ -1619,9 +1619,9 @@ impl Module {
                             ids: iter::once(target_id).collect(),
                         };
 
-                        if [wk.OpExecutionMode, wk.OpExecutionModeId].contains(&opcode) {
+                        if [wk.OpExecutionMode, wk.OpExecutionModeId].contains(opcode) {
                             execution_mode_insts.push(inst);
-                        } else if [wk.OpName, wk.OpMemberName].contains(&opcode) {
+                        } else if [wk.OpName, wk.OpMemberName].contains(opcode) {
                             debug_name_insts.push(inst);
                         } else {
                             decoration_insts.push(inst);
@@ -1797,7 +1797,7 @@ impl Module {
         let mut current_debug_line = None;
         let mut current_block_id = None; // HACK(eddyb) for `current_debug_line` resets.
         for lazy_inst in global_and_func_insts {
-            let (inst, attrs) = lazy_inst.to_inst_and_attrs(self, &ids);
+            let (inst, attrs) = lazy_inst.to_inst_and_attrs(self, ids);
 
             // Reset line debuginfo when crossing/leaving blocks.
             let new_block_id = if inst.opcode == wk.OpLabel {

--- a/src/spv/lift.rs
+++ b/src/spv/lift.rs
@@ -553,7 +553,7 @@ impl<'a> FuncLifting<'a> {
 
         // Create a SPIR-V block for every CFG point needing one.
         let mut blocks = FxIndexMap::default();
-        let mut visit_cfg_point = |point_cursor: CfgCursor| {
+        let mut visit_cfg_point = |point_cursor: CfgCursor<'_>| {
             let point = point_cursor.point;
 
             let phis = match point {
@@ -1066,7 +1066,7 @@ impl LazyInst<'_, '_> {
     fn result_id_attrs_and_import(
         self,
         module: &Module,
-        ids: &AllocatedIds,
+        ids: &AllocatedIds<'_>,
     ) -> (Option<spv::Id>, AttrSet, Option<Import>) {
         let cx = module.cx_ref();
 
@@ -1122,11 +1122,15 @@ impl LazyInst<'_, '_> {
         }
     }
 
-    fn to_inst_and_attrs(self, module: &Module, ids: &AllocatedIds) -> (spv::InstWithIds, AttrSet) {
+    fn to_inst_and_attrs(
+        self,
+        module: &Module,
+        ids: &AllocatedIds<'_>,
+    ) -> (spv::InstWithIds, AttrSet) {
         let wk = &spec::Spec::get().well_known;
         let cx = module.cx_ref();
 
-        let value_to_id = |parent_func: &FuncLifting, v| match v {
+        let value_to_id = |parent_func: &FuncLifting<'_>, v| match v {
             Value::Const(ct) => match cx[ct].ctor {
                 ConstCtor::SpvStringLiteralForExtInst(s) => ids.debug_strings[&cx[s]],
 

--- a/src/spv/lower.rs
+++ b/src/spv/lower.rs
@@ -838,10 +838,12 @@ impl Module {
 
                 Seq::Function
             };
-            if !(seq <= Some(next_seq)) {
-                return Err(invalid(&format!(
-                    "out of order: {next_seq:?} instructions must precede {seq:?} instructions"
-                )));
+            if let Some(prev_seq) = seq {
+                if prev_seq > next_seq {
+                    return Err(invalid(&format!(
+                        "out of order: {next_seq:?} instructions must precede {prev_seq:?} instructions"
+                    )));
+                }
             }
             seq = Some(next_seq);
 

--- a/src/spv/lower.rs
+++ b/src/spv/lower.rs
@@ -1203,7 +1203,7 @@ impl Module {
                             let phi_key = PhiKey {
                                 source_block_id: current_block_details.label_id,
                                 target_block_id: target_block_details.label_id,
-                                target_phi_idx: target_phi_idx,
+                                target_phi_idx,
                             };
                             let phi_value_ids = phi_to_values.remove(&phi_key).unwrap_or_default();
 

--- a/src/spv/lower.rs
+++ b/src/spv/lower.rs
@@ -729,7 +729,7 @@ impl Module {
                                 TypeCtor::SpvInst(inst) if inst.opcode == wk.OpTypeFunction => {
                                     let mut types = ty_def.ctor_args.iter().map(|&arg| match arg {
                                         TypeCtorArg::Type(ty) => ty,
-                                        _ => unreachable!(),
+                                        TypeCtorArg::Const(_) => unreachable!(),
                                     });
                                     Some((types.next().unwrap(), types))
                                 }
@@ -1139,7 +1139,7 @@ impl Module {
                     // to be able to have an entry in `local_id_defs`.
                     let control_region = match local_id_defs[&result_id.unwrap()] {
                         LocalIdDef::BlockLabel(control_region) => control_region,
-                        _ => unreachable!(),
+                        LocalIdDef::Value(_) => unreachable!(),
                     };
                     let current_block_details = &block_details[&control_region];
                     assert_eq!(current_block_details.label_id, result_id.unwrap());

--- a/src/spv/lower.rs
+++ b/src/spv/lower.rs
@@ -945,8 +945,7 @@ impl Module {
                                             inputs: SmallVec::new(),
                                             children: EntityList::empty(),
                                             outputs: SmallVec::new(),
-                                        }
-                                        .into(),
+                                        },
                                     )
                                 };
                                 block_details.insert(

--- a/src/spv/print.rs
+++ b/src/spv/print.rs
@@ -89,10 +89,8 @@ impl<IMMS: Iterator<Item = spv::Imm>, ID, IDS: Iterator<Item = ID>> OperandPrint
     fn enumerant_params(&mut self, enumerant: &spec::Enumerant) {
         let mut first = true;
         for (mode, kind) in enumerant.all_params() {
-            if mode == spec::OperandMode::Optional {
-                if self.is_exhausted() {
-                    break;
-                }
+            if mode == spec::OperandMode::Optional && self.is_exhausted() {
+                break;
             }
 
             self.out
@@ -255,10 +253,8 @@ impl<IMMS: Iterator<Item = spv::Imm>, ID, IDS: Iterator<Item = ID>> OperandPrint
 
     fn inst_operands(mut self, opcode: spec::Opcode) -> impl Iterator<Item = TokensForOperand<ID>> {
         opcode.def().all_operands().map_while(move |(mode, kind)| {
-            if mode == spec::OperandMode::Optional {
-                if self.is_exhausted() {
-                    return None;
-                }
+            if mode == spec::OperandMode::Optional && self.is_exhausted() {
+                return None;
             }
             self.operand(kind);
             Some(mem::take(&mut self.out))

--- a/src/spv/print.rs
+++ b/src/spv/print.rs
@@ -273,7 +273,7 @@ pub fn operand_from_imms(imms: impl IntoIterator<Item = spv::Imm>) -> TokensForO
     };
     let &kind = match printer.imms.peek().unwrap() {
         spv::Imm::Short(kind, _) | spv::Imm::LongStart(kind, _) => kind,
-        _ => unreachable!(),
+        spv::Imm::LongCont(..) => unreachable!(),
     };
     printer.operand(kind);
     assert!(printer.imms.next().is_none());

--- a/src/spv/print.rs
+++ b/src/spv/print.rs
@@ -52,7 +52,7 @@ impl TokensForOperand<String> {
     pub fn concat_to_plain_text(self) -> String {
         self.tokens
             .into_iter()
-            .map(|token| -> Cow<str> {
+            .map(|token| -> Cow<'_, str> {
                 match token {
                     Token::Punctuation(s) | Token::OperandKindName(s) | Token::EnumerandName(s) => {
                         s.into()

--- a/src/spv/print.rs
+++ b/src/spv/print.rs
@@ -172,7 +172,7 @@ impl<IMMS: Iterator<Item = spv::Imm>, ID, IDS: Iterator<Item = ID>> OperandPrint
         let emit_missing_error = |this: &mut Self| {
             this.out
                 .tokens
-                .push(Token::Error(format!("/* missing {name} */")))
+                .push(Token::Error(format!("/* missing {name} */")));
         };
 
         let mut maybe_get_enum_word = || match self.imms.next() {

--- a/src/spv/print.rs
+++ b/src/spv/print.rs
@@ -180,7 +180,7 @@ impl<IMMS: Iterator<Item = spv::Imm>, ID, IDS: Iterator<Item = ID>> OperandPrint
                 assert!(kind == found_kind);
                 Some(word)
             }
-            Some(spv::Imm::LongStart(..)) | Some(spv::Imm::LongCont(..)) => unreachable!(),
+            Some(spv::Imm::LongStart(..) | spv::Imm::LongCont(..)) => unreachable!(),
             None => None,
         };
 
@@ -239,8 +239,9 @@ impl<IMMS: Iterator<Item = spv::Imm>, ID, IDS: Iterator<Item = ID>> OperandPrint
                 // FIXME(eddyb) there's no reason to take the first word now,
                 // `self.literal(kind)` could do it itself.
                 match self.imms.next() {
-                    Some(spv::Imm::Short(found_kind, word))
-                    | Some(spv::Imm::LongStart(found_kind, word)) => {
+                    Some(
+                        spv::Imm::Short(found_kind, word) | spv::Imm::LongStart(found_kind, word),
+                    ) => {
                         assert!(kind == found_kind);
                         self.literal(kind, word);
                     }

--- a/src/spv/read.rs
+++ b/src/spv/read.rs
@@ -224,8 +224,8 @@ impl InstParser<'_> {
                     .ok()
                     .ok_or(Error::IdZero)
             };
-            self.inst.result_type_id = def.has_result_type_id.then(|| id()).transpose()?;
-            self.inst.result_id = def.has_result_id.then(|| id()).transpose()?;
+            self.inst.result_type_id = def.has_result_type_id.then(&mut id).transpose()?;
+            self.inst.result_id = def.has_result_id.then(&mut id).transpose()?;
         }
 
         if let Some(type_id) = self.inst.result_type_id {

--- a/src/spv/read.rs
+++ b/src/spv/read.rs
@@ -145,7 +145,7 @@ impl InstParser<'_> {
             }
 
             spec::OperandKindDef::Id => {
-                let id = word.try_into().map_err(|_| Error::IdZero)?;
+                let id = word.try_into().ok().ok_or(Error::IdZero)?;
                 self.inst.ids.push(id);
             }
 
@@ -221,7 +221,8 @@ impl InstParser<'_> {
                     .next()
                     .ok_or(Error::NotEnoughWords)?
                     .try_into()
-                    .map_err(|_| Error::IdZero)
+                    .ok()
+                    .ok_or(Error::IdZero)
             };
             self.inst.result_type_id = def.has_result_type_id.then(|| id()).transpose()?;
             self.inst.result_id = def.has_result_id.then(|| id()).transpose()?;
@@ -362,7 +363,9 @@ impl Iterator for ModuleParser {
                 KnownIdDef::TypeInt(match inst.imms[0] {
                     spv::Imm::Short(kind, n) => {
                         assert!(kind == wk.LiteralInteger);
-                        n.try_into().map_err(|_| invalid("Width cannot be 0"))?
+                        n.try_into()
+                            .ok()
+                            .ok_or_else(|| invalid("Width cannot be 0"))?
                     }
                     _ => unreachable!(),
                 })
@@ -370,7 +373,9 @@ impl Iterator for ModuleParser {
                 KnownIdDef::TypeFloat(match inst.imms[0] {
                     spv::Imm::Short(kind, n) => {
                         assert!(kind == wk.LiteralInteger);
-                        n.try_into().map_err(|_| invalid("Width cannot be 0"))?
+                        n.try_into()
+                            .ok()
+                            .ok_or_else(|| invalid("Width cannot be 0"))?
                     }
                     _ => unreachable!(),
                 })

--- a/src/spv/read.rs
+++ b/src/spv/read.rs
@@ -325,7 +325,7 @@ impl Iterator for ModuleParser {
         let wk = &spv_spec.well_known;
 
         let words = &bytemuck::cast_slice::<u8, u32>(&self.word_bytes)[self.next_word..];
-        let &opcode = words.get(0)?;
+        let &opcode = words.first()?;
 
         let (inst_len, opcode) = ((opcode >> 16) as usize, opcode as u16);
 

--- a/src/spv/read.rs
+++ b/src/spv/read.rs
@@ -109,10 +109,8 @@ impl InstParser<'_> {
 
     fn enumerant_params(&mut self, enumerant: &spec::Enumerant) -> Result<(), InstParseError> {
         for (mode, kind) in enumerant.all_params() {
-            if mode == spec::OperandMode::Optional {
-                if self.is_exhausted() {
-                    break;
-                }
+            if mode == spec::OperandMode::Optional && self.is_exhausted() {
+                break;
             }
             self.operand(kind)?;
         }
@@ -237,10 +235,8 @@ impl InstParser<'_> {
         }
 
         for (mode, kind) in def.all_operands() {
-            if mode == spec::OperandMode::Optional {
-                if self.is_exhausted() {
-                    break;
-                }
+            if mode == spec::OperandMode::Optional && self.is_exhausted() {
+                break;
             }
             self.operand(kind)?;
         }

--- a/src/spv/spec.rs
+++ b/src/spv/spec.rs
@@ -940,6 +940,9 @@ pub mod raw {
                 D: serde::Deserializer<'de>,
             {
                 let x = Deserialize::deserialize(deserializer)?;
+
+                // HACK(eddyb) this is a `try {...}`-like use of a closure.
+                #[allow(clippy::redundant_closure_call)]
                 (|$x: $in_ty| -> Result<$out_ty, _> { $body })(x)
                     .map_err(serde::de::Error::custom)
             })*

--- a/src/spv/spec.rs
+++ b/src/spv/spec.rs
@@ -758,7 +758,9 @@ impl Spec {
                 }
 
                 // `IdResultType` without `IdResult` is impossible.
-                assert!(!(def.has_result_type_id && !def.has_result_id));
+                if def.has_result_type_id {
+                    assert!(def.has_result_id);
+                }
 
                 (inst.opcode, (inst.opname, def))
             }),

--- a/src/spv/spec.rs
+++ b/src/spv/spec.rs
@@ -394,8 +394,8 @@ impl Spec {
                     "../../khronos-spec/SPIRV-Headers/include/spirv/unified1/spirv.core.grammar.json"
                 );
 
-                let raw_core_grammar: raw::CoreGrammar = serde_json::from_str(SPIRV_CORE_GRAMMAR_JSON)
-                .unwrap();
+                let raw_core_grammar: raw::CoreGrammar<'static> =
+                    serde_json::from_str(SPIRV_CORE_GRAMMAR_JSON).unwrap();
                 Spec::from_raw(raw_core_grammar)
             };
         }
@@ -435,7 +435,7 @@ impl Spec {
             .operand_kinds
             .iter()
             .filter_map(|o| {
-                let enumerant_from_raw = |e: &raw::OperandKindEnumerant| {
+                let enumerant_from_raw = |e: &raw::OperandKindEnumerant<'_>| {
                     let mut all_params = e
                         .parameters
                         .iter()
@@ -950,7 +950,7 @@ pub mod raw {
     }
 
     dew_and_then! {
-        dew_u32_maybe_hex: |x: DecOrHex<u32>| -> u32 { x.try_into() },
+        dew_u32_maybe_hex: |x: DecOrHex<'_, u32>| -> u32 { x.try_into() },
     }
 
     #[derive(Deserialize)]

--- a/src/spv/write.rs
+++ b/src/spv/write.rs
@@ -217,11 +217,10 @@ impl ModuleEmitter {
         self.words.reserve(total_word_count);
         let expected_final_pos = self.words.len() + total_word_count;
 
-        let opcode =
-            u32::from(inst.opcode.as_u16())
-                | u32::from(u16::try_from(total_word_count).map_err(|_| {
-                    invalid("word count of SPIR-V instruction doesn't fit in 16 bits")
-                })?) << 16;
+        let opcode = u32::from(inst.opcode.as_u16())
+            | u32::from(u16::try_from(total_word_count).ok().ok_or_else(|| {
+                invalid("word count of SPIR-V instruction doesn't fit in 16 bits")
+            })?) << 16;
         self.words.extend(
             iter::once(opcode)
                 .chain(inst.result_type_id.map(|id| id.get()))

--- a/src/spv/write.rs
+++ b/src/spv/write.rs
@@ -73,10 +73,8 @@ impl OperandEmitter<'_> {
 
     fn enumerant_params(&mut self, enumerant: &spec::Enumerant) -> Result<(), OperandEmitError> {
         for (mode, kind) in enumerant.all_params() {
-            if mode == spec::OperandMode::Optional {
-                if self.is_exhausted() {
-                    break;
-                }
+            if mode == spec::OperandMode::Optional && self.is_exhausted() {
+                break;
             }
             self.operand(kind)?;
         }
@@ -151,10 +149,8 @@ impl OperandEmitter<'_> {
         use OperandEmitError as Error;
 
         for (mode, kind) in def.all_operands() {
-            if mode == spec::OperandMode::Optional {
-                if self.is_exhausted() {
-                    break;
-                }
+            if mode == spec::OperandMode::Optional && self.is_exhausted() {
+                break;
             }
             self.operand(kind)?;
         }

--- a/src/spv/write.rs
+++ b/src/spv/write.rs
@@ -90,7 +90,7 @@ impl OperandEmitter<'_> {
                 assert!(kind == found_kind);
                 Ok(word)
             }
-            Some(spv::Imm::LongStart(..)) | Some(spv::Imm::LongCont(..)) => unreachable!(),
+            Some(spv::Imm::LongStart(..) | spv::Imm::LongCont(..)) => unreachable!(),
             None => Err(Error::NotEnoughImms),
         };
 


### PR DESCRIPTION
In no particular order, these are the suspicious and/or not-entirely-addressed lints:
* `clippy::single_match_else`: permanently `#![allow(…)]`ed, as the style it denies is important for readability
* `clippy::string_add`: permanently `#![allow(…)]`ed, as it's (IMO) misguided (and perhaps buggy?)
  * `(...: String) + "..."` is short for `{ let mut s = ...; s.push_str("..."); s }`, *not something else*
* `clippy::match_same_arms`: `#[allow(…)]` moved to specific `match`es where listing out the patterns individually is more important than what the actual values are (i.e. grouping by the output values is detrimental)
* `clippy::should_implement_trait`: `#![allow(…)]` moved to specific module encountering this bug:
  * https://github.com/rust-lang/rust-clippy/issues/5004
* `clippy::unused_self`: `#[allow(…)]` moved to specific `impl` (where `self` may be used in the future)
* `clippy::redundant_closure_call`: `#[allow(…)]` moved to specific macro using a closure as a `try {...}` block
* `clippy::map_err_ignore`: had to be worked around because the `map_err(|_|` it complains about have no information in the error, i.e. those `Result`s *might as well be a newtyped `Option`*
* `clippy::nonminimal_bool`: had to be worked around by introducing extra `if`s (which should make the logic clearer)
  * long-term, `nonminimal_bool` could be a real hazard, if it suggests e.g. rewriting `!(foo && foo_bar)` into `!foo || !foo_bar`, when the point of the `&&` is to *group* a `foo_bar` check with its `foo` *prerequisite*
    <sub>(in fact, I need to comb through Rust-GPU looking for artifacts of this lint, because I've seen in the past conditions that were rendered unreadable by an outer `!` being *De Morgan*'d into a `&&`, where the outer `!` may have just been coincidental from e.g. a `retain`/`filter` predicate's keep/remove distinction, but with `||` the correlation between the two sides was erased...)</sub>

Fixes #13

cc @Jake-Shadle (this arguably counts as feedback for Embark's list of lints)