### PR TITLE
Allow embedding diagnostics into SPIR-T as attributes.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased] - ReleaseDate
 
 ### Added ⭐
+- [PR#22](https://github.com/EmbarkStudios/spirt/pull/22) added `Diag` and `Attr::Diagnostics`,
+  for embedding diagnostics (errors or warnings) in SPIR-T itself
 - [PR#18](https://github.com/EmbarkStudios/spirt/pull/18) added anchor-based alignment
   to multi-version pretty-printing output (the same definitions will be kept on
   the same lines in all columns, wherever possible, to improve readability)

--- a/src/spv/lift.rs
+++ b/src/spv/lift.rs
@@ -201,7 +201,7 @@ impl Visitor<'_> for NeedsIdsCollector<'_> {
     }
     fn visit_attr(&mut self, attr: &Attr) {
         match *attr {
-            Attr::SpvAnnotation { .. } | Attr::SpvBitflagsOperand(_) => {}
+            Attr::Diagnostics(_) | Attr::SpvAnnotation { .. } | Attr::SpvBitflagsOperand(_) => {}
             Attr::SpvDebugLine { file_path, .. } => {
                 self.debug_strings.insert(&self.cx[file_path.0]);
             }
@@ -1619,6 +1619,9 @@ impl Module {
 
             for attr in cx[attrs].attrs.iter() {
                 match attr {
+                    Attr::Diagnostics(_)
+                    | Attr::SpvDebugLine { .. }
+                    | Attr::SpvBitflagsOperand(_) => {}
                     Attr::SpvAnnotation(inst @ spv::Inst { opcode, .. }) => {
                         let target_id = result_id.expect(
                             "FIXME: it shouldn't be possible to attach \
@@ -1640,7 +1643,6 @@ impl Module {
                             decoration_insts.push(inst);
                         }
                     }
-                    Attr::SpvDebugLine { .. } | Attr::SpvBitflagsOperand(_) => {}
                 }
 
                 if let Some(import) = import {


### PR DESCRIPTION
This is an easy way to annotate the IR (anything that supports attributes) with diagnostics that would otherwise have a hard time being reported in a way that correlates with the definition they relate to (without a full-on diagnostic system).

Example from an WIP version of #24:
![image](https://user-images.githubusercontent.com/77424/233684908-283697c2-f367-4c84-b0be-be8b5fbf6016.png)