### PR TITLE
Intern, as `DataInstForm`, the `kind` and `output_type` fields of `DataInstDef`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased] - ReleaseDate
 
 ### Changed 🛠
+- [PR#28](https://github.com/EmbarkStudios/spirt/pull/28) moved two `DataInstDef`
+  fields (`kind` and `output_type`) to `DataInstForm`, a new interned type
 - [PR#30](https://github.com/EmbarkStudios/spirt/pull/30) replaced the old `spv-lower-dump`
   example (which only dumped plaintext, not HTML) with a more useful `spv-lower-print` one
 

--- a/src/context.rs
+++ b/src/context.rs
@@ -900,6 +900,7 @@ interners! {
         crate::AttrSetDef,
         crate::TypeDef,
         crate::ConstDef,
+        crate::DataInstFormDef,
     }
 
     // FIXME(eddyb) consider a more uniform naming scheme than the combination
@@ -908,6 +909,7 @@ interners! {
     AttrSet default(crate::AttrSetDef::default()) => crate::AttrSetDef,
     Type => crate::TypeDef,
     Const => crate::ConstDef,
+    DataInstForm => crate::DataInstFormDef,
 }
 
 impl<I: sealed::Interned> InternInCx<I> for I::Def

--- a/src/func_at.rs
+++ b/src/func_at.rs
@@ -117,7 +117,7 @@ impl FuncAt<'_, Value> {
                 control_node,
                 output_idx,
             } => self.at(control_node).def().outputs[output_idx as usize].ty,
-            Value::DataInstOutput(inst) => self.at(inst).def().output_type.unwrap(),
+            Value::DataInstOutput(inst) => cx[self.at(inst).def().form].output_type.unwrap(),
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -870,15 +870,31 @@ pub use context::DataInst;
 pub struct DataInstDef {
     pub attrs: AttrSet,
 
-    pub kind: DataInstKind,
-
-    pub output_type: Option<Type>,
+    pub form: DataInstForm,
 
     // FIXME(eddyb) change the inline size of this to fit most instructions.
     pub inputs: SmallVec<[Value; 2]>,
 }
 
-#[derive(Clone, PartialEq, Eq)]
+/// Interned handle for a [`DataInstFormDef`](crate::DataInstFormDef)
+/// (a "form", or "template", for [`DataInstDef`](crate::DataInstDef)s).
+pub use context::DataInstForm;
+
+/// "Form" (or "template") definition for [`DataInstFormDef`]s, which includes
+/// most of their common *static* information (notably excluding `attrs`, as
+/// they vary more often due to handling diagnostics, debuginfo, refinement etc.).
+//
+// FIXME(eddyb) now that this is interned, try to find all the code that was
+// working around needing to borrow `DataInstKind`, just because it was owned
+// by a `FuncDefBody` (instead of interned in the `Context`).
+#[derive(Clone, PartialEq, Eq, Hash)]
+pub struct DataInstFormDef {
+    pub kind: DataInstKind,
+
+    pub output_type: Option<Type>,
+}
+
+#[derive(Clone, PartialEq, Eq, Hash)]
 pub enum DataInstKind {
     // FIXME(eddyb) try to split this into recursive and non-recursive calls,
     // to avoid needing special handling for recursion where it's impossible.

--- a/src/passes/link.rs
+++ b/src/passes/link.rs
@@ -1,8 +1,8 @@
 use crate::transform::{InnerTransform, Transformed, Transformer};
 use crate::visit::{InnerVisit, Visitor};
 use crate::{
-    AttrSet, Const, Context, DeclDef, ExportKey, Exportee, Func, FxIndexSet, GlobalVar, Import,
-    Module, Type,
+    AttrSet, Const, Context, DataInstForm, DeclDef, ExportKey, Exportee, Func, FxIndexSet,
+    GlobalVar, Import, Module, Type,
 };
 use rustc_hash::{FxHashMap, FxHashSet};
 use std::collections::VecDeque;
@@ -33,6 +33,7 @@ pub fn minimize_exports(module: &mut Module, is_root: impl Fn(&ExportKey) -> boo
 
         seen_types: FxHashSet::default(),
         seen_consts: FxHashSet::default(),
+        seen_data_inst_forms: FxHashSet::default(),
         seen_global_vars: FxHashSet::default(),
         seen_funcs: FxHashSet::default(),
     };
@@ -60,13 +61,16 @@ struct LiveExportCollector<'a> {
     // FIXME(eddyb) build some automation to avoid ever repeating these.
     seen_types: FxHashSet<Type>,
     seen_consts: FxHashSet<Const>,
+    seen_data_inst_forms: FxHashSet<DataInstForm>,
     seen_global_vars: FxHashSet<GlobalVar>,
     seen_funcs: FxHashSet<Func>,
 }
 
 impl Visitor<'_> for LiveExportCollector<'_> {
     // FIXME(eddyb) build some automation to avoid ever repeating these.
-    fn visit_attr_set_use(&mut self, _attrs: AttrSet) {}
+    fn visit_attr_set_use(&mut self, _attrs: AttrSet) {
+        // FIXME(eddyb) if `AttrSet`s are ignored, why not `Type`s too?
+    }
     fn visit_type_use(&mut self, ty: Type) {
         if self.seen_types.insert(ty) {
             self.visit_type_def(&self.cx[ty]);
@@ -75,6 +79,11 @@ impl Visitor<'_> for LiveExportCollector<'_> {
     fn visit_const_use(&mut self, ct: Const) {
         if self.seen_consts.insert(ct) {
             self.visit_const_def(&self.cx[ct]);
+        }
+    }
+    fn visit_data_inst_form_use(&mut self, data_inst_form: DataInstForm) {
+        if self.seen_data_inst_forms.insert(data_inst_form) {
+            self.visit_data_inst_form_def(&self.cx[data_inst_form]);
         }
     }
 
@@ -119,6 +128,7 @@ pub fn resolve_imports(module: &mut Module) {
 
             seen_types: FxHashSet::default(),
             seen_consts: FxHashSet::default(),
+            seen_data_inst_forms: FxHashSet::default(),
             seen_global_vars: FxHashSet::default(),
             seen_funcs: FxHashSet::default(),
         };
@@ -134,6 +144,7 @@ pub fn resolve_imports(module: &mut Module) {
 
         transformed_types: FxHashMap::default(),
         transformed_consts: FxHashMap::default(),
+        transformed_data_inst_forms: FxHashMap::default(),
         transformed_global_vars: FxHashMap::default(),
         global_var_queue: VecDeque::new(),
         transformed_funcs: FxHashMap::default(),
@@ -170,13 +181,16 @@ struct ImportResolutionCollector<'a> {
     // FIXME(eddyb) build some automation to avoid ever repeating these.
     seen_types: FxHashSet<Type>,
     seen_consts: FxHashSet<Const>,
+    seen_data_inst_forms: FxHashSet<DataInstForm>,
     seen_global_vars: FxHashSet<GlobalVar>,
     seen_funcs: FxHashSet<Func>,
 }
 
 impl Visitor<'_> for ImportResolutionCollector<'_> {
     // FIXME(eddyb) build some automation to avoid ever repeating these.
-    fn visit_attr_set_use(&mut self, _attrs: AttrSet) {}
+    fn visit_attr_set_use(&mut self, _attrs: AttrSet) {
+        // FIXME(eddyb) if `AttrSet`s are ignored, why not `Type`s too?
+    }
     fn visit_type_use(&mut self, ty: Type) {
         if self.seen_types.insert(ty) {
             self.visit_type_def(&self.cx[ty]);
@@ -185,6 +199,11 @@ impl Visitor<'_> for ImportResolutionCollector<'_> {
     fn visit_const_use(&mut self, ct: Const) {
         if self.seen_consts.insert(ct) {
             self.visit_const_def(&self.cx[ct]);
+        }
+    }
+    fn visit_data_inst_form_use(&mut self, data_inst_form: DataInstForm) {
+        if self.seen_data_inst_forms.insert(data_inst_form) {
+            self.visit_data_inst_form_def(&self.cx[data_inst_form]);
         }
     }
 
@@ -233,6 +252,7 @@ struct ImportResolver<'a> {
     // FIXME(eddyb) build some automation to avoid ever repeating these.
     transformed_types: FxHashMap<Type, Transformed<Type>>,
     transformed_consts: FxHashMap<Const, Transformed<Const>>,
+    transformed_data_inst_forms: FxHashMap<DataInstForm, Transformed<DataInstForm>>,
     transformed_global_vars: FxHashMap<GlobalVar, Transformed<GlobalVar>>,
     global_var_queue: VecDeque<GlobalVar>,
     transformed_funcs: FxHashMap<Func, Transformed<Func>>,
@@ -259,6 +279,20 @@ impl Transformer for ImportResolver<'_> {
             .transform_const_def(&self.cx[ct])
             .map(|ct_def| self.cx.intern(ct_def));
         self.transformed_consts.insert(ct, transformed);
+        transformed
+    }
+    fn transform_data_inst_form_use(
+        &mut self,
+        data_inst_form: DataInstForm,
+    ) -> Transformed<DataInstForm> {
+        if let Some(&cached) = self.transformed_data_inst_forms.get(&data_inst_form) {
+            return cached;
+        }
+        let transformed = self
+            .transform_data_inst_form_def(&self.cx[data_inst_form])
+            .map(|data_inst_form_def| self.cx.intern(data_inst_form_def));
+        self.transformed_data_inst_forms
+            .insert(data_inst_form, transformed);
         transformed
     }
 

--- a/src/qptr/mod.rs
+++ b/src/qptr/mod.rs
@@ -149,7 +149,7 @@ pub enum QPtrMemUsageKind {
 }
 
 /// `QPtr`-specific operations ([`DataInstKind::QPtr`]).
-#[derive(Clone, PartialEq, Eq)]
+#[derive(Clone, PartialEq, Eq, Hash)]
 pub enum QPtrOp {
     // HACK(eddyb) `OpVariable` replacement, which itself should not be kept as
     // a `SpvInst` - once fn-local variables are lowered, this should go there.

--- a/src/qptr/shapes.rs
+++ b/src/qptr/shapes.rs
@@ -88,7 +88,7 @@ pub enum Handle<BL = MaybeDynMemLayout> {
 /// Only `align` is *required*, that is `size % align == 0` must be always enforced.
 //
 // FIXME(eddyb) consider supporting specialization-constant-length arrays.
-#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
 pub struct MemLayout {
     // FIXME(eddyb) use proper newtypes (and log2 for align!).
     pub align: u32,

--- a/src/spv/mod.rs
+++ b/src/spv/mod.rs
@@ -58,6 +58,8 @@ pub struct Inst {
     // FIXME(eddyb) change the inline size of this to fit most instructions.
     // FIXME(eddyb) it might be worth investigating the performance implications
     // of interning "long immediates", compared to the flattened representation.
+    // NOTE(eddyb) interning these separately is likely unnecessary in many cases,
+    // now that `DataInstForm`s are interned, and `Const`s etc. were already.
     pub imms: SmallVec<[Imm; 2]>,
 }
 

--- a/src/transform.rs
+++ b/src/transform.rs
@@ -5,10 +5,10 @@ use crate::qptr::{self, QPtrAttr, QPtrMemUsage, QPtrMemUsageKind, QPtrOp, QPtrUs
 use crate::{
     cfg, spv, AddrSpace, Attr, AttrSet, AttrSetDef, Const, ConstCtor, ConstDef, ControlNode,
     ControlNodeDef, ControlNodeKind, ControlNodeOutputDecl, ControlRegion, ControlRegionDef,
-    ControlRegionInputDecl, DataInst, DataInstDef, DataInstKind, DeclDef, EntityListIter,
-    ExportKey, Exportee, Func, FuncDecl, FuncDefBody, FuncParam, GlobalVar, GlobalVarDecl,
-    GlobalVarDefBody, Import, Module, ModuleDebugInfo, ModuleDialect, OrdAssertEq, SelectionKind,
-    Type, TypeCtor, TypeCtorArg, TypeDef, Value,
+    ControlRegionInputDecl, DataInst, DataInstDef, DataInstForm, DataInstFormDef, DataInstKind,
+    DeclDef, EntityListIter, ExportKey, Exportee, Func, FuncDecl, FuncDefBody, FuncParam,
+    GlobalVar, GlobalVarDecl, GlobalVarDefBody, Import, Module, ModuleDebugInfo, ModuleDialect,
+    OrdAssertEq, SelectionKind, Type, TypeCtor, TypeCtorArg, TypeDef, Value,
 };
 use std::cmp::Ordering;
 use std::rc::Rc;
@@ -145,6 +145,12 @@ pub trait Transformer: Sized {
     fn transform_const_use(&mut self, _ct: Const) -> Transformed<Const> {
         Transformed::Unchanged
     }
+    fn transform_data_inst_form_use(
+        &mut self,
+        _data_inst_form: DataInstForm,
+    ) -> Transformed<DataInstForm> {
+        Transformed::Unchanged
+    }
 
     // Module-stored entity leaves (noop default behavior).
     fn transform_global_var_use(&mut self, _gv: GlobalVar) -> Transformed<GlobalVar> {
@@ -171,6 +177,12 @@ pub trait Transformer: Sized {
     }
     fn transform_const_def(&mut self, ct_def: &ConstDef) -> Transformed<ConstDef> {
         ct_def.inner_transform_with(self)
+    }
+    fn transform_data_inst_form_def(
+        &mut self,
+        data_inst_form_def: &DataInstFormDef,
+    ) -> Transformed<DataInstFormDef> {
+        data_inst_form_def.inner_transform_with(self)
     }
     fn transform_value_use(&mut self, v: &Value) -> Transformed<Value> {
         v.inner_transform_with(self)
@@ -740,32 +752,47 @@ impl InnerInPlaceTransform for FuncAtMut<'_, DataInst> {
     fn inner_in_place_transform_with(&mut self, transformer: &mut impl Transformer) {
         let DataInstDef {
             attrs,
-            kind,
-            output_type,
+            form,
             inputs,
         } = self.reborrow().def();
 
         transformer.transform_attr_set_use(*attrs).apply_to(attrs);
-        match kind {
-            DataInstKind::FuncCall(func) => transformer.transform_func_use(*func).apply_to(func),
-            DataInstKind::QPtr(op) => match op {
-                QPtrOp::FuncLocalVar(_)
-                | QPtrOp::HandleArrayIndex
-                | QPtrOp::BufferData
-                | QPtrOp::BufferDynLen { .. }
-                | QPtrOp::Offset(_)
-                | QPtrOp::DynOffset { .. }
-                | QPtrOp::Load
-                | QPtrOp::Store => {}
-            },
-            DataInstKind::SpvInst(_) | DataInstKind::SpvExtInst { .. } => {}
-        }
-        if let Some(ty) = output_type {
-            transformer.transform_type_use(*ty).apply_to(ty);
-        }
+        transformer
+            .transform_data_inst_form_use(*form)
+            .apply_to(form);
         for v in inputs {
             transformer.transform_value_use(v).apply_to(v);
         }
+    }
+}
+
+impl InnerTransform for DataInstFormDef {
+    fn inner_transform_with(&self, transformer: &mut impl Transformer) -> Transformed<Self> {
+        let Self { kind, output_type } = self;
+
+        transform!({
+            kind -> match kind {
+                DataInstKind::FuncCall(func) => transformer.transform_func_use(*func).map(DataInstKind::FuncCall),
+                DataInstKind::QPtr(op) => match op {
+                    QPtrOp::FuncLocalVar(_)
+                    | QPtrOp::HandleArrayIndex
+                    | QPtrOp::BufferData
+                    | QPtrOp::BufferDynLen { .. }
+                    | QPtrOp::Offset(_)
+                    | QPtrOp::DynOffset { .. }
+                    | QPtrOp::Load
+                    | QPtrOp::Store => Transformed::Unchanged,
+                },
+                DataInstKind::SpvInst(_) | DataInstKind::SpvExtInst { .. } => Transformed::Unchanged,
+            },
+            // FIXME(eddyb) this should be replaced with an impl of `InnerTransform`
+            // for `Option<T>` or some other helper, to avoid "manual transpose".
+            output_type -> output_type.map(|ty| transformer.transform_type_use(ty))
+                .map_or(Transformed::Unchanged, |t| t.map(Some)),
+        } => Self {
+            kind,
+            output_type,
+        })
     }
 }
 


### PR DESCRIPTION
This should, in theory, allow reusing one `DataInst` "form" (or "template") for many `DataInst`s, with only runtime inputs (and/or attributes) differing between their "instances".

While there is no good reason to have the extra indirection today (and the performance impact seems to fall within noise), there is a refactor I want to try (which would require multiple outputs per `DataInst`, and that would add to the growing size of `DataInstDef`, before this interning change).

~~Will keep this PR as draft until I can confirm that refactor is successful.~~