### PR TITLE
Add support for `EmitMeshTasksEXT` op

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased] - ReleaseDate
 
 ### Changed 🛠
+- [PR#26](https://github.com/EmbarkStudios/spirt/pull/26) adds support for `EmitMeshTasksEXT` op
 - [PR#25](https://github.com/EmbarkStudios/spirt/pull/25) updated SPIRV-headers from 1.5.4 to 1.6.1
 - [PR#21](https://github.com/EmbarkStudios/spirt/pull/21) tweaked pretty-printing
   styles around de-emphasis (shrinking instead of thinning, for width savings),

--- a/src/spv/spec.rs
+++ b/src/spv/spec.rs
@@ -655,9 +655,10 @@ impl Spec {
                     Some(InstructionCategory::Const)
                 } else if has_categorical_prefix("OpIgnore")
                     || has_categorical_prefix("OpTerminate")
+                    || inst.opname == "OpEmitMeshTasksEXT"
                 {
                     // HACK(eddyb) not category prefixes, but they help with
-                    // working around `Reserved` extensions with control-flow
+                    // working around `Reserved` A with control-flow
                     // instructions. False positives will be caught by the
                     // assert further down, if `category_from_class` differs.
                     Some(InstructionCategory::ControlFlow)


### PR DESCRIPTION
When using `EmitMeshTasksEXT` inside the task shader, there is an error while lowering to SPIRT because it does not detect `EmitMeshTasksEXT` as an op that terminates.
The reason is because its class is `Reserved` instead of `Control-Flow` inside the `spirv.core.grammar.json`.
So I added a simple workaround.