### PR TITLE
Unbreak CI via `cargo clippy --fix` (for `clippy::uninlined-format-args`).

### DIFF
--- a/examples/spv-lower-lift-roundtrip.rs
+++ b/examples/spv-lower-lift-roundtrip.rs
@@ -25,9 +25,9 @@ fn main() -> std::io::Result<()> {
                 eprint!("  ");
 
                 if let Some(id) = inst.result_id {
-                    eprint!("%{}", id);
+                    eprint!("%{id}");
                     if let Some(type_id) = inst.result_type_id {
-                        eprint!(": %{}", type_id);
+                        eprint!(": %{type_id}");
                     }
                     eprint!(" = ");
                 }
@@ -36,7 +36,7 @@ fn main() -> std::io::Result<()> {
                 spirt::spv::print::inst_operands(
                     inst.opcode,
                     inst.imms.iter().copied(),
-                    inst.ids.iter().map(|id| format!("%{}", id)),
+                    inst.ids.iter().map(|id| format!("%{id}")),
                 )
                 .for_each(|operand_parts| eprint!(" {}", operand_parts.concat_to_plain_text()));
 

--- a/examples/spv-read-write-roundtrip.rs
+++ b/examples/spv-read-write-roundtrip.rs
@@ -16,9 +16,9 @@ fn main() -> std::io::Result<()> {
                 eprint!("  ");
 
                 if let Some(id) = inst.result_id {
-                    eprint!("%{}", id);
+                    eprint!("%{id}");
                     if let Some(type_id) = inst.result_type_id {
-                        eprint!(": %{}", type_id);
+                        eprint!(": %{type_id}");
                     }
                     eprint!(" = ");
                 }
@@ -27,7 +27,7 @@ fn main() -> std::io::Result<()> {
                 spirt::spv::print::inst_operands(
                     inst.opcode,
                     inst.imms.iter().copied(),
-                    inst.ids.iter().map(|id| format!("%{}", id)),
+                    inst.ids.iter().map(|id| format!("%{id}")),
                 )
                 .for_each(|operand_parts| eprint!(" {}", operand_parts.concat_to_plain_text()));
 

--- a/src/print/mod.rs
+++ b/src/print/mod.rs
@@ -1064,7 +1064,7 @@ impl<'a> Printer<'a> {
                                 spv::print::Token::Id(id) => {
                                     let comment = self
                                         .comment_style()
-                                        .apply(format!("/* #{} */", next_extra_idx));
+                                        .apply(format!("/* #{next_extra_idx} */"));
                                     next_extra_idx += 1;
 
                                     let id = print_id(id, self).into().unwrap_or_else(|| {
@@ -1423,12 +1423,12 @@ impl Print for ModuleDialect {
                             "version: ".into(),
                             printer
                                 .numeric_literal_style()
-                                .apply(format!("{}.{}", version_major, version_minor)),
+                                .apply(format!("{version_major}.{version_minor}")),
                         ]),
                         pretty::join_comma_sep(
                             "extensions: {",
                             extensions.iter().map(|ext| {
-                                printer.string_literal_style().apply(format!("{:?}", ext))
+                                printer.string_literal_style().apply(format!("{ext:?}"))
                             }),
                             "}",
                         ),
@@ -1487,13 +1487,11 @@ impl Print for ModuleDebugInfo {
                                         (generator_magic.get() >> 16, generator_magic.get() as u16);
                                     pretty::Fragment::new([
                                         "{ tool_id: ".into(),
-                                        printer
-                                            .numeric_literal_style()
-                                            .apply(format!("{}", tool_id)),
+                                        printer.numeric_literal_style().apply(format!("{tool_id}")),
                                         ", version: ".into(),
                                         printer
                                             .numeric_literal_style()
-                                            .apply(format!("{}", tool_version)),
+                                            .apply(format!("{tool_version}")),
                                         " }".into(),
                                     ])
                                 })
@@ -1763,9 +1761,9 @@ impl Print for Attr {
                 // and escaping for well-behaved file paths.
                 let file_path = &printer.cx[file_path.0];
                 let comment = if file_path.chars().all(|c| c.is_ascii_graphic() && c != ':') {
-                    format!("// at {}:{}:{}", file_path, line, col)
+                    format!("// at {file_path}:{line}:{col}")
                 } else {
-                    format!("// at {:?}:{}:{}", file_path, line, col)
+                    format!("// at {file_path:?}:{line}:{col}")
                 };
                 (
                     AttrStyle::Comment,
@@ -1806,9 +1804,9 @@ impl Print for TypeDef {
                 };
 
                 Some(if signed {
-                    kw(format!("s{}", width))
+                    kw(format!("s{width}"))
                 } else {
-                    kw(format!("u{}", width))
+                    kw(format!("u{width}"))
                 })
             } else if opcode == wk.OpTypeFloat {
                 let width = match imms[..] {
@@ -1816,7 +1814,7 @@ impl Print for TypeDef {
                     _ => unreachable!(),
                 };
 
-                Some(kw(format!("f{}", width)))
+                Some(kw(format!("f{width}")))
             } else if opcode == wk.OpTypeVector {
                 let (elem_ty, elem_count) = match (&imms[..], &ctor_args[..]) {
                     (&[spv::Imm::Short(_, elem_count)], &[TypeCtorArg::Type(elem_ty)]) => {
@@ -1830,7 +1828,7 @@ impl Print for TypeDef {
                     "×".into(),
                     printer
                         .numeric_literal_style()
-                        .apply(format!("{}", elem_count))
+                        .apply(format!("{elem_count}"))
                         .into(),
                 ]))
             } else {
@@ -1956,7 +1954,7 @@ impl Print for ConstDef {
                             float_to_bits: impl FnOnce(FLOAT) -> BITS,
                         ) -> Option<String> {
                             let float = float_from_bits(bits);
-                            Some(format!("{:?}", float)).filter(|s| {
+                            Some(format!("{float:?}")).filter(|s| {
                                 s.parse::<FLOAT>()
                                     .map(float_to_bits)
                                     .map_or(false, |roundtrip_bits| roundtrip_bits == bits)
@@ -2482,7 +2480,7 @@ impl Print for DataInstDef {
                     ">).".into(),
                     printer.declarative_keyword_style().apply("OpExtInst"),
                     "<".into(),
-                    printer.numeric_literal_style().apply(format!("{}", inst)),
+                    printer.numeric_literal_style().apply(format!("{inst}")),
                     ">".into(),
                 ])
             }

--- a/src/spv/lower.rs
+++ b/src/spv/lower.rs
@@ -84,7 +84,7 @@ struct IntraFuncInst {
 fn invalid(reason: &str) -> io::Error {
     io::Error::new(
         io::ErrorKind::InvalidData,
-        format!("malformed SPIR-V ({})", reason),
+        format!("malformed SPIR-V ({reason})"),
     )
 }
 
@@ -137,8 +137,7 @@ impl Module {
 
             if (version_reserved_lo, version_reserved_hi) != (0, 0) {
                 return Err(invalid(&format!(
-                    "version 0x{:08x} is not in expected (0.major.minor.0) form",
-                    version
+                    "version 0x{version:08x} is not in expected (0.major.minor.0) form"
                 )));
             }
 
@@ -147,8 +146,7 @@ impl Module {
 
             if reserved_inst_schema != 0 {
                 return Err(invalid(&format!(
-                    "unknown instruction schema {} - only 0 is supported",
-                    reserved_inst_schema
+                    "unknown instruction schema {reserved_inst_schema} - only 0 is supported"
                 )));
             }
 
@@ -228,8 +226,7 @@ impl Module {
                                 Some(&IdDef::SpvDebugString(s)) => s,
                                 _ => {
                                     return Err(invalid(&format!(
-                                        "%{} is not an OpString",
-                                        file_path_id
+                                        "%{file_path_id} is not an OpString"
                                     )));
                                 }
                             };
@@ -300,7 +297,7 @@ impl Module {
                         type_id,
                         id_def.descr(&cx)
                     ))),
-                    None => Err(invalid(&format!("result type %{} not defined", type_id))),
+                    None => Err(invalid(&format!("result type %{type_id} not defined"))),
                 })
                 .transpose()?;
 
@@ -409,8 +406,7 @@ impl Module {
                             Some(&IdDef::SpvDebugString(s)) => s,
                             _ => {
                                 return Err(invalid(&format!(
-                                    "%{} is not an OpString",
-                                    file_path_id
+                                    "%{file_path_id} is not an OpString"
                                 )));
                             }
                         };
@@ -594,11 +590,11 @@ impl Module {
                         Some(&IdDef::Type(ty)) => Ok(TypeCtorArg::Type(ty)),
                         Some(&IdDef::Const(ct)) => Ok(TypeCtorArg::Const(ct)),
                         Some(id_def) => Err(id_def.descr(&cx)),
-                        None => Err(format!("a forward reference to %{}", id)),
+                        None => Err(format!("a forward reference to %{id}")),
                     })
                     .map(|result| {
                         result.map_err(|descr| {
-                            invalid(&format!("unsupported use of {} in a type", descr))
+                            invalid(&format!("unsupported use of {descr} in a type"))
                         })
                     })
                     .collect::<Result<_, _>>()?;
@@ -619,11 +615,11 @@ impl Module {
                     .map(|&id| match id_defs.get(&id) {
                         Some(&IdDef::Const(ct)) => Ok(ct),
                         Some(id_def) => Err(id_def.descr(&cx)),
-                        None => Err(format!("a forward reference to %{}", id)),
+                        None => Err(format!("a forward reference to %{id}")),
                     })
                     .map(|result| {
                         result.map_err(|descr| {
-                            invalid(&format!("unsupported use of {} in a constant", descr))
+                            invalid(&format!("unsupported use of {descr} in a constant"))
                         })
                     })
                     .collect::<Result<_, _>>()?;
@@ -668,13 +664,12 @@ impl Module {
                     .map(|id| match id_defs.get(&id) {
                         Some(&IdDef::Const(ct)) => Ok(ct),
                         Some(id_def) => Err(id_def.descr(&cx)),
-                        None => Err(format!("a forward reference to %{}", id)),
+                        None => Err(format!("a forward reference to %{id}")),
                     })
                     .transpose()
                     .map_err(|descr| {
                         invalid(&format!(
-                            "unsupported use of {} as the initializer of a global variable",
-                            descr
+                            "unsupported use of {descr} as the initializer of a global variable"
                         ))
                     })?;
 
@@ -745,8 +740,7 @@ impl Module {
                     }
                     .ok_or_else(|| {
                         invalid(&format!(
-                            "function type %{} not an `OpTypeFunction`",
-                            func_type_id
+                            "function type %{func_type_id} not an `OpTypeFunction`"
                         ))
                     })?;
 
@@ -846,8 +840,7 @@ impl Module {
             };
             if !(seq <= Some(next_seq)) {
                 return Err(invalid(&format!(
-                    "out of order: {:?} instructions must precede {:?} instructions",
-                    next_seq, seq
+                    "out of order: {next_seq:?} instructions must precede {seq:?} instructions"
                 )));
             }
             seq = Some(next_seq);
@@ -863,7 +856,7 @@ impl Module {
 
         if !pending_attrs.is_empty() {
             let ids = pending_attrs.keys().collect::<BTreeSet<_>>();
-            return Err(invalid(&format!("decorated IDs never defined: {:?}", ids)));
+            return Err(invalid(&format!("decorated IDs never defined: {ids:?}")));
         }
 
         if current_func_body.is_some() {
@@ -1033,9 +1026,8 @@ impl Module {
                         // FIXME(remove) embed IDs in errors by moving them to the
                         // `let invalid = |...| ...;` closure that wraps insts.
                         return Err(invalid(&format!(
-                            "function %{} lacks any blocks, \
-                             but isn't an import either",
-                            func_id
+                            "function %{func_id} lacks any blocks, \
+                             but isn't an import either"
                         )));
                     }
                 }
@@ -1107,7 +1099,7 @@ impl Module {
                         None => local_id_defs
                             .get(&id)
                             .copied()
-                            .ok_or_else(|| invalid(&format!("undefined ID %{}", id,))),
+                            .ok_or_else(|| invalid(&format!("undefined ID %{id}",))),
                     };
 
                 if opcode == wk.OpFunctionParameter {
@@ -1336,8 +1328,7 @@ impl Module {
                             .transpose()
                             .map_err(|descr| {
                                 invalid(&format!(
-                                    "unsupported use of {} as the `OpFunctionCall` callee",
-                                    descr
+                                    "unsupported use of {descr} as the `OpFunctionCall` callee"
                                 ))
                             })?;
 
@@ -1366,13 +1357,12 @@ impl Module {
                         let ext_set = match id_defs.get(&ext_set_id) {
                             Some(&IdDef::SpvExtInstImport(name)) => Ok(name),
                             Some(id_def) => Err(id_def.descr(&cx)),
-                            None => Err(format!("unknown ID %{}", ext_set_id)),
+                            None => Err(format!("unknown ID %{ext_set_id}")),
                         }
                         .map_err(|descr| {
                             invalid(&format!(
-                                "unsupported use of {} as the `OpExtInst` \
-                                 extended instruction set ID",
-                                descr
+                                "unsupported use of {descr} as the `OpExtInst` \
+                                 extended instruction set ID"
                             ))
                         })?;
 
@@ -1518,8 +1508,7 @@ impl Module {
                     // FIXME(remove) embed IDs in errors by moving them to the
                     // `let invalid = |...| ...;` closure that wraps insts.
                     return Err(invalid(&format!(
-                        "in %{}, the entry block contains `OpPhi`s",
-                        func_id
+                        "in %{func_id}, the entry block contains `OpPhi`s"
                     )));
                 }
             }
@@ -1537,12 +1526,11 @@ impl Module {
                         },
                         Some(&IdDef::Func(func)) => Ok(Exportee::Func(func)),
                         Some(id_def) => Err(id_def.descr(&cx)),
-                        None => Err(format!("unknown ID %{}", target_id)),
+                        None => Err(format!("unknown ID %{target_id}")),
                     }
                     .map_err(|descr| {
                         invalid(&format!(
-                            "unsupported use of {} as the `LinkageAttributes` target",
-                            descr
+                            "unsupported use of {descr} as the `LinkageAttributes` target"
                         ))
                     })?;
 
@@ -1557,12 +1545,11 @@ impl Module {
                     let func = match id_defs.get(&func_id) {
                         Some(&IdDef::Func(func)) => Ok(func),
                         Some(id_def) => Err(id_def.descr(&cx)),
-                        None => Err(format!("unknown ID %{}", func_id)),
+                        None => Err(format!("unknown ID %{func_id}")),
                     }
                     .map_err(|descr| {
                         invalid(&format!(
-                            "unsupported use of {} as the `OpEntryPoint` target",
-                            descr
+                            "unsupported use of {descr} as the `OpEntryPoint` target"
                         ))
                     })?;
                     let interface_global_vars = interface_ids
@@ -1573,13 +1560,12 @@ impl Module {
                                 _ => Err(id_def.descr(&cx)),
                             },
                             Some(id_def) => Err(id_def.descr(&cx)),
-                            None => Err(format!("unknown ID %{}", id)),
+                            None => Err(format!("unknown ID %{id}")),
                         })
                         .map(|result| {
                             result.map_err(|descr| {
                                 invalid(&format!(
-                                    "unsupported use of {} as an `OpEntryPoint` interface variable",
-                                    descr
+                                    "unsupported use of {descr} as an `OpEntryPoint` interface variable"
                                 ))
                             })
                         })

--- a/src/spv/print.rs
+++ b/src/spv/print.rs
@@ -128,8 +128,8 @@ impl<IMMS: Iterator<Item = spv::Imm>, ID, IDS: Iterator<Item = ID>> OperandPrint
                 .take_while(|&byte| byte != 0)
                 .collect();
             match str::from_utf8(&bytes) {
-                Ok(s) => Token::StringLiteral(format!("{:?}", s)),
-                Err(e) => Token::Error(format!("/* {} in {:?} */", e, bytes)),
+                Ok(s) => Token::StringLiteral(format!("{s:?}")),
+                Err(e) => Token::Error(format!("/* {e} in {bytes:?} */")),
             }
         } else {
             let mut words_msb_to_lsb = words
@@ -143,11 +143,11 @@ impl<IMMS: Iterator<Item = spv::Imm>, ID, IDS: Iterator<Item = ID>> OperandPrint
             // how to print integer(?) literals.
             let mut s;
             if words_msb_to_lsb.peek().is_none() && most_significant_word <= 0xffff {
-                s = format!("{}", most_significant_word);
+                s = format!("{most_significant_word}");
             } else {
-                s = format!("0x{:x}", most_significant_word);
+                s = format!("0x{most_significant_word:x}");
                 for word in words_msb_to_lsb {
-                    write!(s, "_{:08x}", word).unwrap();
+                    write!(s, "_{word:08x}").unwrap();
                 }
             }
             Token::NumericLiteral(s)
@@ -174,7 +174,7 @@ impl<IMMS: Iterator<Item = spv::Imm>, ID, IDS: Iterator<Item = ID>> OperandPrint
         let emit_missing_error = |this: &mut Self| {
             this.out
                 .tokens
-                .push(Token::Error(format!("/* missing {} */", name)))
+                .push(Token::Error(format!("/* missing {name} */")))
         };
 
         let mut maybe_get_enum_word = || match self.imms.next() {

--- a/src/spv/read.rs
+++ b/src/spv/read.rs
@@ -80,18 +80,18 @@ impl InstParseError {
                         let unsupported = spec::BitIdx::of_all_set_bits(word)
                             .filter(|&bit_idx| bits.get(bit_idx).is_none())
                             .fold(0u32, |x, i| x | (1 << i.0));
-                        format!("unsupported {} bit-pattern 0x{:08x}", name, unsupported).into()
+                        format!("unsupported {name} bit-pattern 0x{unsupported:08x}").into()
                     }
 
                     spec::OperandKindDef::ValueEnum { .. } => {
-                        format!("unsupported {} value {}", name, word).into()
+                        format!("unsupported {name} value {word}").into()
                     }
 
                     _ => unreachable!(),
                 }
             }
             Self::UnknownResultTypeId(id) => {
-                format!("ID %{} used as result type before definition", id).into()
+                format!("ID %{id} used as result type before definition").into()
             }
             Self::MissingContextSensitiveLiteralType => "missing type for literal".into(),
             Self::UnsupportedContextSensitiveLiteralType { type_opcode } => {
@@ -274,7 +274,7 @@ pub struct ModuleParser {
 fn invalid(reason: &str) -> io::Error {
     io::Error::new(
         io::ErrorKind::InvalidData,
-        format!("malformed SPIR-V ({})", reason),
+        format!("malformed SPIR-V ({reason})"),
     )
 }
 
@@ -335,10 +335,10 @@ impl Iterator for ModuleParser {
 
         let (opcode, inst_name, def) = match spec::Opcode::try_from_u16_with_name_and_def(opcode) {
             Some(opcode_name_and_def) => opcode_name_and_def,
-            None => return Some(Err(invalid(&format!("unsupported opcode {}", opcode)))),
+            None => return Some(Err(invalid(&format!("unsupported opcode {opcode}")))),
         };
 
-        let invalid = |msg: &str| invalid(&format!("in {}: {}", inst_name, msg));
+        let invalid = |msg: &str| invalid(&format!("in {inst_name}: {msg}"));
 
         if words.len() < inst_len {
             return Some(Err(invalid("truncated instruction")));
@@ -388,8 +388,7 @@ impl Iterator for ModuleParser {
             let old = self.known_ids.insert(id, known_id_def);
             if old.is_some() {
                 return Err(invalid(&format!(
-                    "ID %{} is a result of multiple instructions",
-                    id
+                    "ID %{id} is a result of multiple instructions"
                 )));
             }
 

--- a/src/spv/spec.rs
+++ b/src/spv/spec.rs
@@ -753,7 +753,7 @@ impl Spec {
                             Seq::Rest
                         }
                     };
-                    assert!(seq <= Some(next_seq), "{:?} -> {:?}", next_seq, seq);
+                    assert!(seq <= Some(next_seq), "{next_seq:?} -> {seq:?}");
                     seq = Some(next_seq);
                 }
 
@@ -767,9 +767,7 @@ impl Spec {
                 // Only allow aliases that do not meaningfully differ.
                 assert!(
                     prev_def == new_def,
-                    "instructions {} and {} share an opcode but differ in definition",
-                    prev_name,
-                    new_name,
+                    "instructions {prev_name} and {new_name} share an opcode but differ in definition",
                 );
 
                 (preferred_name_between_dups(prev_name, new_name), new_def)
@@ -1089,8 +1087,7 @@ pub mod indexed {
                 // for special handling of duplicates (via `merge_duplicates`).
                 if usize::from(idx) < last_idx {
                     panic!(
-                        "KhrSegmentedVec::insert_in_order: out of order indices ({} after {})",
-                        idx, last_idx,
+                        "KhrSegmentedVec::insert_in_order: out of order indices ({idx} after {last_idx})",
                     );
                 }
             }

--- a/src/spv/write.rs
+++ b/src/spv/write.rs
@@ -50,11 +50,11 @@ impl OperandEmitError {
                         let unsupported = spec::BitIdx::of_all_set_bits(word)
                             .filter(|&bit_idx| bits.get(bit_idx).is_none())
                             .fold(0u32, |x, i| x | (1 << i.0));
-                        format!("unsupported {} bit-pattern 0x{:08x}", name, unsupported).into()
+                        format!("unsupported {name} bit-pattern 0x{unsupported:08x}").into()
                     }
 
                     spec::OperandKindDef::ValueEnum { .. } => {
-                        format!("unsupported {} value {}", name, word).into()
+                        format!("unsupported {name} value {word}").into()
                     }
 
                     _ => unreachable!(),
@@ -187,7 +187,7 @@ pub struct ModuleEmitter {
 fn invalid(reason: &str) -> io::Error {
     io::Error::new(
         io::ErrorKind::InvalidData,
-        format!("malformed SPIR-V ({})", reason),
+        format!("malformed SPIR-V ({reason})"),
     )
 }
 
@@ -202,7 +202,7 @@ impl ModuleEmitter {
     // FIXME(eddyb) sanity-check the operands against the definition of `inst.opcode`.
     pub fn push_inst(&mut self, inst: &spv::InstWithIds) -> io::Result<()> {
         let (inst_name, def) = inst.opcode.name_and_def();
-        let invalid = |msg: &str| invalid(&format!("in {}: {}", inst_name, msg));
+        let invalid = |msg: &str| invalid(&format!("in {inst_name}: {msg}"));
 
         // FIXME(eddyb) make these errors clearer (or turn them into asserts?).
         if inst.result_type_id.is_some() != def.has_result_type_id {


### PR DESCRIPTION
This is new on nightly - result looks great, but it being flipped on broke our CI.