### PR TITLE
print: fix a couple bugs in the initial diagnostics PR.

### DIFF
--- a/src/print/mod.rs
+++ b/src/print/mod.rs
@@ -1799,7 +1799,7 @@ impl Print for Attr {
                             let bug_location_prefix = match level {
                                 DiagLevel::Bug(location) => {
                                     let location = location.to_string();
-                                    let location = match location.split_once("/src/") {
+                                    let location = match location.rsplit_once("/src/") {
                                         Some((_path_prefix, intra_src)) => intra_src,
                                         None => &location,
                                     };

--- a/src/print/mod.rs
+++ b/src/print/mod.rs
@@ -1825,27 +1825,31 @@ impl Print for Attr {
                             // HACK(eddyb) this would ideally use line comments,
                             // but adding the line prefix properly to everything
                             // is a bit of a pain without special `pretty` support.
-                            pretty::Node::InlineOrIndentedBlock(vec![pretty::Fragment::new([
-                                comment_style.clone().apply("/* ").into(),
-                                pretty::Styles {
-                                    thickness: Some(3),
+                            pretty::Fragment::new([
+                                comment_style.clone().apply("/*"),
+                                pretty::Node::BreakingOnlySpace,
+                                pretty::Node::InlineOrIndentedBlock(vec![pretty::Fragment::new([
+                                    pretty::Styles {
+                                        thickness: Some(3),
 
-                                    // HACK(eddyb) this allows larger "icons"
-                                    // without adding gaps via `line-height`.
-                                    subscript: true,
-                                    size: Some(2),
+                                        // HACK(eddyb) this allows larger "icons"
+                                        // without adding gaps via `line-height`.
+                                        subscript: true,
+                                        size: Some(2),
 
-                                    ..pretty::Styles::color(icon_color)
-                                }
-                                .apply(icon)
-                                .into(),
-                                " ".into(),
-                                bug_location_prefix,
-                                printed_message,
-                                comment_style.apply(" */").into(),
-                            ])])
+                                        ..pretty::Styles::color(icon_color)
+                                    }
+                                    .apply(icon)
+                                    .into(),
+                                    " ".into(),
+                                    bug_location_prefix,
+                                    printed_message,
+                                ])]),
+                                pretty::Node::BreakingOnlySpace,
+                                comment_style.apply("*/"),
+                            ])
                         })
-                        .intersperse(pretty::Node::ForceLineSeparation),
+                        .intersperse(pretty::Node::ForceLineSeparation.into()),
                 ),
             ),
 


### PR DESCRIPTION
* the first commit is the same fix as https://github.com/EmbarkStudios/rust-gpu/pull/1043
* the second commit fixes a layout issue (where multi-line `/* ... */` didn't indent at the right level)

Combined we have this example:
<sub>(the specific message is still a bit whacky but it's only a BUG)</sub>
|Before this PR|After this PR|
|-|-|
|![image](https://user-images.githubusercontent.com/77424/235386845-418f790c-52ec-455b-9630-c621729bc7ba.png)|![image](https://user-images.githubusercontent.com/77424/235386717-081ef62a-4baa-4420-944e-be9454ecae18.png)|
