### PR TITLE
print: align adjacent multi-version columns' lines, to match up their anchors.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased] - ReleaseDate
 
+### Added ⭐
+- [PR#18](https://github.com/EmbarkStudios/spirt/pull/18) added anchor-based alignment
+  to multi-version pretty-printing output (the same definitions will be kept on
+  the same lines in all columns, wherever possible, to improve readability)
+
 ### Changed 🛠
 - [PR#26](https://github.com/EmbarkStudios/spirt/pull/26) allowed using `OpEmitMeshTasksEXT` as a terminator (by hardcoding it as `Control-Flow`)
 - [PR#25](https://github.com/EmbarkStudios/spirt/pull/25) updated SPIRV-headers from 1.5.4 to 1.6.1

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ arrayvec = "0.7.1"
 bytemuck = "1.12.3"
 elsa = { version = "1.6.0", features = ["indexmap"] }
 indexmap = "1.7.0"
+internal-iterator = "0.2.0"
 itertools = "0.10.3"
 lazy_static = "1.4.0"
 rustc-hash = "1.1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,7 @@ indexmap = "1.7.0"
 internal-iterator = "0.2.0"
 itertools = "0.10.3"
 lazy_static = "1.4.0"
+longest-increasing-subsequence = "0.1.0"
 rustc-hash = "1.1.0"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/src/print/mod.rs
+++ b/src/print/mod.rs
@@ -466,7 +466,7 @@ impl Visit for AllCxInterned {
 }
 
 // FIXME(eddyb) make max line width configurable.
-const MAX_LINE_WIDTH: usize = 120;
+const MAX_LINE_WIDTH: usize = 100;
 
 impl Plan<'_> {
     #[allow(rustdoc::private_intra_doc_links)]

--- a/src/print/mod.rs
+++ b/src/print/mod.rs
@@ -465,6 +465,9 @@ impl Visit for AllCxInterned {
     fn visit_with<'a>(&'a self, _visitor: &mut impl Visitor<'a>) {}
 }
 
+// FIXME(eddyb) make max line width configurable.
+const MAX_LINE_WIDTH: usize = 120;
+
 impl Plan<'_> {
     #[allow(rustdoc::private_intra_doc_links)]
     /// Print the whole [`Plan`] to a [`Versions<pretty::Fragment>`] and perform
@@ -474,11 +477,8 @@ impl Plan<'_> {
     /// [`fmt::Display`] for convenience, but also more specific methods
     /// (e.g. HTML output).
     pub fn pretty_print(&self) -> Versions<pretty::FragmentPostLayout> {
-        // FIXME(eddyb) make max line width configurable.
-        let max_line_width = 120;
-
         self.print(&Printer::new(self))
-            .map_pretty_fragments(|fragment| fragment.layout_with_max_line_width(max_line_width))
+            .map_pretty_fragments(|fragment| fragment.layout_with_max_line_width(MAX_LINE_WIDTH))
     }
 }
 

--- a/src/print/mod.rs
+++ b/src/print/mod.rs
@@ -20,6 +20,7 @@
 use itertools::Itertools as _;
 
 use crate::func_at::FuncAt;
+use crate::print::multiversion::Versions;
 use crate::visit::{DynVisit, InnerVisit, Visit, Visitor};
 use crate::{
     cfg, spv, AddrSpace, Attr, AttrSet, AttrSetDef, Const, ConstCtor, ConstDef, Context,
@@ -32,9 +33,9 @@ use crate::{
 use rustc_hash::FxHashMap;
 use smallvec::SmallVec;
 use std::collections::hash_map::Entry;
-use std::fmt::Write;
-use std::{fmt, mem};
+use std::mem;
 
+mod multiversion;
 mod pretty;
 
 /// "Definitions-before-uses" / "topo-sorted" printing plan.
@@ -446,198 +447,6 @@ impl<E: Visit, F: Visit> InnerVisit for ExpectedVsFound<E, F> {
 
 impl Visit for AllCxInterned {
     fn visit_with<'a>(&'a self, _visitor: &mut impl Visitor<'a>) {}
-}
-
-#[allow(rustdoc::private_intra_doc_links)]
-/// Wrapper for handling the difference between single-version and multi-version
-/// output, which aren't expressible in [`pretty::Fragment`].
-//
-// FIXME(eddyb) introduce a `pretty::Node` variant capable of handling this,
-// but that's complicated wrt non-HTML output, if they're to also be 2D tables.
-pub enum Versions<PF> {
-    Single(PF),
-    Multiple {
-        // FIXME(eddyb) avoid allocating this if possible.
-        version_names: Vec<String>,
-
-        /// Each node has definitions "tagged" with an `usize` indicating the
-        /// number of versions that share that definition, aka "repeat count"
-        /// (i.e. "repeat counts" larger than `1` indicate deduplication).
-        per_node_versions_with_repeat_count: Vec<SmallVec<[(PF, usize); 1]>>,
-    },
-}
-
-impl fmt::Display for Versions<pretty::FragmentPostLayout> {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            Self::Single(fragment) => fragment.fmt(f),
-            Self::Multiple {
-                version_names,
-                per_node_versions_with_repeat_count,
-            } => {
-                let mut first = true;
-
-                // HACK(eddyb) this is not the nicest output, but multi-version
-                // is intended for HTML input primarily anyway.
-                for versions_with_repeat_count in per_node_versions_with_repeat_count {
-                    if !first {
-                        writeln!(f)?;
-                    }
-                    first = false;
-
-                    let mut next_version_idx = 0;
-                    let mut any_headings = false;
-                    for (fragment, repeat_count) in versions_with_repeat_count {
-                        // No headings for anything uniform across versions.
-                        if (next_version_idx, *repeat_count) != (0, version_names.len()) {
-                            any_headings = true;
-
-                            if next_version_idx == 0 {
-                                write!(f, "//#IF ")?;
-                            } else {
-                                write!(f, "//#ELSEIF ")?;
-                            }
-                            let mut first_name = true;
-                            for name in &version_names[next_version_idx..][..*repeat_count] {
-                                if !first_name {
-                                    write!(f, " | ")?;
-                                }
-                                first_name = false;
-
-                                write!(f, "`{name}`")?;
-                            }
-                            writeln!(f)?;
-                        }
-
-                        writeln!(f, "{fragment}")?;
-
-                        next_version_idx += repeat_count;
-                    }
-                    if any_headings {
-                        writeln!(f, "//#ENDIF")?;
-                    }
-                }
-
-                Ok(())
-            }
-        }
-    }
-}
-
-impl Versions<pretty::FragmentPostLayout> {
-    // FIXME(eddyb) provide a non-allocating version.
-    pub fn render_to_html(&self) -> pretty::HtmlSnippet {
-        match self {
-            Self::Single(fragment) => fragment.render_to_html(),
-            Self::Multiple {
-                version_names,
-                per_node_versions_with_repeat_count,
-            } => {
-                // HACK(eddyb) using an UUID as a class name in lieu of "scoped <style>".
-                const TABLE_CLASS_NAME: &str = "spirt-table-90c2056d-5b38-4644-824a-b4be1c82f14d";
-
-                let mut html = pretty::HtmlSnippet::default();
-                html.head_deduplicatable_elements.insert(
-                    "
-<style>
-    SCOPE {
-        min-width: 100%;
-
-        border-collapse: collapse;
-    }
-    SCOPE>tbody>tr>*:not(:only-child) {
-        border: solid 1px;
-    }
-    SCOPE>tbody>tr>th {
-        /* HACK(eddyb) these are relative to `pretty`'s own HTML styles. */
-        font-size: 17px;
-        font-weight: 700;
-
-        font-style: italic;
-    }
-    SCOPE>tbody>tr>td {
-        vertical-align: top;
-
-        /* HACK(eddyb) force local scroll when table isn't wide enough. */
-        max-width: 40ch;
-    }
-    SCOPE>tbody>tr>td>pre {
-        overflow-x: auto;
-    }
-</style>
-        "
-                    .replace("SCOPE", &format!("table.{TABLE_CLASS_NAME}")),
-                );
-
-                let headings = {
-                    let mut h = "<tr>".to_string();
-                    for name in version_names {
-                        write!(h, "<th><code>{name}</code></th>").unwrap();
-                    }
-                    h + "</tr>\n"
-                };
-
-                html.body = format!("<table class=\"{TABLE_CLASS_NAME}\">\n");
-                let mut last_was_uniform = true;
-                for versions_with_repeat_count in per_node_versions_with_repeat_count {
-                    let is_uniform = match versions_with_repeat_count[..] {
-                        [(_, repeat_count)] => repeat_count == version_names.len(),
-                        _ => false,
-                    };
-
-                    if last_was_uniform && is_uniform {
-                        // Headings unnecessary, they would be between uniform
-                        // rows (or at the very start, before an uniform row).
-                    } else {
-                        // Repeat the headings often, where necessary.
-                        html.body += &headings;
-                    }
-                    last_was_uniform = is_uniform;
-
-                    html.body += "<tr>\n";
-                    for (fragment, repeat_count) in versions_with_repeat_count {
-                        writeln!(html.body, "<td colspan=\"{repeat_count}\">").unwrap();
-
-                        let pretty::HtmlSnippet {
-                            head_deduplicatable_elements: fragment_head,
-                            body: fragment_body,
-                        } = fragment.render_to_html();
-                        html.head_deduplicatable_elements.extend(fragment_head);
-                        html.body += &fragment_body;
-
-                        html.body += "</td>\n";
-                    }
-                    html.body += "</tr>\n";
-                }
-                html.body += "</table>";
-
-                html
-            }
-        }
-    }
-}
-
-impl<PF> Versions<PF> {
-    fn map_pretty_fragments<PF2>(self, f: impl Fn(PF) -> PF2) -> Versions<PF2> {
-        match self {
-            Versions::Single(fragment) => Versions::Single(f(fragment)),
-            Versions::Multiple {
-                version_names,
-                per_node_versions_with_repeat_count,
-            } => Versions::Multiple {
-                version_names,
-                per_node_versions_with_repeat_count: per_node_versions_with_repeat_count
-                    .into_iter()
-                    .map(|versions_with_repeat_count| {
-                        versions_with_repeat_count
-                            .into_iter()
-                            .map(|(fragment, repeat_count)| (f(fragment), repeat_count))
-                            .collect()
-                    })
-                    .collect(),
-            },
-        }
-    }
 }
 
 impl Plan<'_> {
@@ -1439,7 +1248,7 @@ impl Print for Plan<'_> {
                     .iter()
                     .map(|(name, _)| name.clone())
                     .collect(),
-                per_node_versions_with_repeat_count: per_node_versions_with_repeat_count.collect(),
+                per_row_versions_with_repeat_count: per_node_versions_with_repeat_count.collect(),
             }
         }
     }

--- a/src/print/multiversion.rs
+++ b/src/print/multiversion.rs
@@ -1,9 +1,14 @@
 //! Multi-version pretty-printing support (e.g. for comparing the IR between passes).
 
-use crate::print::pretty;
+use crate::print::pretty::{self, TextOp};
+use crate::FxIndexMap;
+use internal_iterator::{
+    FromInternalIterator, InternalIterator, IntoInternalIterator, IteratorExt,
+};
+use itertools::Itertools;
 use smallvec::SmallVec;
-use std::fmt;
 use std::fmt::Write;
+use std::{fmt, mem};
 
 #[allow(rustdoc::private_intra_doc_links)]
 /// Wrapper for handling the difference between single-version and multi-version
@@ -153,14 +158,25 @@ impl Versions<pretty::FragmentPostLayout> {
                     }
                     last_was_uniform = is_uniform;
 
+                    // Attempt to align as many anchors as possible between the
+                    // columns, to improve legibility (see also `AnchorAligner`).
+                    let mut anchor_aligner = AnchorAligner::default();
+                    for (fragment, _) in versions_with_repeat_count {
+                        anchor_aligner
+                            .add_column_and_align_anchors(fragment.render_to_text_ops().collect());
+                    }
+
                     html.body += "<tr>\n";
-                    for (fragment, repeat_count) in versions_with_repeat_count {
+                    for ((_, repeat_count), column) in versions_with_repeat_count
+                        .iter()
+                        .zip(anchor_aligner.merged_columns())
+                    {
                         writeln!(html.body, "<td colspan=\"{repeat_count}\">").unwrap();
 
                         let pretty::HtmlSnippet {
                             head_deduplicatable_elements: fragment_head,
                             body: fragment_body,
-                        } = fragment.render_to_html();
+                        } = column.into_internal().collect();
                         html.head_deduplicatable_elements.extend(fragment_head);
                         html.body += &fragment_body;
 
@@ -196,5 +212,262 @@ impl<PF> Versions<PF> {
                     .collect(),
             },
         }
+    }
+}
+
+/// Tool for adjusting pretty-printed columns, so that their anchors line up
+/// (by adding empty lines to whichever side "is behind").
+#[derive(Default)]
+struct AnchorAligner<'a> {
+    merged_lines: Vec<AAMergedLine>,
+
+    /// Current ("rightmost") column's anchor definitions (with indices pointing
+    /// into `merged_lines`), which the next column will align to.
+    //
+    // FIXME(eddyb) does this need additional interning?
+    anchor_def_to_merged_line_idx: FxIndexMap<&'a String, usize>,
+
+    // FIXME(eddyb) fine-tune this inline size.
+    // FIXME(eddyb) maybe don't keep most of this data around anyway?
+    original_columns: SmallVec<[AAColumn<'a>; 4]>,
+}
+
+/// Abstraction for one "physical" line spanning all columns, after alignment.
+struct AAMergedLine {
+    // FIXME(eddyb) fine-tune this inline size.
+    // FIXME(eddyb) consider using `u32` here?
+    per_column_line_lengths: SmallVec<[usize; 4]>,
+}
+
+struct AAColumn<'a> {
+    /// All `TextOp`s in all lines from this column, concatenated together.
+    text_ops: Vec<TextOp<'a>>,
+
+    /// The length, in `TextOp`s (from `text_ops`), of each line.
+    //
+    // FIXME(eddyb) consider using `u32` here?
+    line_lengths: Vec<usize>,
+}
+
+impl<'a> AAColumn<'a> {
+    /// Reconstruct lines (made of `TextOp`s) from line lengths.
+    fn lines(
+        &self,
+        line_lengths: impl Iterator<Item = usize>,
+    ) -> impl Iterator<Item = &[TextOp<'a>]> {
+        let mut next_start = 0;
+        line_lengths.map(move |len| {
+            let start = next_start;
+            let end = start + len;
+            next_start = end;
+            &self.text_ops[start..end]
+        })
+    }
+}
+
+// FIXME(eddyb) is this impl the best way? (maybe it should be a inherent method)
+impl<'a> FromInternalIterator<TextOp<'a>> for AAColumn<'a> {
+    fn from_iter<T>(text_ops: T) -> Self
+    where
+        T: IntoInternalIterator<Item = TextOp<'a>>,
+    {
+        let mut column = AAColumn {
+            text_ops: vec![],
+            line_lengths: vec![0],
+        };
+        text_ops.into_internal_iter().for_each(|op| {
+            if let TextOp::Text("\n") = op {
+                column.line_lengths.push(0);
+            } else {
+                // FIXME(eddyb) this *happens* to be true,
+                // but the `LineOp`/`TextOp` split could be
+                // improved to avoid such sanity checks.
+                if let TextOp::Text(text) = op {
+                    assert!(!text.contains('\n'));
+                }
+                column.text_ops.push(op);
+                *column.line_lengths.last_mut().unwrap() += 1;
+            }
+        });
+        column
+    }
+}
+
+impl<'a> AnchorAligner<'a> {
+    /// Flatten all columns to `TextOp`s (including line separators).
+    fn merged_columns(&self) -> impl Iterator<Item = impl Iterator<Item = TextOp<'a>> + '_> {
+        self.original_columns
+            .iter()
+            .enumerate()
+            .map(|(column_idx, column)| {
+                let line_lengths = self
+                    .merged_lines
+                    .iter()
+                    .map(move |line| line.per_column_line_lengths[column_idx]);
+
+                // HACK(eddyb) trim all trailing empty lines (which is done on
+                // a `peekable` of the reverse, followed by reversing *again*,
+                // equivalent to a hypothetical `peekable_back` and no reversing).
+                let mut rev_line_lengths = line_lengths.rev().peekable();
+                while rev_line_lengths.peek() == Some(&0) {
+                    rev_line_lengths.next().unwrap();
+                }
+                let line_lengths = rev_line_lengths.rev();
+
+                column
+                    .lines(line_lengths)
+                    .intersperse(&[TextOp::Text("\n")])
+                    .flatten()
+                    .copied()
+            })
+    }
+
+    /// Merge `new_column` into the current set of columns, aligning as many
+    /// anchors as possible, between it, and the most recent column.
+    fn add_column_and_align_anchors(&mut self, new_column: AAColumn<'a>) {
+        // NOTE(eddyb) "old" and "new" are used to refer to the two columns being
+        // aligned, but "old" maps to the *merged* lines, not its original ones.
+
+        let old_lines = mem::take(&mut self.merged_lines);
+        let old_anchor_def_to_line_idx = mem::take(&mut self.anchor_def_to_merged_line_idx);
+
+        // Index all the anchor definitions in the new column.
+        let mut new_anchor_def_to_line_idx = FxIndexMap::default();
+        for (new_line_idx, new_line_text_ops) in new_column
+            .lines(new_column.line_lengths.iter().copied())
+            .enumerate()
+        {
+            for op in new_line_text_ops {
+                if let TextOp::PushStyles(styles) = op {
+                    if let Some(anchor) = &styles.anchor {
+                        if styles.anchor_is_def {
+                            new_anchor_def_to_line_idx
+                                .entry(anchor)
+                                .or_insert(new_line_idx);
+                        }
+                    }
+                }
+            }
+        }
+
+        // Find all the possible anchor alignments (i.e. anchors defined in both
+        // "old" and "new") as pairs of line indices in "old" and "new".
+        //
+        // HACK(eddyb) the order is given by the "new" line index, implicitly.
+        // FIXME(eddyb) fine-tune this inline size.
+        let common_anchors: SmallVec<[_; 8]> = new_anchor_def_to_line_idx
+            .iter()
+            .filter_map(|(anchor, &new_line_idx)| {
+                Some((*old_anchor_def_to_line_idx.get(anchor)?, new_line_idx))
+            })
+            .collect();
+
+        // Fast-path: if all the "old" line indices are already in (increasing)
+        // order (i.e. "monotonic"), they can all be used directly for alignment.
+        let is_already_monotonic = {
+            // FIXME(eddyb) should be `.is_sorted_by_key(|&(old_line_idx, _)| old_line_idx)`
+            // but that slice method is still unstable.
+            common_anchors.windows(2).all(|w| w[0].0 <= w[1].0)
+        };
+        let monotonic_common_anchors = if is_already_monotonic {
+            common_anchors
+        } else {
+            // FIXME(eddyb) this could maybe avoid all the unnecessary allocations.
+            longest_increasing_subsequence::lis(&common_anchors)
+                .into_iter()
+                .map(|i| common_anchors[i])
+                .collect()
+        };
+
+        // Allocate space for the merge of "old" and "new".
+        let mut merged_lines = Vec::with_capacity({
+            // Cheap conservative estimate, based on the last anchor (i.e. the
+            // final position of the last anchor is *at least* `min_before_last`).
+            let &(old_last, new_last) = monotonic_common_anchors.last().unwrap_or(&(0, 0));
+            let min_before_last = old_last.max(new_last);
+            let after_last =
+                (old_lines.len() - old_last).max(new_column.line_lengths.len() - new_last);
+            (min_before_last + after_last).next_power_of_two()
+        });
+
+        // Build the merged lines using (partially) lockstep iteration to pull
+        // the relevant data out of either side, and update "new" line indices.
+        let mut old_lines = old_lines.into_iter().enumerate().peekable();
+        let mut new_lines = new_column
+            .line_lengths
+            .iter()
+            .copied()
+            .enumerate()
+            .peekable();
+        let mut monotonic_common_anchors = monotonic_common_anchors.into_iter().peekable();
+        let mut fixup_new_to_merged = new_anchor_def_to_line_idx.values_mut().peekable();
+        while old_lines.len() > 0 || new_lines.len() > 0 {
+            let old_line_idx = old_lines.peek().map(|&(i, _)| i);
+            let new_line_idx = new_lines.peek().map(|&(i, _)| i);
+            let mut next_anchor = monotonic_common_anchors.peek().copied();
+
+            // Discard anchor alignments that have been used already, and also
+            // any others that cannot be relevant anymore - this can occur when
+            // multiple anchors coincide on the same line.
+            while let Some((anchor_old, anchor_new)) = next_anchor {
+                let obsolete = old_line_idx.map_or(false, |old| old > anchor_old)
+                    || new_line_idx.map_or(false, |new| new > anchor_new);
+                if !obsolete {
+                    break;
+                }
+                monotonic_common_anchors.next().unwrap();
+                next_anchor = monotonic_common_anchors.peek().copied();
+            }
+
+            // Figure out which side has to wait, to align an upcoming anchor.
+            let (old_at_anchor, new_at_anchor) =
+                next_anchor.map_or((false, false), |(anchor_old, anchor_new)| {
+                    (
+                        old_line_idx.map_or(false, |old| old == anchor_old),
+                        new_line_idx.map_or(false, |new| new == anchor_new),
+                    )
+                });
+            let old_line = if old_at_anchor && !new_at_anchor {
+                // Pausing "old", waiting for "new".
+                None
+            } else {
+                old_lines.next().map(|(_, old_line)| old_line)
+            };
+            let new_line_len = if !old_at_anchor && new_at_anchor {
+                // Pausing "new", waiting for "old".
+                None
+            } else {
+                new_lines.next().map(|(_, new_line_len)| new_line_len)
+            };
+
+            // When the "new" side is advanced, that "sets" the merged line index
+            // of the consumed line, which can then be used for fixing up indices.
+            if new_line_len.is_some() {
+                let new_line_idx = new_line_idx.unwrap();
+                let merged_line_idx = merged_lines.len();
+                while fixup_new_to_merged.peek().map(|i| **i) == Some(new_line_idx) {
+                    *fixup_new_to_merged.next().unwrap() = merged_line_idx;
+                }
+            }
+
+            let new_line_len = new_line_len.unwrap_or(0);
+            let merged_line = match old_line {
+                Some(mut line) => {
+                    line.per_column_line_lengths.push(new_line_len);
+                    line
+                }
+                None => AAMergedLine {
+                    per_column_line_lengths: (0..self.original_columns.len())
+                        .map(|_| 0)
+                        .chain([new_line_len])
+                        .collect(),
+                },
+            };
+            merged_lines.push(merged_line);
+        }
+
+        self.merged_lines = merged_lines;
+        self.anchor_def_to_merged_line_idx = new_anchor_def_to_line_idx;
+        self.original_columns.push(new_column);
     }
 }

--- a/src/print/multiversion.rs
+++ b/src/print/multiversion.rs
@@ -1,0 +1,200 @@
+//! Multi-version pretty-printing support (e.g. for comparing the IR between passes).
+
+use crate::print::pretty;
+use smallvec::SmallVec;
+use std::fmt;
+use std::fmt::Write;
+
+#[allow(rustdoc::private_intra_doc_links)]
+/// Wrapper for handling the difference between single-version and multi-version
+/// output, which aren't expressible in [`pretty::Fragment`].
+//
+// FIXME(eddyb) introduce a `pretty::Node` variant capable of handling this,
+// but that's complicated wrt non-HTML output, if they're to also be 2D tables.
+pub enum Versions<PF> {
+    Single(PF),
+    Multiple {
+        // FIXME(eddyb) avoid allocating this if possible.
+        version_names: Vec<String>,
+
+        /// Each row consists of *deduplicated* (or "run-length encoded")
+        /// versions, with "repeat count"s larger than `1` indicating that
+        /// multiple versions (columns) have the exact same content.
+        ///
+        /// For HTML output, "repeat count"s map to `colspan` attributes.
+        per_row_versions_with_repeat_count: Vec<SmallVec<[(PF, usize); 1]>>,
+    },
+}
+
+impl fmt::Display for Versions<pretty::FragmentPostLayout> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Single(fragment) => fragment.fmt(f),
+            Self::Multiple {
+                version_names,
+                per_row_versions_with_repeat_count,
+            } => {
+                let mut first = true;
+
+                // HACK(eddyb) this is not the nicest output, but multi-version
+                // is intended for HTML input primarily anyway.
+                for versions_with_repeat_count in per_row_versions_with_repeat_count {
+                    if !first {
+                        writeln!(f)?;
+                    }
+                    first = false;
+
+                    let mut next_version_idx = 0;
+                    let mut any_headings = false;
+                    for (fragment, repeat_count) in versions_with_repeat_count {
+                        // No headings for anything uniform across versions.
+                        if (next_version_idx, *repeat_count) != (0, version_names.len()) {
+                            any_headings = true;
+
+                            if next_version_idx == 0 {
+                                write!(f, "//#IF ")?;
+                            } else {
+                                write!(f, "//#ELSEIF ")?;
+                            }
+                            let mut first_name = true;
+                            for name in &version_names[next_version_idx..][..*repeat_count] {
+                                if !first_name {
+                                    write!(f, " | ")?;
+                                }
+                                first_name = false;
+
+                                write!(f, "`{name}`")?;
+                            }
+                            writeln!(f)?;
+                        }
+
+                        writeln!(f, "{fragment}")?;
+
+                        next_version_idx += repeat_count;
+                    }
+                    if any_headings {
+                        writeln!(f, "//#ENDIF")?;
+                    }
+                }
+
+                Ok(())
+            }
+        }
+    }
+}
+
+impl Versions<pretty::FragmentPostLayout> {
+    // FIXME(eddyb) provide a non-allocating version.
+    pub fn render_to_html(&self) -> pretty::HtmlSnippet {
+        match self {
+            Self::Single(fragment) => fragment.render_to_html(),
+            Self::Multiple {
+                version_names,
+                per_row_versions_with_repeat_count,
+            } => {
+                // HACK(eddyb) using an UUID as a class name in lieu of "scoped <style>".
+                const TABLE_CLASS_NAME: &str = "spirt-table-90c2056d-5b38-4644-824a-b4be1c82f14d";
+
+                let mut html = pretty::HtmlSnippet::default();
+                html.head_deduplicatable_elements.insert(
+                    "
+<style>
+    SCOPE {
+        min-width: 100%;
+
+        border-collapse: collapse;
+    }
+    SCOPE>tbody>tr>*:not(:only-child) {
+        border: solid 1px;
+    }
+    SCOPE>tbody>tr>th {
+        /* HACK(eddyb) these are relative to `pretty`'s own HTML styles. */
+        font-size: 17px;
+        font-weight: 700;
+
+        font-style: italic;
+    }
+    SCOPE>tbody>tr>td {
+        vertical-align: top;
+
+        /* HACK(eddyb) force local scroll when table isn't wide enough. */
+        max-width: 40ch;
+    }
+    SCOPE>tbody>tr>td>pre {
+        overflow-x: auto;
+    }
+</style>
+        "
+                    .replace("SCOPE", &format!("table.{TABLE_CLASS_NAME}")),
+                );
+
+                let headings = {
+                    let mut h = "<tr>".to_string();
+                    for name in version_names {
+                        write!(h, "<th><code>{name}</code></th>").unwrap();
+                    }
+                    h + "</tr>\n"
+                };
+
+                html.body = format!("<table class=\"{TABLE_CLASS_NAME}\">\n");
+                let mut last_was_uniform = true;
+                for versions_with_repeat_count in per_row_versions_with_repeat_count {
+                    let is_uniform = match versions_with_repeat_count[..] {
+                        [(_, repeat_count)] => repeat_count == version_names.len(),
+                        _ => false,
+                    };
+
+                    if last_was_uniform && is_uniform {
+                        // Headings unnecessary, they would be between uniform
+                        // rows (or at the very start, before an uniform row).
+                    } else {
+                        // Repeat the headings often, where necessary.
+                        html.body += &headings;
+                    }
+                    last_was_uniform = is_uniform;
+
+                    html.body += "<tr>\n";
+                    for (fragment, repeat_count) in versions_with_repeat_count {
+                        writeln!(html.body, "<td colspan=\"{repeat_count}\">").unwrap();
+
+                        let pretty::HtmlSnippet {
+                            head_deduplicatable_elements: fragment_head,
+                            body: fragment_body,
+                        } = fragment.render_to_html();
+                        html.head_deduplicatable_elements.extend(fragment_head);
+                        html.body += &fragment_body;
+
+                        html.body += "</td>\n";
+                    }
+                    html.body += "</tr>\n";
+                }
+                html.body += "</table>";
+
+                html
+            }
+        }
+    }
+}
+
+impl<PF> Versions<PF> {
+    pub fn map_pretty_fragments<PF2>(self, f: impl Fn(PF) -> PF2) -> Versions<PF2> {
+        match self {
+            Versions::Single(fragment) => Versions::Single(f(fragment)),
+            Versions::Multiple {
+                version_names,
+                per_row_versions_with_repeat_count,
+            } => Versions::Multiple {
+                version_names,
+                per_row_versions_with_repeat_count: per_row_versions_with_repeat_count
+                    .into_iter()
+                    .map(|versions_with_repeat_count| {
+                        versions_with_repeat_count
+                            .into_iter()
+                            .map(|(fragment, repeat_count)| (f(fragment), repeat_count))
+                            .collect()
+                    })
+                    .collect(),
+            },
+        }
+    }
+}

--- a/src/print/pretty.rs
+++ b/src/print/pretty.rs
@@ -309,7 +309,10 @@ impl<'a> FromInternalIterator<TextOp<'a>> for HtmlSnippet {
 "
         .replace("SCOPE", &format!("pre.{ROOT_CLASS_NAME}"));
 
-        let mut body = format!("<pre class=\"{ROOT_CLASS_NAME}\">");
+        // HACK(eddyb) load-bearing newline after `<pre ...>`, to front-load any
+        // weird HTML whitespace handling, and allow the actual contents to start
+        // with empty lines (i.e. `\n\n...`), without e.g. losing the first one.
+        let mut body = format!("<pre class=\"{ROOT_CLASS_NAME}\">\n");
         text_ops.into_internal_iter().for_each(|op| match op {
             TextOp::PushStyles(styles) | TextOp::PopStyles(styles) => {
                 let mut special_tags = [

--- a/src/print/pretty.rs
+++ b/src/print/pretty.rs
@@ -297,6 +297,9 @@ impl<'a> FromInternalIterator<TextOp<'a>> for HtmlSnippet {
     SCOPE a:not(:hover) {
         text-decoration: unset;
     }
+    SCOPE sub, SCOPE sup {
+        line-height: 0;
+    }
 </style>
 "
         .replace("SCOPE", &format!("pre.{ROOT_CLASS_NAME}"));


### PR DESCRIPTION
This extra step, just before turning multi-version pretty-printed fragments into a HTML table row, allows for a clearer visual match between the columns, turning the multi-version mode into something closer to a pass "differ", but the use of *anchors* (instead of line contents) makes it more conservative, reliable and somewhat simpler.

In short, if two adjacent versions contain a *definition* like `v123 = ...`, it should now end up on the same horizontal line in both versions (assuming it's not e.g. out of order wrt most of the other definitions).

Before, adding or removing instructions (or even their pretty-printing needing different line amounts) would result in one side being behind (and the other, ahead), which would accumulate (even if most of their contents might be similar or even identical). With this PR, a lot of that should be alleviated, as padding (of empty lines) is added to keep both versions aligned as much as possible.

---

*However*, while it works great for correcting *small* misalignments (the original usecase), it's quite zealous (and lacks any heuristics or further constraint-solving etc.), leading to results like this:

|[**Before**](https://htmlpreview.github.io/?https://gist.github.com/eddyb/387fb2b7e128e8ca4e4c00ff82baf459/raw/0-before-spirt%252318-simplest_shader.spirt.html&dark#func1)<br><sub><sup>(click&nbsp;for&nbsp;complete<br>pretty&nbsp;HTML&nbsp;example)</sup></sub>|![image](https://user-images.githubusercontent.com/77424/224555823-318a9019-3463-4f9a-ac61-430d48197b72.png)|
|:-:|-|
|[**After**](https://htmlpreview.github.io/?https://gist.github.com/eddyb/387fb2b7e128e8ca4e4c00ff82baf459/raw/1-after-spirt%252318-simplest_shader.spirt.html&dark#func1)<br><sub><sup>(click&nbsp;for&nbsp;complete<br>pretty&nbsp;HTML&nbsp;example)</sup></sub>|![image](https://user-images.githubusercontent.com/77424/229123954-fd79df73-0cd4-41c6-b515-59646c0bdc5e.png)|

This is for the same SPIR-T as the last screenshot from [the Rust-GPU `reduce`+`fuse_selects` PR](https://github.com/EmbarkStudios/rust-gpu/pull/988#issue-1532474917).

The `OpNop`s don't help (and those should be gone once SPIR-T APIs are adjusted), but it's generally much worse looking than I was hoping. Maybe it's worth it for the ability, but some things are just annoying.

Based on this screenshot alone, several possible further improvements come to mind:
<sub>(_**EDIT**: several of these have been implemented in this PR since it was opened_)</sub>
* [x] ~~hidden anchors could be added for e.g. `ControlNode`s and `ControlRegion`s, even if there's not necessarily any syntax to attach them to (other than the keyword for non-`Block` `ControlNode`s and the `{...}` brackets for `ControlRegion`?)~~
* [x] ~~the contents of the aligned lines could be compared and some kind of graying/translucency used to de-emphasize the lines that haven't changed~~
  * ~~there's a risk here of making them confused with *removed* lines~~
    * [x] ~~this is where merely *partial* grayscaling, or some kind of sepia effect, might come in handy~~
  * [x] ~~such diff-like mode could supplant the use of `colspan` *entirely*, and allow horizontal scrolling of the whole table, with the max line length being used to size the cells (e.g. `td { max-width: 100ch; }`), instead of divvying up the whole viewport width~~
  * <sub>may need some level of interactivity (based on which column is being hovered on?)</sub>
* Rust-GPU's `--spirt-dump-passes` could skip the unstructured control-flow column, which adds a bunch of gaps for no good reason (or it could be kept but with the alignment turned off?)
* <sub>euristics (or just more user control) to avoid large gaps</sub>
* <sub>some additional "layout" pass could rearrange all the lines that are "floating" in between anchors</sub>
  * <sub>crucially, the current state is that the new vertical gaps are _always_ inserted just before the anchor, _and never elsewhere_, but the lines before the anchor might be more "attached" to it than the ones after
   (sadly, we can't just switch where the vertical gap goes unconditionally: anchors can easily precede multiple-line contents that _should not_ be broken up)</sub>
  * <sub>e.g. ideally the vertical gap would be at the outermost indentation level, which would allow e.g. structured control-flow to "coalesce together" (may require either using `LineOp` more directly, or just making indentation special in `TextOp`)</sub>
  * <sub>it almost feels like this requires a redesign of a bunch of the `print::pretty` layout, to allow "flexible vertical spacing", which frankly seems like overkill</sub>
* <sub>dynamic control over the HTML table via JS, to allow user adjustments on the fly</sub>
  * <sub>some part of the anchor alignment algorithm would likely need to be implemented in JS, to avoid the combinatorial explosion in the data that would need to be statically generated otherwise</sub>