### PR TITLE
Update SPIRV-headers to latest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased] - ReleaseDate
 
 ### Changed 🛠
+- [PR#25](https://github.com/EmbarkStudios/spirt/pull/25) updated SPIRV-headers from 1.5.4 to 1.6.1
 - [PR#21](https://github.com/EmbarkStudios/spirt/pull/21) tweaked pretty-printing
   styles around de-emphasis (shrinking instead of thinning, for width savings),
   and SPIR-V ops/enums (via de-emphasized `spv.` prefix and distinct orange color)


### PR DESCRIPTION
I updated the SPIRV-headers to latest.
Since I'm adding mesh shader support to rust-gpu, this is required to make it work!