### PR TITLE
pretty: prefer shrinking instead of thinning text, and make SPIR-V ops/enums more distinct.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased] - ReleaseDate
 
+### Changed 🛠
+- [PR#21](https://github.com/EmbarkStudios/spirt/pull/21) tweaked pretty-printing
+  styles around de-emphasis (shrinking instead of thinning, for width savings),
+  and SPIR-V ops/enums (via de-emphasized `spv.` prefix and distinct orange color)
+
 ## [0.1.0] - 2022-12-16
 *Initial public release of SPIR-T for minimal Rust-GPU integration.*
 ### Added ⭐

--- a/src/print/mod.rs
+++ b/src/print/mod.rs
@@ -949,7 +949,7 @@ impl Printer<'_> {
     fn comment_style(&self) -> pretty::Styles {
         pretty::Styles {
             color_opacity: Some(0.3),
-            thickness: Some(-3),
+            size: Some(-4),
             ..pretty::Styles::color(pretty::palettes::simple::DARK_GRAY)
         }
     }

--- a/src/print/pretty.rs
+++ b/src/print/pretty.rs
@@ -68,6 +68,12 @@ pub struct Styles {
     /// For HTML output, each unit is equivalent to `±100` in CSS `font-weight`.
     pub thickness: Option<i8>,
 
+    /// `0` corresponds to the default, with positive values meaning larger,
+    /// and negative values smaller text, respectively.
+    ///
+    /// For HTML output, each unit is equivalent to `±0.1em` in CSS `font-size`.
+    pub size: Option<i8>,
+
     pub subscript: bool,
     pub superscript: bool,
 }
@@ -302,6 +308,7 @@ impl FragmentPostLayout {
                             color,
                             color_opacity,
                             thickness,
+                            size,
                             subscript: _,
                             superscript: _,
                         } = *styles;
@@ -323,6 +330,10 @@ impl FragmentPostLayout {
                         }
                         if let Some(thickness) = thickness {
                             write!(css_style, "font-weight:{};", 500 + (thickness as i32) * 100)
+                                .unwrap();
+                        }
+                        if let Some(size) = size {
+                            write!(css_style, "font-size:{}em;", 1.0 + (size as f64) * 0.1)
                                 .unwrap();
                         }
                         if !css_style.is_empty() {

--- a/src/print/pretty.rs
+++ b/src/print/pretty.rs
@@ -96,12 +96,16 @@ pub mod palettes {
     /// Minimalist palette, chosen to work with both light and dark backgrounds.
     pub mod simple {
         pub const DARK_GRAY: [u8; 3] = [0x44, 0x44, 0x44];
+
         pub const RED: [u8; 3] = [0xcc, 0x55, 0x55];
         pub const GREEN: [u8; 3] = [0x44, 0x99, 0x44];
         pub const BLUE: [u8; 3] = [0x44, 0x66, 0xcc];
+
         pub const YELLOW: [u8; 3] = [0xcc, 0x99, 0x44];
         pub const MAGENTA: [u8; 3] = [0xcc, 0x44, 0xcc];
         pub const CYAN: [u8; 3] = [0x44, 0x99, 0xcc];
+
+        pub const ORANGE: [u8; 3] = [0xcc, 0x77, 0x55];
     }
 }
 

--- a/src/print/pretty.rs
+++ b/src/print/pretty.rs
@@ -186,8 +186,19 @@ impl HtmlSnippet {
         var params = new URLSearchParams(document.location.search);
         var dark = params.has("dark"), light = params.has("light");
         if(dark || light) {
-            if(dark && !light)
+            if(dark && !light) {
                 document.documentElement.classList.add("simple-dark-theme");
+
+                // HACK(eddyb) forcefully disable Dark Reader, for two reasons:
+                // - its own detection of websites with built-in dark themes
+                //   (https://github.com/darkreader/darkreader/pull/7995)
+                //   isn't on by default, and the combination is jarring
+                // - it interacts badly with whole-document-replacement
+                //   (as used by htmlpreview.github.io)
+                document.documentElement.removeAttribute('data-darkreader-scheme');
+                document.querySelectorAll('style.darkreader')
+                    .forEach(style => style.disabled = true);
+            }
         } else if(matchMedia("(prefers-color-scheme: dark)").matches) {
             // FIXME(eddyb) also use media queries in CSS directly, to ensure dark mode
             // still works with JS disabled (sadly that likely requires CSS duplication).
@@ -198,9 +209,7 @@ impl HtmlSnippet {
 
 <style>
     /* HACK(eddyb) `[data-darkreader-scheme="dark"]` is for detecting Dark Reader,
-      as its own automatic detection of websites with built-in dark themes
-      (https://github.com/darkreader/darkreader/pull/7995) isn't on by default,
-      and the result is jarring when both dark modes combine. */
+      to avoid transient interactions (see also comment in the `<script>`). */
 
     html.simple-dark-theme:not([data-darkreader-scheme="dark"]) {
         background: #16181a;

--- a/src/spv/print.rs
+++ b/src/spv/print.rs
@@ -187,25 +187,25 @@ impl<IMMS: Iterator<Item = spv::Imm>, ID, IDS: Iterator<Item = ID>> OperandPrint
                     .tokens
                     .push(Token::OperandKindNamespacePrefix(name));
                 if word == 0 {
-                    self.out.tokens.extend([Token::EnumerandName(empty_name)]);
+                    self.out.tokens.push(Token::EnumerandName(empty_name));
+                } else if let Some(bit_idx) = spec::BitIdx::of_single_set_bit(word) {
+                    let (bit_name, bit_def) = bits.get_named(bit_idx).unwrap();
+                    self.out.tokens.push(Token::EnumerandName(bit_name));
+                    self.enumerant_params(bit_def);
                 } else {
-                    // FIXME(eddyb) consider using `A.{B,C}` instead of `A.(.B,.C)`,
-                    // but also skipping the grouping entirely if there's only one.
-                    self.out.tokens.push(Token::Punctuation("("));
+                    self.out.tokens.push(Token::Punctuation("{"));
                     let mut first = true;
                     for bit_idx in spec::BitIdx::of_all_set_bits(word) {
                         if !first {
-                            self.out.tokens.push(Token::Punctuation(" | "));
+                            self.out.tokens.push(Token::Punctuation(", "));
                         }
                         first = false;
 
                         let (bit_name, bit_def) = bits.get_named(bit_idx).unwrap();
-                        self.out
-                            .tokens
-                            .extend([Token::Punctuation("."), Token::EnumerandName(bit_name)]);
+                        self.out.tokens.push(Token::EnumerandName(bit_name));
                         self.enumerant_params(bit_def);
                     }
-                    self.out.tokens.push(Token::Punctuation(")"));
+                    self.out.tokens.push(Token::Punctuation("}"));
                 }
             }
             spec::OperandKindDef::ValueEnum { variants } => {

--- a/src/spv/print.rs
+++ b/src/spv/print.rs
@@ -9,7 +9,8 @@ use std::{iter, mem, str};
 /// The smallest unit produced by printing a ("logical") SPIR-V operand.
 ///
 /// All variants other than `Id` contain a fully formatted string, and the
-/// distinction between variants can be erased to obtain a plain-text version.
+/// distinction between variants can be erased to obtain a plain-text version
+/// (also except `OperandKindNamespacePrefix` requiring an extra implicit `.`).
 //
 // FIXME(eddyb) should there be a `TokenKind` enum and then `Cow<'static, str>`
 // paired with a `TokenKind` in place of all of these individual variants?
@@ -23,7 +24,9 @@ pub enum Token<ID> {
     // parameters, so that the SPIR-T printer can do layout for them.
     Punctuation(&'static str),
 
-    OperandKindName(&'static str),
+    // NOTE(eddyb) this implies a suffix `.` not included in the string.
+    OperandKindNamespacePrefix(&'static str),
+
     EnumerandName(&'static str),
 
     NumericLiteral(String),
@@ -52,16 +55,16 @@ impl TokensForOperand<String> {
     pub fn concat_to_plain_text(self) -> String {
         self.tokens
             .into_iter()
-            .map(|token| -> Cow<'_, str> {
-                match token {
-                    Token::Punctuation(s) | Token::OperandKindName(s) | Token::EnumerandName(s) => {
-                        s.into()
-                    }
+            .flat_map(|token| {
+                let (first, second): (Cow<'_, str>, _) = match token {
+                    Token::OperandKindNamespacePrefix(s) => (s.into(), Some(".".into())),
+                    Token::Punctuation(s) | Token::EnumerandName(s) => (s.into(), None),
                     Token::Error(s)
                     | Token::NumericLiteral(s)
                     | Token::StringLiteral(s)
-                    | Token::Id(s) => s.into(),
-                }
+                    | Token::Id(s) => (s.into(), None),
+                };
+                [first].into_iter().chain(second)
             })
             .reduce(|out, extra| (out.into_owned() + &extra).into())
             .unwrap_or_default()
@@ -115,7 +118,7 @@ impl<IMMS: Iterator<Item = spv::Imm>, ID, IDS: Iterator<Item = ID>> OperandPrint
             words.push(word);
         }
 
-        let (name, def) = kind.name_and_def();
+        let def = kind.def();
         assert!(matches!(def, spec::OperandKindDef::Literal { .. }));
 
         let literal_token = if kind == spec::Spec::get().well_known.LiteralString {
@@ -151,18 +154,7 @@ impl<IMMS: Iterator<Item = spv::Imm>, ID, IDS: Iterator<Item = ID>> OperandPrint
             Token::NumericLiteral(s)
         };
 
-        // FIXME(eddyb) decide when it's useful to show the kind of literal.
-        let explicit_kind = false;
-
-        if explicit_kind {
-            self.out
-                .tokens
-                .extend([Token::OperandKindName(name), Token::Punctuation("(")]);
-        }
         self.out.tokens.push(literal_token);
-        if explicit_kind {
-            self.out.tokens.push(Token::Punctuation(")"));
-        }
     }
 
     fn operand(&mut self, kind: spec::OperandKind) {
@@ -191,13 +183,15 @@ impl<IMMS: Iterator<Item = spv::Imm>, ID, IDS: Iterator<Item = ID>> OperandPrint
                     None => return emit_missing_error(self),
                 };
 
-                self.out.tokens.push(Token::OperandKindName(name));
+                self.out
+                    .tokens
+                    .push(Token::OperandKindNamespacePrefix(name));
                 if word == 0 {
-                    self.out
-                        .tokens
-                        .extend([Token::Punctuation("."), Token::EnumerandName(empty_name)]);
+                    self.out.tokens.extend([Token::EnumerandName(empty_name)]);
                 } else {
-                    self.out.tokens.push(Token::Punctuation(".("));
+                    // FIXME(eddyb) consider using `A.{B,C}` instead of `A.(.B,.C)`,
+                    // but also skipping the grouping entirely if there's only one.
+                    self.out.tokens.push(Token::Punctuation("("));
                     let mut first = true;
                     for bit_idx in spec::BitIdx::of_all_set_bits(word) {
                         if !first {
@@ -223,8 +217,7 @@ impl<IMMS: Iterator<Item = spv::Imm>, ID, IDS: Iterator<Item = ID>> OperandPrint
                 let (variant_name, variant_def) =
                     variants.get_named(word.try_into().unwrap()).unwrap();
                 self.out.tokens.extend([
-                    Token::OperandKindName(name),
-                    Token::Punctuation("."),
+                    Token::OperandKindNamespacePrefix(name),
                     Token::EnumerandName(variant_name),
                 ]);
                 self.enumerant_params(variant_def);


### PR DESCRIPTION
The main observation here is that *since* picking most of the SPIR-T pretty-printing styles, I've started using RA inlays set to a tiny size, e.g.:
![image](https://user-images.githubusercontent.com/77424/219393103-596ef343-3ddb-475b-bf5f-39ec8ada0031.png)

It's probably a more subjective choice, but on a 4K monitor the result is quite crisp.

In contrast to this, SPIR-T styles used a lot of "low visibility" but never shrinking text, which now feels worse.

---

On the other hand, I've been working on some experiments (involving pointers), and some instructions and attributes unique/specific to SPIR-T, and when those are not visually distinguishable from SPIR-V, it can get confusing.

This PR tries to tackle a bit of all that, the result is:
|[**Before**](https://htmlpreview.github.io/?https://gist.github.com/eddyb/405e25ff9689176cdcc15ace4b7c5c3b/raw/0-before-spirt%252321-mouse-shader.post-merge.link.spirt.html&dark#func99)<br><sub><sup>(click&nbsp;for&nbsp;complete<br>pretty&nbsp;HTML&nbsp;example)</sup></sub>|![image](https://user-images.githubusercontent.com/77424/219394592-bbc7ded5-a034-4f09-bca2-098cc30dc1c2.png)|
|:-:|-|
|[**After**](https://htmlpreview.github.io/?https://gist.github.com/eddyb/405e25ff9689176cdcc15ace4b7c5c3b/raw/1-after-spirt%252321-mouse-shader.post-merge.link.spirt.html&dark#func99)<br><sub><sup>(click&nbsp;for&nbsp;complete<br>pretty&nbsp;HTML&nbsp;example)</sup></sub>|![image](https://user-images.githubusercontent.com/77424/219394714-ebb74abf-337b-49ed-b10b-455eb1857b23.png)|

(because of the sheer length of those gray comment lines, I couldn't even put them side-by-side)

---

What I think is a clear win:
* shrinking text (instead of/alongside thinning and/or lowering opacity)
* the orange color to distinguish SPIR-V from "SPIR-T native" (typically blue)
  * (only as I was writing this, did I remember that orange/blue are supposed to be nice complementary colors, heh)
* styling "namespacing" `.` instead of leaving it the default color
  * (much easier to "visually ignore" the `Foo` in `Foo.Bar` when the `.` isn't sticking out like a sore thumb)
* cleaning up bitflags e.g. `FunctionControl.(.Inline)` became just `FunctionControl.Inline`

What I'm less sure about:
* the new `spv.` everywhere - it's cute, but it might overstay its welcome
* should *all* `Op...` get an orange color? (e.g. attributes are still green right now)
  * (may be needed if considering not including the `spv.`)
  * alternatively, orange `spv.` means the `Op...` could take different colors (e.g. blue in types/consts), potentially
* all namespacing can be somewhat alleviated with a mix of HTML attributes (for text on hover) and even links (all SPIR-V instruction opcodes and enumerands could link to the SPIR-V spec)
  * that would allow `spv.OpVariable<spv.StorageClass.Function>` to become just `OpVariable<Function>`
* the smaller text is aligned to the baseline, which works well for a lot of punctuation, but not `<...>`
  * should angle brackets just be abolished? `(...)` could make sense in most situations

In the end, this PR introduces more textual verbosity, and that's _probably_ to be preferred, I just wish I already had an easy toggle for "verbosity levels" (e.g. using a tiny bit of JS to toggle CSS classes).