### PR TITLE
[WIP] disaggregate by-value `OpTypeStruct`/`OpTypeArray` inputs/outputs.

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ fn main() -> @location(0) i32 {
 ```cxx
 #[spv.Decoration.Flat]
 #[spv.Decoration.Location(Location: 0)]
-global_var GV0 in spv.StorageClass.Output: s32
+global_var GV0(spv.StorageClass.Output): s32
 
 func F0() {
   loop(v0: s32 <- 1s32, v1: s32 <- 1s32) {

--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ func F0() -> spv.OpTypeVoid {
       v6 = spv.OpIAdd(v1, 1s32): s32
       (v5, v6)
     } else {
-      (spv.OpUndef: s32, spv.OpUndef: s32)
+      (undef: s32, undef: s32)
     }
     (v3, v4) -> (v0, v1)
   } while v2

--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ fn main() -> @location(0) i32 {
 #[spv.Decoration.Location(Location: 0)]
 global_var GV0 in spv.StorageClass.Output: s32
 
-func F0() -> spv.OpTypeVoid {
+func F0() {
   loop(v0: s32 <- 1s32, v1: s32 <- 1s32) {
     v2 = s.lt(v1, 10s32): bool
     (v3: s32, v4: s32) = if v2 {

--- a/README.md
+++ b/README.md
@@ -139,10 +139,10 @@ global_var GV0 in spv.StorageClass.Output: s32
 
 func F0() -> spv.OpTypeVoid {
   loop(v0: s32 <- 1s32, v1: s32 <- 1s32) {
-    v2 = spv.OpSLessThan(v1, 10s32): bool
+    v2 = s.lt(v1, 10s32): bool
     (v3: s32, v4: s32) = if v2 {
-      v5 = spv.OpIMul(v0, v1): s32
-      v6 = spv.OpIAdd(v1, 1s32): s32
+      v5 = i.mul(v0, v1): s32
+      v6 = i.add(v1, 1s32): s32
       (v5, v6)
     } else {
       (undef: s32, undef: s32)

--- a/src/cfg.rs
+++ b/src/cfg.rs
@@ -51,7 +51,8 @@ pub enum ControlInstKind {
     /// necessary preconditions for reaching this point, are never met.
     Unreachable,
 
-    /// Leave the current function, optionally returning a value.
+    /// Leave the current function, returning some number of [`Value`]s, as per
+    /// the function's signature (`ret_types` in [`FuncDecl`](crate::FuncDecl)).
     Return,
 
     /// Leave the current invocation, similar to returning from every function

--- a/src/cfg.rs
+++ b/src/cfg.rs
@@ -1568,14 +1568,6 @@ impl<'a> Structurizer<'a> {
     /// Create an undefined constant (as a placeholder where a value needs to be
     /// present, but won't actually be used), of type `ty`.
     fn const_undef(&self, ty: Type) -> Const {
-        // FIXME(eddyb) SPIR-T should have native undef itself.
-        let wk = &spv::spec::Spec::get().well_known;
-        self.cx.intern(ConstDef {
-            attrs: AttrSet::default(),
-            ty,
-            kind: ConstKind::SpvInst {
-                spv_inst_and_const_inputs: Rc::new((wk.OpUndef.into(), [].into_iter().collect())),
-            },
-        })
+        self.cx.intern(ConstDef { attrs: AttrSet::default(), ty, kind: ConstKind::Undef })
     }
 }

--- a/src/func_at.rs
+++ b/src/func_at.rs
@@ -116,7 +116,9 @@ impl FuncAt<'_, Value> {
             Value::ControlNodeOutput { control_node, output_idx } => {
                 self.at(control_node).def().outputs[output_idx as usize].ty
             }
-            Value::DataInstOutput(inst) => cx[self.at(inst).def().form].output_type.unwrap(),
+            Value::DataInstOutput { inst, output_idx } => {
+                cx[self.at(inst).def().form].output_types[output_idx as usize]
+            }
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -987,6 +987,12 @@ pub enum DataInstKind {
     #[from]
     Scalar(scalar::Op),
 
+    /// Vector (small array of [`scalar`]s) pure operations.
+    ///
+    /// See also the [`vector`] module for more documentation and definitions.
+    #[from]
+    Vector(vector::Op),
+
     // FIXME(eddyb) try to split this into recursive and non-recursive calls,
     // to avoid needing special handling for recursion where it's impossible.
     FuncCall(Func),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -938,6 +938,12 @@ pub struct DataInstFormDef {
 
 #[derive(Clone, PartialEq, Eq, Hash, derive_more::From)]
 pub enum DataInstKind {
+    /// Scalar (`bool`, integer, and floating-point) pure operations.
+    ///
+    /// See also the [`scalar`] module for more documentation and definitions.
+    #[from]
+    Scalar(scalar::Op),
+
     // FIXME(eddyb) try to split this into recursive and non-recursive calls,
     // to avoid needing special handling for recursion where it's impossible.
     FuncCall(Func),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -168,6 +168,7 @@ pub mod passes {
     pub mod qptr;
 }
 pub mod qptr;
+pub mod scalar;
 pub mod spv;
 
 use smallvec::SmallVec;
@@ -453,16 +454,23 @@ impl<T: Eq> Ord for OrdAssertEq<T> {
 pub use context::Type;
 
 /// Definition for a [`Type`].
-//
-// FIXME(eddyb) maybe special-case some basic types like integers.
 #[derive(PartialEq, Eq, Hash)]
 pub struct TypeDef {
     pub attrs: AttrSet,
     pub kind: TypeKind,
 }
 
-#[derive(Clone, PartialEq, Eq, Hash)]
+#[derive(Clone, PartialEq, Eq, Hash, derive_more::From)]
 pub enum TypeKind {
+    /// Scalar (`bool`, integer, and floating-point) type, with limitations
+    /// on the supported bit-widths (power-of-two multiples of a byte).
+    ///
+    /// **Note**: pointers are never scalars (like SPIR-V, but unlike other IRs).
+    ///
+    /// See also the [`scalar`] module for more documentation and definitions.
+    #[from]
+    Scalar(scalar::Type),
+
     /// "Quasi-pointer", an untyped pointer-like abstract scalar that can represent
     /// both memory locations (in any address space) and other kinds of locations
     /// (e.g. SPIR-V `OpVariable`s in non-memory "storage classes").
@@ -490,12 +498,18 @@ pub enum TypeKind {
     SpvStringLiteralForExtInst,
 }
 
-// HACK(eddyb) this behaves like an implicit conversion for `cx.intern(...)`.
-impl context::InternInCx<Type> for TypeKind {
-    fn intern_in_cx(self, cx: &Context) -> Type {
-        cx.intern(TypeDef { attrs: Default::default(), kind: self })
+// HACK(eddyb) this behaves like an implicit conversion for `cx.intern(...)`,
+// and the macro is only used because coherence bans `impl<T: Into<TypeKind>>`.
+macro_rules! impl_intern_type_kind {
+    ($($kind:ty),+ $(,)?) => {
+        $(impl context::InternInCx<Type> for $kind {
+            fn intern_in_cx(self, cx: &Context) -> Type {
+                cx.intern(TypeDef { attrs: Default::default(), kind: self.into() })
+            }
+        })+
     }
 }
+impl_intern_type_kind!(TypeKind, scalar::Type);
 
 // HACK(eddyb) this is like `Either<Type, Const>`, only used in `TypeKind::SpvInst`,
 // and only because SPIR-V type definitions can references both types and consts.
@@ -503,6 +517,16 @@ impl context::InternInCx<Type> for TypeKind {
 pub enum TypeOrConst {
     Type(Type),
     Const(Const),
+}
+
+// HACK(eddyb) on `Type` instead of `TypeDef` for ergonomics reasons.
+impl Type {
+    pub fn as_scalar(self, cx: &Context) -> Option<scalar::Type> {
+        match cx[self].kind {
+            TypeKind::Scalar(ty) => Some(ty),
+            _ => None,
+        }
+    }
 }
 
 /// Interned handle for a [`ConstDef`](crate::ConstDef) (a constant value).
@@ -518,13 +542,25 @@ pub struct ConstDef {
     pub kind: ConstKind,
 }
 
-#[derive(Clone, PartialEq, Eq, Hash)]
+#[derive(Clone, PartialEq, Eq, Hash, derive_more::From)]
 pub enum ConstKind {
     /// Undeterminate value (i.e. SPIR-V `OpUndef`, LLVM `undef`).
     //
     // FIXME(eddyb) could it be possible to adopt LLVM's newer `poison`+`freeze`
     // model, without being forced to never lift back to `OpUndef`?
     Undef,
+
+    /// Scalar (`bool`, integer, and floating-point) constant, which must have
+    /// a type of [`TypeKind::Scalar`] (of the same [`scalar::Type`]).
+    ///
+    /// See also the [`scalar`] module for more documentation and definitions.
+    //
+    // FIXME(eddyb) maybe document the 128-bit limitation?.
+    // FIXME(eddyb) this technically makes the `scalar::Type` redundant, could
+    // it get out of sync? (perhaps "forced canonicalization" could be used to
+    // enforce that interning simply doesn't allow such scenarios?).
+    #[from]
+    Scalar(scalar::Const),
 
     PtrToGlobalVar(GlobalVar),
 
@@ -538,6 +574,34 @@ pub enum ConstKind {
     /// which can't have literals itself - for non-string literals `OpConstant*`
     /// are readily usable, but only `OpString` is supported for string literals.
     SpvStringLiteralForExtInst(InternedStr),
+}
+
+// HACK(eddyb) this behaves like an implicit conversion for `cx.intern(...)`,
+// like the `TypeKind` one, but this one is even weirder because it also interns
+// the inherent type of the constant, as a `Type` (with empty attributes).
+macro_rules! impl_intern_const_kind {
+    ($($kind:ty),+ $(,)?) => {
+        $(impl context::InternInCx<Const> for $kind {
+            fn intern_in_cx(self, cx: &Context) -> Const {
+                cx.intern(ConstDef {
+                    attrs: Default::default(),
+                    ty: cx.intern(self.ty()),
+                    kind: self.into(),
+                })
+            }
+        })+
+    }
+}
+impl_intern_const_kind!(scalar::Const);
+
+// HACK(eddyb) on `Const` instead of `ConstDef` for ergonomics reasons.
+impl Const {
+    pub fn as_scalar(self, cx: &Context) -> Option<&scalar::Const> {
+        match &cx[self].kind {
+            ConstKind::Scalar(ct) => Some(ct),
+            _ => None,
+        }
+    }
 }
 
 /// Declarations ([`GlobalVarDecl`], [`FuncDecl`]) can contain a full definition,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -520,6 +520,12 @@ pub struct ConstDef {
 
 #[derive(Clone, PartialEq, Eq, Hash)]
 pub enum ConstKind {
+    /// Undeterminate value (i.e. SPIR-V `OpUndef`, LLVM `undef`).
+    //
+    // FIXME(eddyb) could it be possible to adopt LLVM's newer `poison`+`freeze`
+    // model, without being forced to never lift back to `OpUndef`?
+    Undef,
+
     PtrToGlobalVar(GlobalVar),
 
     // HACK(eddyb) this is a fallback case that should become increasingly rare

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -895,13 +895,24 @@ pub enum ControlNodeKind {
     },
 }
 
+// FIXME(eddyb) consider interning this, perhaps in a similar vein to `DataInstForm`.
 #[derive(Clone)]
 pub enum SelectionKind {
     /// Two-case selection based on boolean condition, i.e. `if`-`else`, with
     /// the two cases being "then" and "else" (in that order).
     BoolCond,
 
-    SpvInst(spv::Inst),
+    /// `N+1`-case selection based on comparing an integer scrutinee against
+    /// `N` constants, i.e. `switch`, with the last case being the "default"
+    /// (making it the only case without a matching entry in `case_consts`).
+    Switch {
+        // FIXME(eddyb) avoid some of the `scalar::Const` overhead here, as there
+        // is only a single type and we shouldn't need to store more bits per case,
+        // than the actual width of the integer type.
+        // FIXME(eddyb) consider storing this more like sorted compressed keyset,
+        // as there can be no duplicates, and in many cases it may be contiguous.
+        case_consts: Vec<scalar::Const>,
+    },
 }
 
 /// Entity handle for a [`DataInstDef`](crate::DataInstDef) (an SSA instruction).

--- a/src/print/mod.rs
+++ b/src/print/mod.rs
@@ -24,7 +24,7 @@ use crate::print::multiversion::Versions;
 use crate::qptr::{self, QPtrAttr, QPtrMemUsage, QPtrMemUsageKind, QPtrOp, QPtrUsage};
 use crate::visit::{InnerVisit, Visit, Visitor};
 use crate::{
-    cfg, spv, AddrSpace, Attr, AttrSet, AttrSetDef, Const, ConstDef, ConstKind, Context,
+    cfg, scalar, spv, AddrSpace, Attr, AttrSet, AttrSetDef, Const, ConstDef, ConstKind, Context,
     ControlNode, ControlNodeDef, ControlNodeKind, ControlNodeOutputDecl, ControlRegion,
     ControlRegionDef, ControlRegionInputDecl, DataInst, DataInstDef, DataInstForm, DataInstFormDef,
     DataInstKind, DeclDef, Diag, DiagLevel, DiagMsgPart, EntityListIter, ExportKey, Exportee, Func,
@@ -817,19 +817,13 @@ impl<'a> Printer<'a> {
                                     // here and `TypeDef`'s `Print` impl.
                                     let has_compact_print_or_is_leaf = match &ty_def.kind {
                                         TypeKind::SpvInst { spv_inst, type_and_const_inputs } => {
-                                            [
-                                                wk.OpTypeBool,
-                                                wk.OpTypeInt,
-                                                wk.OpTypeFloat,
-                                                wk.OpTypeVector,
-                                            ]
-                                            .contains(&spv_inst.opcode)
+                                            spv_inst.opcode == wk.OpTypeVector
                                                 || type_and_const_inputs.is_empty()
                                         }
 
-                                        TypeKind::QPtr | TypeKind::SpvStringLiteralForExtInst => {
-                                            true
-                                        }
+                                        TypeKind::Scalar(_)
+                                        | TypeKind::QPtr
+                                        | TypeKind::SpvStringLiteralForExtInst => true,
                                     };
 
                                     ty_def.attrs == AttrSet::default()
@@ -838,28 +832,16 @@ impl<'a> Printer<'a> {
                                 CxInterned::Const(ct) => {
                                     let ct_def = &cx[ct];
 
-                                    // FIXME(eddyb) remove the duplication between
-                                    // here and `ConstDef`'s `Print` impl.
-                                    let (has_compact_print, has_nested_consts) = match &ct_def.kind
-                                    {
+                                    let has_nested_consts = match &ct_def.kind {
                                         ConstKind::SpvInst { spv_inst_and_const_inputs } => {
-                                            let (spv_inst, const_inputs) =
+                                            let (_spv_inst, const_inputs) =
                                                 &**spv_inst_and_const_inputs;
-                                            (
-                                                [
-                                                    wk.OpConstantFalse,
-                                                    wk.OpConstantTrue,
-                                                    wk.OpConstant,
-                                                ]
-                                                .contains(&spv_inst.opcode),
-                                                !const_inputs.is_empty(),
-                                            )
+                                            !const_inputs.is_empty()
                                         }
-                                        _ => (false, false),
+                                        _ => false,
                                     };
 
-                                    ct_def.attrs == AttrSet::default()
-                                        && (has_compact_print || !has_nested_consts)
+                                    ct_def.attrs == AttrSet::default() && !has_nested_consts
                                 }
                             }
                     }
@@ -2380,30 +2362,13 @@ impl Print for TypeDef {
 
         // FIXME(eddyb) should this be done by lowering SPIR-V types to SPIR-T?
         let kw = |kw| printer.declarative_keyword_style().apply(kw).into();
+        #[allow(irrefutable_let_patterns)]
         let compact_def = if let &TypeKind::SpvInst {
             spv_inst: spv::Inst { opcode, ref imms },
             ref type_and_const_inputs,
         } = kind
         {
-            if opcode == wk.OpTypeBool {
-                Some(kw("bool".into()))
-            } else if opcode == wk.OpTypeInt {
-                let (width, signed) = match imms[..] {
-                    [spv::Imm::Short(_, width), spv::Imm::Short(_, signedness)] => {
-                        (width, signedness != 0)
-                    }
-                    _ => unreachable!(),
-                };
-
-                Some(if signed { kw(format!("s{width}")) } else { kw(format!("u{width}")) })
-            } else if opcode == wk.OpTypeFloat {
-                let width = match imms[..] {
-                    [spv::Imm::Short(_, width)] => width,
-                    _ => unreachable!(),
-                };
-
-                Some(kw(format!("f{width}")))
-            } else if opcode == wk.OpTypeVector {
+            if opcode == wk.OpTypeVector {
                 let (elem_ty, elem_count) = match (&imms[..], &type_and_const_inputs[..]) {
                     (&[spv::Imm::Short(_, elem_count)], &[TypeOrConst::Type(elem_ty)]) => {
                         (elem_ty, elem_count)
@@ -2429,6 +2394,16 @@ impl Print for TypeDef {
                 def
             } else {
                 match kind {
+                    TypeKind::Scalar(ty) => {
+                        let width = ty.bit_width();
+                        kw(match ty {
+                            scalar::Type::Bool => "bool".into(),
+                            scalar::Type::SInt(_) => format!("s{width}"),
+                            scalar::Type::UInt(_) => format!("u{width}"),
+                            scalar::Type::Float(_) => format!("f{width}"),
+                        })
+                    }
+
                     // FIXME(eddyb) should this be shortened to `qtr`?
                     TypeKind::QPtr => printer.declarative_keyword_style().apply("qptr").into(),
 
@@ -2462,71 +2437,22 @@ impl Print for ConstDef {
         let wk = &spv::spec::Spec::get().well_known;
 
         let kw = |kw| printer.declarative_keyword_style().apply(kw).into();
-        let literal_ty_suffix = |ty| {
-            pretty::Styles {
-                // HACK(eddyb) the exact type detracts from the value.
-                color_opacity: Some(0.4),
-                subscript: true,
-                ..printer.declarative_keyword_style()
-            }
-            .apply(ty)
-        };
-        let compact_def = if let ConstKind::SpvInst { spv_inst_and_const_inputs } = kind {
-            let (spv_inst, _const_inputs) = &**spv_inst_and_const_inputs;
-            let &spv::Inst { opcode, ref imms } = spv_inst;
 
-            if opcode == wk.OpConstantFalse {
-                Some(kw("false"))
-            } else if opcode == wk.OpConstantTrue {
-                Some(kw("true"))
-            } else if opcode == wk.OpConstant {
-                // HACK(eddyb) it's simpler to only handle a limited subset of
-                // integer/float bit-widths, for now.
-                let raw_bits = match imms[..] {
-                    [spv::Imm::Short(_, x)] => Some(u64::from(x)),
-                    [spv::Imm::LongStart(_, lo), spv::Imm::LongCont(_, hi)] => {
-                        Some(u64::from(lo) | (u64::from(hi) << 32))
-                    }
-                    _ => None,
-                };
-
-                if let (
-                    Some(raw_bits),
-                    &TypeKind::SpvInst {
-                        spv_inst: spv::Inst { opcode: ty_opcode, imms: ref ty_imms },
-                        ..
-                    },
-                ) = (raw_bits, &printer.cx[*ty].kind)
-                {
-                    if ty_opcode == wk.OpTypeInt {
-                        let (width, signed) = match ty_imms[..] {
-                            [spv::Imm::Short(_, width), spv::Imm::Short(_, signedness)] => {
-                                (width, signedness != 0)
-                            }
-                            _ => unreachable!(),
-                        };
-
-                        if width <= 64 {
-                            let (printed_value, ty) = if signed {
-                                let sext_raw_bits =
-                                    (raw_bits as u128 as i128) << (128 - width) >> (128 - width);
-                                (format!("{sext_raw_bits}"), format!("s{width}"))
-                            } else {
-                                (format!("{raw_bits}"), format!("u{width}"))
-                            };
-                            Some(pretty::Fragment::new([
-                                printer.numeric_literal_style().apply(printed_value),
-                                literal_ty_suffix(ty),
-                            ]))
-                        } else {
-                            None
-                        }
-                    } else if ty_opcode == wk.OpTypeFloat {
-                        let width = match ty_imms[..] {
-                            [spv::Imm::Short(_, width)] => width,
-                            _ => unreachable!(),
-                        };
-
+        let def_without_name = match kind {
+            ConstKind::Undef => pretty::Fragment::new([
+                printer.imperative_keyword_style().apply("undef").into(),
+                printer.pretty_type_ascription_suffix(*ty),
+            ]),
+            ConstKind::Scalar(scalar::Const::FALSE) => kw("false"),
+            ConstKind::Scalar(scalar::Const::TRUE) => kw("true"),
+            ConstKind::Scalar(ct) => {
+                let ty = ct.ty();
+                let width = ty.bit_width();
+                let (maybe_printed_value, ty_prefix) = match ty {
+                    scalar::Type::Bool => unreachable!(),
+                    scalar::Type::SInt(_) => (ct.int_as_i128().map(|x| x.to_string()), 's'),
+                    scalar::Type::UInt(_) => (ct.int_as_u128().map(|x| x.to_string()), 'u'),
+                    scalar::Type::Float(_) => {
                         /// Check that parsing the result of printing produces
                         /// the original bits of the floating-point value, and
                         /// only return `Some` if that is the case.
@@ -2546,69 +2472,81 @@ impl Print for ConstDef {
                             })
                         }
 
-                        let printed_value = match width {
-                            32 => bitwise_roundtrip_float_print(
-                                raw_bits as u32,
-                                f32::from_bits,
-                                f32::to_bits,
-                            ),
-                            64 => bitwise_roundtrip_float_print(
-                                raw_bits,
-                                f64::from_bits,
-                                f64::to_bits,
-                            ),
-                            _ => None,
-                        };
-                        printed_value.map(|s| {
-                            pretty::Fragment::new([
-                                printer.numeric_literal_style().apply(s),
-                                literal_ty_suffix(format!("f{width}")),
-                            ])
-                        })
-                    } else {
-                        None
+                        (
+                            match width {
+                                32 => bitwise_roundtrip_float_print(
+                                    ct.bits() as u32,
+                                    f32::from_bits,
+                                    f32::to_bits,
+                                ),
+                                64 => bitwise_roundtrip_float_print(
+                                    ct.bits() as u64,
+                                    f64::from_bits,
+                                    f64::to_bits,
+                                ),
+                                _ => None,
+                            },
+                            'f',
+                        )
                     }
-                } else {
-                    None
-                }
-            } else {
-                None
-            }
-        } else {
-            None
-        };
-
-        AttrsAndDef {
-            attrs: attrs.print(printer),
-            def_without_name: compact_def.unwrap_or_else(|| match kind {
-                ConstKind::Undef => pretty::Fragment::new([
-                    printer.imperative_keyword_style().apply("undef").into(),
-                    printer.pretty_type_ascription_suffix(*ty),
-                ]),
-                &ConstKind::PtrToGlobalVar(gv) => {
-                    pretty::Fragment::new(["&".into(), gv.print(printer)])
-                }
-
-                ConstKind::SpvInst { spv_inst_and_const_inputs } => {
-                    let (spv_inst, const_inputs) = &**spv_inst_and_const_inputs;
-                    pretty::Fragment::new([
-                        printer.pretty_spv_inst(
-                            printer.spv_op_style(),
-                            spv_inst.opcode,
-                            &spv_inst.imms,
-                            const_inputs.iter().map(|ct| ct.print(printer)),
+                };
+                match maybe_printed_value {
+                    Some(printed_value) => {
+                        let literal_ty_suffix = pretty::Styles {
+                            // HACK(eddyb) the exact type detracts from the value.
+                            color_opacity: Some(0.4),
+                            subscript: true,
+                            ..printer.declarative_keyword_style()
+                        }
+                        .apply(format!("{ty_prefix}{width}"));
+                        pretty::Fragment::new([
+                            printer.numeric_literal_style().apply(printed_value),
+                            literal_ty_suffix,
+                        ])
+                    }
+                    // HACK(eddyb) fallback using the bitwise representation.
+                    None => pretty::Fragment::new([
+                        printer
+                            .demote_style_for_namespace_prefix(printer.declarative_keyword_style())
+                            .apply(format!("{ty_prefix}{width}."))
+                            .into(),
+                        printer.declarative_keyword_style().apply("from_bits").into(),
+                        pretty::join_comma_sep(
+                            "(",
+                            [
+                                // FIXME(eddyb) consider padding this with enough
+                                // leading zeroes for its respective width.
+                                printer.numeric_literal_style().apply(format!("0x{:x}", ct.bits())),
+                            ],
+                            ")",
                         ),
-                        printer.pretty_type_ascription_suffix(*ty),
-                    ])
+                    ]),
                 }
-                &ConstKind::SpvStringLiteralForExtInst(s) => pretty::Fragment::new([
-                    printer.pretty_spv_opcode(printer.spv_op_style(), wk.OpString),
-                    "(".into(),
-                    printer.pretty_string_literal(&printer.cx[s]),
-                    ")".into(),
-                ]),
-            }),
-        }
+            }
+            &ConstKind::PtrToGlobalVar(gv) => {
+                pretty::Fragment::new(["&".into(), gv.print(printer)])
+            }
+
+            ConstKind::SpvInst { spv_inst_and_const_inputs } => {
+                let (spv_inst, const_inputs) = &**spv_inst_and_const_inputs;
+                pretty::Fragment::new([
+                    printer.pretty_spv_inst(
+                        printer.spv_op_style(),
+                        spv_inst.opcode,
+                        &spv_inst.imms,
+                        const_inputs.iter().map(|ct| ct.print(printer)),
+                    ),
+                    printer.pretty_type_ascription_suffix(*ty),
+                ])
+            }
+            &ConstKind::SpvStringLiteralForExtInst(s) => pretty::Fragment::new([
+                printer.pretty_spv_opcode(printer.spv_op_style(), wk.OpString),
+                "(".into(),
+                printer.pretty_string_literal(&printer.cx[s]),
+                ")".into(),
+            ]),
+        };
+        AttrsAndDef { attrs: attrs.print(printer), def_without_name }
     }
 }
 
@@ -3299,21 +3237,17 @@ impl Print for FuncAt<'_, DataInst> {
                 let pseudo_imm_from_value = |v: Value| {
                     if let Value::Const(ct) = v {
                         match &printer.cx[ct].kind {
-                            ConstKind::Undef | ConstKind::PtrToGlobalVar(_) => {}
+                            ConstKind::Undef
+                            | ConstKind::PtrToGlobalVar(_)
+                            | ConstKind::SpvInst { .. } => {}
 
                             &ConstKind::SpvStringLiteralForExtInst(s) => {
                                 return Some(PseudoImm::Str(&printer.cx[s]));
                             }
-                            ConstKind::SpvInst { spv_inst_and_const_inputs } => {
-                                let (spv_inst, _const_inputs) = &**spv_inst_and_const_inputs;
-                                if spv_inst.opcode == wk.OpConstant {
-                                    if let [spv::Imm::Short(_, x)] = spv_inst.imms[..] {
-                                        // HACK(eddyb) only allow unambiguously positive values.
-                                        if i32::try_from(x).and_then(u32::try_from) == Ok(x) {
-                                            return Some(PseudoImm::U32(x));
-                                        }
-                                    }
-                                }
+                            // HACK(eddyb) lossless roundtrip through `i32` is most conservative
+                            // option (only `0..=i32::MAX`, i.e. `0 <= x < 2**32, is allowed).
+                            ConstKind::Scalar(ct) => {
+                                return Some(PseudoImm::U32(u32::try_from(ct.int_as_i32()?).ok()?));
                             }
                         }
                     }

--- a/src/print/mod.rs
+++ b/src/print/mod.rs
@@ -2581,9 +2581,14 @@ impl Print for ConstDef {
         AttrsAndDef {
             attrs: attrs.print(printer),
             def_without_name: compact_def.unwrap_or_else(|| match kind {
+                ConstKind::Undef => pretty::Fragment::new([
+                    printer.imperative_keyword_style().apply("undef").into(),
+                    printer.pretty_type_ascription_suffix(*ty),
+                ]),
                 &ConstKind::PtrToGlobalVar(gv) => {
                     pretty::Fragment::new(["&".into(), gv.print(printer)])
                 }
+
                 ConstKind::SpvInst { spv_inst_and_const_inputs } => {
                     let (spv_inst, const_inputs) = &**spv_inst_and_const_inputs;
                     pretty::Fragment::new([
@@ -3294,6 +3299,8 @@ impl Print for FuncAt<'_, DataInst> {
                 let pseudo_imm_from_value = |v: Value| {
                     if let Value::Const(ct) = v {
                         match &printer.cx[ct].kind {
+                            ConstKind::Undef | ConstKind::PtrToGlobalVar(_) => {}
+
                             &ConstKind::SpvStringLiteralForExtInst(s) => {
                                 return Some(PseudoImm::Str(&printer.cx[s]));
                             }
@@ -3308,7 +3315,6 @@ impl Print for FuncAt<'_, DataInst> {
                                     }
                                 }
                             }
-                            ConstKind::PtrToGlobalVar(_) => {}
                         }
                     }
                     None

--- a/src/print/mod.rs
+++ b/src/print/mod.rs
@@ -24,8 +24,8 @@ use crate::print::multiversion::Versions;
 use crate::qptr::{self, QPtrAttr, QPtrMemUsage, QPtrMemUsageKind, QPtrOp, QPtrUsage};
 use crate::visit::{InnerVisit, Visit, Visitor};
 use crate::{
-    cfg, scalar, spv, AddrSpace, Attr, AttrSet, AttrSetDef, Const, ConstDef, ConstKind, Context,
-    ControlNode, ControlNodeDef, ControlNodeKind, ControlNodeOutputDecl, ControlRegion,
+    cfg, scalar, spv, vector, AddrSpace, Attr, AttrSet, AttrSetDef, Const, ConstDef, ConstKind,
+    Context, ControlNode, ControlNodeDef, ControlNodeKind, ControlNodeOutputDecl, ControlRegion,
     ControlRegionDef, ControlRegionInputDecl, DataInst, DataInstDef, DataInstForm, DataInstFormDef,
     DataInstKind, DeclDef, Diag, DiagLevel, DiagMsgPart, EntityListIter, ExportKey, Exportee, Func,
     FuncDecl, FuncParam, FxIndexMap, FxIndexSet, GlobalVar, GlobalVarDecl, GlobalVarDefBody,
@@ -2407,7 +2407,7 @@ impl Print for ConstDef {
 
         let kw = |kw| printer.declarative_keyword_style().apply(kw).into();
 
-        // FIXME(eddyb) should this just a method on `scalar::Const` instead?
+        // FIXME(eddyb) should this be a method on `scalar::Const` instead?
         let print_scalar = |ct: scalar::Const, include_type_suffix: bool| match ct {
             scalar::Const::FALSE => kw("false"),
             scalar::Const::TRUE => kw("true"),
@@ -3023,17 +3023,62 @@ impl Print for FuncAt<'_, DataInst> {
 
         let mut output_type_to_print = *output_type;
 
+        // FIXME(eddyb) should this be a method on `scalar::Op` instead?
+        let print_scalar = |op: scalar::Op| {
+            let name = op.name();
+            let (namespace_prefix, name) = name.split_at(name.find('.').unwrap() + 1);
+            pretty::Fragment::new([
+                printer
+                    .demote_style_for_namespace_prefix(printer.declarative_keyword_style())
+                    .apply(namespace_prefix),
+                printer.declarative_keyword_style().apply(name),
+            ])
+        };
+
         let def_without_type = match kind {
-            &DataInstKind::Scalar(op) => {
-                let name = op.name();
+            &DataInstKind::Scalar(op) => pretty::Fragment::new([
+                print_scalar(op),
+                pretty::join_comma_sep("(", inputs.iter().map(|v| v.print(printer)), ")"),
+            ]),
+
+            &DataInstKind::Vector(op) => {
+                let (name, extra_last_input) = match op {
+                    vector::Op::Distribute(_) => ("vec.distribute", None),
+                    vector::Op::Reduce(op) => (op.name(), None),
+                    vector::Op::Whole(op) => (
+                        op.name(),
+                        match op {
+                            vector::WholeOp::Extract { elem_idx }
+                            | vector::WholeOp::Insert { elem_idx } => Some(
+                                printer.numeric_literal_style().apply(elem_idx.to_string()).into(),
+                            ),
+                            vector::WholeOp::New
+                            | vector::WholeOp::DynExtract
+                            | vector::WholeOp::DynInsert
+                            | vector::WholeOp::Mul => None,
+                        },
+                    ),
+                };
                 let (namespace_prefix, name) = name.split_at(name.find('.').unwrap() + 1);
-                pretty::Fragment::new([
+                let mut pretty_name = pretty::Fragment::new([
                     printer
                         .demote_style_for_namespace_prefix(printer.declarative_keyword_style())
-                        .apply(namespace_prefix)
-                        .into(),
-                    printer.declarative_keyword_style().apply(name).into(),
-                    pretty::join_comma_sep("(", inputs.iter().map(|v| v.print(printer)), ")"),
+                        .apply(namespace_prefix),
+                    printer.declarative_keyword_style().apply(name),
+                ]);
+                if let vector::Op::Distribute(op) = op {
+                    pretty_name = pretty::Fragment::new([
+                        pretty_name,
+                        pretty::join_comma_sep("(", [print_scalar(op)], ")"),
+                    ]);
+                }
+                pretty::Fragment::new([
+                    pretty_name,
+                    pretty::join_comma_sep(
+                        "(",
+                        inputs.iter().map(|v| v.print(printer)).chain(extra_last_input),
+                        ")",
+                    ),
                 ])
             }
 

--- a/src/print/mod.rs
+++ b/src/print/mod.rs
@@ -3044,6 +3044,19 @@ impl Print for FuncAt<'_, DataInst> {
         let mut output_type_to_print = *output_type;
 
         let def_without_type = match kind {
+            &DataInstKind::Scalar(op) => {
+                let name = op.name();
+                let (namespace_prefix, name) = name.split_at(name.find('.').unwrap() + 1);
+                pretty::Fragment::new([
+                    printer
+                        .demote_style_for_namespace_prefix(printer.declarative_keyword_style())
+                        .apply(namespace_prefix)
+                        .into(),
+                    printer.declarative_keyword_style().apply(name).into(),
+                    pretty::join_comma_sep("(", inputs.iter().map(|v| v.print(printer)), ")"),
+                ])
+            }
+
             &DataInstKind::FuncCall(func) => pretty::Fragment::new([
                 printer.declarative_keyword_style().apply("call").into(),
                 " ".into(),

--- a/src/qptr/analyze.rs
+++ b/src/qptr/analyze.rs
@@ -906,6 +906,8 @@ impl<'a> InferUsage<'a> {
                     });
                 };
                 match &data_inst_form_def.kind {
+                    DataInstKind::Scalar(_) => {}
+
                     &DataInstKind::FuncCall(callee) => {
                         match self.infer_usage_in_func(module, callee) {
                             FuncInferUsageState::Complete(callee_results) => {

--- a/src/qptr/analyze.rs
+++ b/src/qptr/analyze.rs
@@ -805,7 +805,7 @@ impl<'a> InferUsage<'a> {
                         DeclDef::Imported(_) => continue,
                     };
 
-                    for (v, usage) in usage_or_err_attrs_to_attach {
+                    for (v, mut usage) in usage_or_err_attrs_to_attach {
                         let attrs = match v {
                             Value::Const(_) => unreachable!(),
                             Value::ControlRegionInput { region, input_idx } => {
@@ -817,8 +817,45 @@ impl<'a> InferUsage<'a> {
                                     [output_idx as usize]
                                     .attrs
                             }
-                            Value::DataInstOutput(data_inst) => {
-                                &mut func_def_body.at_mut(data_inst).def().attrs
+                            Value::DataInstOutput { inst, output_idx } => {
+                                let data_inst_def = func_def_body.at_mut(inst).def();
+
+                                // HACK(eddyb) there are no legal multiple-output
+                                // instructions, where one of the outputs is a
+                                // pointer, and there are no per-output attributes,
+                                // so guard against misunderstandings herhe.
+                                if output_idx != 0
+                                    || self.cx[data_inst_def.form].output_types.len() != 1
+                                {
+                                    usage = Err(AnalysisError(match usage {
+                                        Ok(usage) => {
+                                            let attr: AttrSet = self.cx.intern(AttrSetDef {
+                                                attrs: [Attr::QPtr(QPtrAttr::Usage(OrdAssertEq(
+                                                    usage,
+                                                )))]
+                                                .into(),
+                                            });
+                                            Diag::bug([
+                                                format!(
+                                                    "cannot attach attribute to \
+                                                     output #{output_idx} of \
+                                                     multi-output instruction:\n"
+                                                )
+                                                .into(),
+                                                attr.into(),
+                                            ])
+                                        }
+                                        Err(AnalysisError(mut diag)) => {
+                                            diag.message.insert(
+                                                0,
+                                                format!("output #{output_idx}: ").into(),
+                                            );
+                                            diag
+                                        }
+                                    }));
+                                }
+
+                                &mut data_inst_def.attrs
                             }
                         };
                         match usage {
@@ -887,13 +924,28 @@ impl<'a> InferUsage<'a> {
         let mut all_data_insts = CollectAllDataInsts::default();
         func_def_body.inner_visit_with(&mut all_data_insts);
 
-        let mut data_inst_output_usages = FxHashMap::default();
+        let mut data_inst_to_per_output_usage: FxHashMap<_, SmallVec<[Option<_>; 2]>> =
+            FxHashMap::default();
         for insts in all_data_insts.0.into_iter().rev() {
             for func_at_inst in func_def_body.at(insts).into_iter().rev() {
                 let data_inst = func_at_inst.position;
                 let data_inst_def = func_at_inst.def();
                 let data_inst_form_def = &cx[data_inst_def.form];
-                let output_usage = data_inst_output_usages.remove(&data_inst).flatten();
+
+                // FIXME(eddyb) should remaining `Some`s in `per_output_usage`
+                // be attached to the instruction, after all the handling below?
+                let mut per_output_usage =
+                    data_inst_to_per_output_usage.remove(&data_inst).unwrap_or_default();
+
+                // HACK(eddyb) this may be a bit wasteful, but it avoids
+                // complicating acessing `per_output_usage` below, and
+                // most instructions should only have at most two outputs.
+                {
+                    let expected = data_inst_form_def.output_types.len();
+                    if per_output_usage.len() < expected {
+                        per_output_usage.extend((per_output_usage.len()..expected).map(|_| None));
+                    }
+                }
 
                 let mut generate_usage = |this: &mut Self, ptr: Value, new_usage| {
                     let slot = match ptr {
@@ -906,8 +958,11 @@ impl<'a> InferUsage<'a> {
                             // or actually support by adding the usage attribute
                             // in the same manner (if it makes sense to do so).
                             _ => {
+                                // FIXME(eddyb) this output may not even exist,
+                                // there should be a different way to have a
+                                // `Diag` get attached to a whole `DataInst`.
                                 usage_or_err_attrs_to_attach.push((
-                                    Value::DataInstOutput(data_inst),
+                                    Value::DataInstOutput { inst: data_inst, output_idx: 0 },
                                     Err(AnalysisError(Diag::bug([
                                         "unsupported pointer constant `".into(),
                                         ct.into(),
@@ -930,8 +985,13 @@ impl<'a> InferUsage<'a> {
                             ));
                             return;
                         }
-                        Value::DataInstOutput(ptr_inst) => {
-                            data_inst_output_usages.entry(ptr_inst).or_default()
+                        Value::DataInstOutput { inst: ptr_inst, output_idx } => {
+                            let i = output_idx as usize;
+                            let slots = data_inst_to_per_output_usage.entry(ptr_inst).or_default();
+                            if i >= slots.len() {
+                                slots.extend((slots.len()..=i).map(|_| None));
+                            }
+                            &mut slots[i]
                         }
                     };
                     *slot = Some(match slot.take() {
@@ -958,33 +1018,48 @@ impl<'a> InferUsage<'a> {
                                 }
                             }
                             FuncInferUsageState::InProgress => {
+                                // FIXME(eddyb) this output may not even exist,
+                                // there should be a different way to have a
+                                // `Diag` get attached to a whole `DataInst`.
                                 usage_or_err_attrs_to_attach.push((
-                                    Value::DataInstOutput(data_inst),
+                                    Value::DataInstOutput { inst: data_inst, output_idx: 0 },
                                     Err(AnalysisError(Diag::bug([
                                         "unsupported recursive call".into()
                                     ]))),
                                 ));
                             }
                         };
-                        if data_inst_form_def.output_type.map_or(false, is_qptr) {
-                            if let Some(usage) = output_usage {
-                                usage_or_err_attrs_to_attach
-                                    .push((Value::DataInstOutput(data_inst), usage));
+                        for (i, &ty) in data_inst_form_def.output_types.iter().enumerate() {
+                            if is_qptr(ty) {
+                                if let Some(usage) = per_output_usage[i].take() {
+                                    usage_or_err_attrs_to_attach.push((
+                                        Value::DataInstOutput {
+                                            inst: data_inst,
+                                            output_idx: i.try_into().unwrap(),
+                                        },
+                                        usage,
+                                    ));
+                                }
                             }
                         }
                     }
 
                     DataInstKind::QPtr(QPtrOp::FuncLocalVar(_)) => {
-                        if let Some(usage) = output_usage {
-                            usage_or_err_attrs_to_attach
-                                .push((Value::DataInstOutput(data_inst), usage));
+                        assert_eq!(per_output_usage.len(), 1);
+                        if let Some(usage) = per_output_usage[0].take() {
+                            usage_or_err_attrs_to_attach.push((
+                                Value::DataInstOutput { inst: data_inst, output_idx: 0 },
+                                usage,
+                            ));
                         }
                     }
                     DataInstKind::QPtr(QPtrOp::HandleArrayIndex) => {
+                        assert_eq!(per_output_usage.len(), 1);
                         generate_usage(
                             self,
                             data_inst_def.inputs[0],
-                            output_usage
+                            per_output_usage[0]
+                                .take()
                                 .unwrap_or_else(|| {
                                     Err(AnalysisError(Diag::bug([
                                         "HandleArrayIndex: unknown element".into(),
@@ -999,10 +1074,12 @@ impl<'a> InferUsage<'a> {
                         );
                     }
                     DataInstKind::QPtr(QPtrOp::BufferData) => {
+                        assert_eq!(per_output_usage.len(), 1);
                         generate_usage(
                             self,
                             data_inst_def.inputs[0],
-                            output_usage
+                            per_output_usage[0]
+                                .take()
                                 .unwrap_or(Ok(QPtrUsage::Memory(QPtrMemUsage::UNUSED)))
                                 .and_then(|usage| {
                                     let usage = match usage {
@@ -1051,10 +1128,11 @@ impl<'a> InferUsage<'a> {
                         );
                     }
                     &DataInstKind::QPtr(QPtrOp::Offset(offset)) => {
+                        assert_eq!(per_output_usage.len(), 1);
                         generate_usage(
                             self,
                             data_inst_def.inputs[0],
-                            output_usage
+                            per_output_usage[0].take()
                                 .unwrap_or(Ok(QPtrUsage::Memory(QPtrMemUsage::UNUSED)))
                                 .and_then(|usage| {
                                     let usage = match usage {
@@ -1093,10 +1171,11 @@ impl<'a> InferUsage<'a> {
                         );
                     }
                     DataInstKind::QPtr(QPtrOp::DynOffset { stride, index_bounds }) => {
+                        assert_eq!(per_output_usage.len(), 1);
                         generate_usage(
                             self,
                             data_inst_def.inputs[0],
-                            output_usage
+                            per_output_usage[0].take()
                                 .unwrap_or(Ok(QPtrUsage::Memory(QPtrMemUsage::UNUSED)))
                                 .and_then(|usage| {
                                     let usage = match usage {
@@ -1151,9 +1230,7 @@ impl<'a> InferUsage<'a> {
                         op @ (QPtrOp::Load { offset } | QPtrOp::Store { offset }),
                     ) => {
                         let (op_name, access_type) = match op {
-                            QPtrOp::Load { .. } => {
-                                ("Load", data_inst_form_def.output_type.unwrap())
-                            }
+                            QPtrOp::Load { .. } => ("Load", data_inst_form_def.output_types[0]),
                             QPtrOp::Store { .. } => {
                                 ("Store", func_at_inst.at(data_inst_def.inputs[1]).type_of(&cx))
                             }
@@ -1228,7 +1305,8 @@ impl<'a> InferUsage<'a> {
                         );
                     }
 
-                    DataInstKind::SpvInst(_) | DataInstKind::SpvExtInst { .. } => {
+                    DataInstKind::SpvInst(_, lowering)
+                    | DataInstKind::SpvExtInst { lowering, .. } => {
                         let mut has_from_spv_ptr_output_attr = false;
                         for attr in &cx[data_inst_def.attrs].attrs {
                             match *attr {
@@ -1253,7 +1331,8 @@ impl<'a> InferUsage<'a> {
                                                         // since it would conflict with our
                                                         // own `Block`-annotated wrapper.
                                                         shapes::Handle::Buffer(..) => {
-                                                            return Err(AnalysisError(Diag::bug(["ToSpvPtrInput: whole Buffer ambiguous (handle vs buffer data)".into()])
+                                                            return Err(AnalysisError(
+                                                                Diag::bug(["ToSpvPtrInput: whole Buffer ambiguous (handle vs buffer data)".into()])
                                                             ));
                                                         }
                                                     };
@@ -1266,7 +1345,8 @@ impl<'a> InferUsage<'a> {
                                                 // a generated type that matches the
                                                 // desired `pointee` type.
                                                 TypeLayout::HandleArray(..) => {
-                                                    Err(AnalysisError(Diag::bug(["ToSpvPtrInput: whole handle array unrepresentable".into()])
+                                                    Err(AnalysisError(
+                                                        Diag::bug(["ToSpvPtrInput: whole handle array unrepresentable".into()])
                                                     ))
                                                 }
                                                 TypeLayout::Concrete(concrete) => {
@@ -1299,10 +1379,14 @@ impl<'a> InferUsage<'a> {
                         }
 
                         if has_from_spv_ptr_output_attr {
+                            assert!(lowering.disaggregated_output.is_none());
+                            assert_eq!(per_output_usage.len(), 1);
                             // FIXME(eddyb) merge with `FromSpvPtrOutput`'s `pointee`.
-                            if let Some(usage) = output_usage {
-                                usage_or_err_attrs_to_attach
-                                    .push((Value::DataInstOutput(data_inst), usage));
+                            if let Some(usage) = per_output_usage[0].take() {
+                                usage_or_err_attrs_to_attach.push((
+                                    Value::DataInstOutput { inst: data_inst, output_idx: 0 },
+                                    usage,
+                                ));
                             }
                         }
                     }

--- a/src/qptr/analyze.rs
+++ b/src/qptr/analyze.rs
@@ -906,7 +906,7 @@ impl<'a> InferUsage<'a> {
                     });
                 };
                 match &data_inst_form_def.kind {
-                    DataInstKind::Scalar(_) => {}
+                    DataInstKind::Scalar(_) | DataInstKind::Vector(_) => {}
 
                     &DataInstKind::FuncCall(callee) => {
                         match self.infer_usage_in_func(module, callee) {

--- a/src/qptr/analyze.rs
+++ b/src/qptr/analyze.rs
@@ -901,8 +901,21 @@ impl<'a> InferUsage<'a> {
                             ConstKind::PtrToGlobalVar(gv) => {
                                 this.global_var_usages.entry(gv).or_default()
                             }
-                            // FIXME(eddyb) may be relevant?
-                            _ => unreachable!(),
+                            // FIXME(eddyb) attach on the `Const` by replacing
+                            // it with a copy that also has an extra attribute,
+                            // or actually support by adding the usage attribute
+                            // in the same manner (if it makes sense to do so).
+                            _ => {
+                                usage_or_err_attrs_to_attach.push((
+                                    Value::DataInstOutput(data_inst),
+                                    Err(AnalysisError(Diag::bug([
+                                        "unsupported pointer constant `".into(),
+                                        ct.into(),
+                                        "`".into(),
+                                    ]))),
+                                ));
+                                return;
+                            }
                         },
                         Value::ControlRegionInput { region, input_idx }
                             if region == func_def_body.body =>

--- a/src/qptr/analyze.rs
+++ b/src/qptr/analyze.rs
@@ -1147,10 +1147,14 @@ impl<'a> InferUsage<'a> {
                                 }),
                         );
                     }
-                    DataInstKind::QPtr(op @ (QPtrOp::Load | QPtrOp::Store)) => {
+                    DataInstKind::QPtr(
+                        op @ (QPtrOp::Load { offset } | QPtrOp::Store { offset }),
+                    ) => {
                         let (op_name, access_type) = match op {
-                            QPtrOp::Load => ("Load", data_inst_form_def.output_type.unwrap()),
-                            QPtrOp::Store => {
+                            QPtrOp::Load { .. } => {
+                                ("Load", data_inst_form_def.output_type.unwrap())
+                            }
+                            QPtrOp::Store { .. } => {
                                 ("Store", func_at_inst.at(data_inst_def.inputs[1]).type_of(&cx))
                             }
                             _ => unreachable!(),
@@ -1162,7 +1166,7 @@ impl<'a> InferUsage<'a> {
                                 .layout_of(access_type)
                                 .map_err(|LayoutError(e)| AnalysisError(e))
                                 .and_then(|layout| match layout {
-                                    TypeLayout::Handle(shapes::Handle::Opaque(ty)) => {
+                                    TypeLayout::Handle(shapes::Handle::Opaque(ty)) if *offset == 0 => {
                                         Ok(QPtrUsage::Handles(shapes::Handle::Opaque(ty)))
                                     }
                                     TypeLayout::Handle(shapes::Handle::Buffer(..)) => {
@@ -1170,6 +1174,11 @@ impl<'a> InferUsage<'a> {
                                             "{op_name}: cannot access whole Buffer"
                                         )
                                         .into()])))
+                                    }
+                                    TypeLayout::Handle(_) => {
+                                        Err(AnalysisError(Diag::bug([format!(
+                                            "{op_name} {{ offset: {offset} }}: cannot offset Handles"
+                                        ).into()])))
                                     }
                                     TypeLayout::HandleArray(..) => {
                                         Err(AnalysisError(Diag::bug([format!(
@@ -1186,9 +1195,33 @@ impl<'a> InferUsage<'a> {
                                         .into()])))
                                     }
                                     TypeLayout::Concrete(concrete) => {
-                                        Ok(QPtrUsage::Memory(QPtrMemUsage {
+                                        let usage = QPtrMemUsage {
                                             max_size: Some(concrete.mem_layout.fixed_base.size),
                                             kind: QPtrMemUsageKind::DirectAccess(access_type),
+                                        };
+
+                                        // FIXME(eddyb) deduplicate this with
+                                        // `QPtrOp::Offset` above.
+                                        let offset = u32::try_from(*offset).ok().ok_or_else(|| {
+                                            AnalysisError(Diag::bug([format!("{op_name} {{ offset: {offset} }}: negative offset").into()]))
+                                        })?;
+
+                                        if offset == 0 {
+                                            return Ok(QPtrUsage::Memory(usage));
+                                        }
+
+                                        Ok(QPtrUsage::Memory(QPtrMemUsage {
+                                            max_size: usage
+                                                .max_size
+                                                .map(|max_size| offset.checked_add(max_size).ok_or_else(|| {
+                                                    AnalysisError(Diag::bug([format!("{op_name} {{ offset: {offset} }}: size overflow ({offset}+{max_size})").into()]))
+                                                })).transpose()?,
+                                            // FIXME(eddyb) allocating `Rc<BTreeMap<_, _>>`
+                                            // to represent the one-element case, seems
+                                            // quite wasteful when it's likely consumed.
+                                            kind: QPtrMemUsageKind::OffsetBase(Rc::new(
+                                                [(offset, usage)].into(),
+                                            )),
                                         }))
                                     }
                                 }),

--- a/src/qptr/const_data.rs
+++ b/src/qptr/const_data.rs
@@ -1,0 +1,236 @@
+//! Constant data efficiently mixing concrete bytes with symbolic values.
+
+use itertools::Itertools;
+use smallvec::SmallVec;
+use std::collections::BTreeMap;
+use std::iter;
+use std::num::NonZeroU32;
+use std::ops::Range;
+
+/// Constant data "blob" or "chunk", where each byte can be part of:
+/// - uninitialized areas (e.g. SPIR-V `OpUndef`)
+/// - concrete data (i.e. `u8` values)
+/// - symbolic values of type `V` (spanning some number of bytes)
+///
+/// This is similar to (and inspired by), [`rustc`'s `mir::interpret::Allocation`](
+/// https://rustc-dev-guide.rust-lang.org/const-eval/interpret.html#memory),
+/// which only has abstract pointers as symbolic values, encoded as "relocations"
+/// (i.e. concrete data contains the respective offset for each abstract pointer,
+/// whereas here the symbolic values are completely disjoint with concrete data).
+pub struct ConstData<V> {
+    /// The bit `init[i / 64] & (1 << (i % 64))` is set iff byte offset `i` is
+    /// initialized, either with concrete data, or as part of a symbolic value.
+    init: Vec<u64>,
+
+    /// Concrete data bytes, with each byte only used when `init` indicates
+    /// it is initialized *and* no symbolic value overlaps it. Unused bytes can
+    /// have any values in `bytes`, as they're guaranteed to be always ignored.
+    data: Vec<u8>,
+
+    /// Non-overlapping set of symbolic `V` values, forming an "overlay" on top
+    /// of the concrete data bytes, with `syms[offset] = (size, value)`
+    /// indicating bytes `offset..(offset + size)` are occupied by `value`.
+    syms: BTreeMap<u32, (NonZeroU32, V)>,
+
+    /// Largest symbolic value size, i.e. `syms.values().map(|(size, _)| size).max()`.
+    //
+    // FIXME(eddyb) this is only needed to help with scanning overlaps in `syms`,
+    // and because there is no inherent limit on the size of symbolic values.
+    max_sym_size: NonZeroU32,
+}
+
+/// One uniform "slice" of a `ConstData` (*not* mixing value categories).
+#[derive(Clone)]
+pub enum Part<'a, V> {
+    Uninit {
+        size: u32,
+    },
+    Data(&'a [u8]),
+    Symbolic {
+        size: NonZeroU32,
+        /// This is only the full `value` if `slice == 0..size`.
+        slice: Range<u32>,
+        value: V,
+    },
+}
+
+/// Error type for write operations, emitted when they would otherwise cause a
+/// partial overwrite of a symbolic value, if allowed to take effect.
+#[derive(Debug)]
+pub struct PartialSymbolicOverlap {
+    pub offsets: Range<u32>,
+}
+
+// FIXME(eddyb) come up with a nicer abstraction for bitvecs, or use a crate.
+fn bitrange_word_chunks(range: Range<u32>) -> (Range<usize>, impl Iterator<Item = Range<u8>>) {
+    let words = (range.start / 64)..(range.end.div_ceil(64));
+    (
+        (words.start as usize)..(words.end as usize),
+        words.map(move |i| {
+            (((i * 64).clamp(range.start, range.end) % 64) as u8)
+                ..((((i + 1) * 64).clamp(range.start, range.end) % 64) as u8)
+        }),
+    )
+}
+
+impl<V: Copy> ConstData<V> {
+    pub fn new(size: u32) -> Self {
+        let size = size as usize;
+        Self {
+            init: vec![0; size.div_ceil(64)],
+            data: vec![0; size],
+            syms: BTreeMap::new(),
+            max_sym_size: NonZeroU32::new(1).unwrap(),
+        }
+    }
+
+    pub fn size(&self) -> u32 {
+        self.data.len() as u32
+    }
+
+    pub fn read(&self, range: Range<u32>) -> impl Iterator<Item = Part<'_, V>> {
+        // HACK(eddyb) trigger bounds-checking panics.
+        let _ = &self.data[(range.start as usize)..(range.end as usize)];
+
+        // HACK(eddyb) the range has to be extended backwards, because a partial
+        // overlap could exit, i.e. `range.start` being in the middle of a value,
+        // but then irrelevant values have to be ignored.
+        let mut syms = self
+            .syms
+            .range((range.start - (self.max_sym_size.get() - 1))..range.end)
+            .map(|(&offset, &(size, value))| (offset..(offset + size.get()), value))
+            .peekable();
+        while let Some((sym_range, _)) = syms.peek() {
+            if sym_range.end > range.start {
+                break;
+            }
+            syms.next().unwrap();
+        }
+
+        let mut part_start = range.start;
+        iter::from_fn(move || {
+            if part_start >= range.end {
+                return None;
+            }
+            let next_sym_range = syms.peek().cloned().map_or(range.end..range.end, |(r, _)| r);
+
+            let max_part_end = if next_sym_range.contains(&part_start) {
+                next_sym_range.end
+            } else {
+                next_sym_range.start
+            };
+            // FIXME(eddyb) come up with a nicer abstraction for bitvecs, or use a crate.
+            let (part_is_init, part_size) = {
+                let (words, word_bitslices) = bitrange_word_chunks(part_start..max_part_end);
+                self.init[words]
+                    .iter()
+                    .zip_eq(word_bitslices)
+                    .flat_map(|(&word, word_bitslice)| {
+                        let sliced_word =
+                            (word >> word_bitslice.start) & (!0 >> (64 - word_bitslice.end));
+                        let first = (sliced_word & 1) != 0;
+                        let same_run = if first {
+                            sliced_word.trailing_ones()
+                        } else {
+                            sliced_word.trailing_zeros()
+                        };
+                        [(first, same_run)]
+                            .into_iter()
+                            .chain((same_run < word_bitslice.len() as u32).then_some((!first, 0)))
+                    })
+                    .coalesce(|(a, a_run), (b, b_run)| {
+                        if a == b { Ok((a, a_run + b_run)) } else { Err(((a, a_run), (b, b_run))) }
+                    })
+                    .next()
+                    .unwrap()
+            };
+
+            let part_end = part_start + part_size;
+            let part = if !part_is_init {
+                Part::Uninit { size: part_size }
+            } else if next_sym_range.contains(&part_start) {
+                let (sym_range, value) = syms.next().unwrap();
+                // HACK(eddyb) ensure slicing is caused by `range`, *not* `init`.
+                assert_eq!(
+                    part_start..part_end,
+                    sym_range.start.clamp(range.start, range.end)
+                        ..sym_range.end.clamp(range.start, range.end)
+                );
+                Part::Symbolic {
+                    size: NonZeroU32::new(sym_range.len() as u32).unwrap(),
+                    slice: (part_start - sym_range.start)..(part_end - sym_range.start),
+                    value,
+                }
+            } else {
+                Part::Data(&self.data[(part_start as usize)..(part_end as usize)])
+            };
+            part_start = part_end;
+            Some(part)
+        })
+    }
+
+    /// Helper for `write_bytes` and `write_symbolic`, which only modifies `self`
+    /// (removing fully overwritten symbolic values, and setting `init` bits),
+    /// when it can guarantee it will return `Ok(())` (i.e. after error checks).
+    fn try_init(&mut self, range: Range<u32>) -> Result<(), PartialSymbolicOverlap> {
+        // HACK(eddyb) trigger bounds-checking panics.
+        let _ = &self.data[(range.start as usize)..(range.end as usize)];
+
+        // HACK(eddyb) the range has to be extended backwards, because a partial
+        // overlap could exit, i.e. `range.start` being in the middle of a value,
+        // but then irrelevant values have to be ignored.
+        let syms_ranges = self
+            .syms
+            .range((range.start - (self.max_sym_size.get() - 1))..range.end)
+            .map(|(&offset, &(size, _))| offset..(offset + size.get()));
+
+        // FIXME(eddyb) this is a bit inefficient but we don't have
+        // cursors, so we have to buffer the `BTreeMap` keys here.
+        let mut full_overwritten_sym_offsets = SmallVec::<[u32; 16]>::new();
+        for sym_range in syms_ranges {
+            let overlap = sym_range.start.clamp(range.start, range.end)
+                ..sym_range.end.clamp(range.start, range.end);
+            if overlap.is_empty() {
+                continue;
+            }
+            if overlap == sym_range {
+                full_overwritten_sym_offsets.push(sym_range.start);
+            } else {
+                return Err(PartialSymbolicOverlap { offsets: overlap });
+            }
+        }
+        for offset in full_overwritten_sym_offsets {
+            self.syms.remove(&offset);
+        }
+
+        // FIXME(eddyb) come up with a nicer abstraction for bitvecs, or use a crate.
+        {
+            let (words, word_bitslices) = bitrange_word_chunks(range);
+            for (word, word_bitslice) in self.init[words].iter_mut().zip(word_bitslices) {
+                *word |= (!0 << word_bitslice.start) & (!0 >> (64 - word_bitslice.end));
+            }
+        }
+
+        Ok(())
+    }
+
+    pub fn write_bytes(&mut self, offset: u32, bytes: &[u8]) -> Result<(), PartialSymbolicOverlap> {
+        let range = offset..(offset + bytes.len() as u32);
+        self.try_init(range.clone())?;
+        self.data[(range.start as usize)..(range.end as usize)].copy_from_slice(bytes);
+        Ok(())
+    }
+
+    // FIXME(eddyb) should this take an offset range instead?
+    pub fn write_symbolic(
+        &mut self,
+        offset: u32,
+        size: NonZeroU32,
+        value: V,
+    ) -> Result<(), PartialSymbolicOverlap> {
+        let range = offset..(offset + size.get());
+        self.try_init(range.clone())?;
+        self.syms.insert(offset, (size, value));
+        Ok(())
+    }
+}

--- a/src/qptr/layout.rs
+++ b/src/qptr/layout.rs
@@ -356,7 +356,7 @@ impl<'a> LayoutCache<'a> {
                     ["`layout_of(qptr)` (already lowered?)".into()],
                 )));
             }
-            TypeKind::SpvInst { spv_inst, type_and_const_inputs } => {
+            TypeKind::SpvInst { spv_inst, type_and_const_inputs, .. } => {
                 (spv_inst, type_and_const_inputs)
             }
             TypeKind::SpvStringLiteralForExtInst => {

--- a/src/qptr/layout.rs
+++ b/src/qptr/layout.rs
@@ -2,7 +2,7 @@
 
 use crate::qptr::shapes;
 use crate::{
-    spv, AddrSpace, Attr, Const, ConstKind, Context, Diag, FxIndexMap, Type, TypeKind, TypeOrConst,
+    scalar, spv, AddrSpace, Attr, Const, Context, Diag, FxIndexMap, Type, TypeKind, TypeOrConst,
 };
 use itertools::Either;
 use smallvec::SmallVec;
@@ -182,18 +182,10 @@ impl<'a> LayoutCache<'a> {
         Self { cx, wk: &spv::spec::Spec::get().well_known, config, cache: Default::default() }
     }
 
-    // FIXME(eddyb) properly distinguish between zero-extension and sign-extension.
     fn const_as_u32(&self, ct: Const) -> Option<u32> {
-        if let ConstKind::SpvInst { spv_inst_and_const_inputs } = &self.cx[ct].kind {
-            let (spv_inst, _const_inputs) = &**spv_inst_and_const_inputs;
-            if spv_inst.opcode == self.wk.OpConstant && spv_inst.imms.len() == 1 {
-                match spv_inst.imms[..] {
-                    [spv::Imm::Short(_, x)] => return Some(x),
-                    _ => unreachable!(),
-                }
-            }
-        }
-        None
+        // HACK(eddyb) lossless roundtrip through `i32` is most conservative
+        // option (only `0..=i32::MAX`, i.e. `0 <= x < 2**32, is allowed).
+        u32::try_from(ct.as_scalar(&self.cx)?.int_as_i32()?).ok()
     }
 
     /// Attempt to compute a `TypeLayout` for a given (SPIR-V) `Type`.
@@ -202,26 +194,16 @@ impl<'a> LayoutCache<'a> {
             return Ok(cached);
         }
 
+        let layout = self.layout_of_uncached(ty)?;
+        self.cache.borrow_mut().insert(ty, layout.clone());
+        Ok(layout)
+    }
+
+    fn layout_of_uncached(&self, ty: Type) -> Result<TypeLayout, LayoutError> {
         let cx = &self.cx;
         let wk = self.wk;
 
         let ty_def = &cx[ty];
-        let (spv_inst, type_and_const_inputs) = match &ty_def.kind {
-            // FIXME(eddyb) treat `QPtr`s as scalars.
-            TypeKind::QPtr => {
-                return Err(LayoutError(Diag::bug(
-                    ["`layout_of(qptr)` (already lowered?)".into()],
-                )));
-            }
-            TypeKind::SpvInst { spv_inst, type_and_const_inputs } => {
-                (spv_inst, type_and_const_inputs)
-            }
-            TypeKind::SpvStringLiteralForExtInst => {
-                return Err(LayoutError(Diag::bug([
-                    "`layout_of(type_of(OpString<\"...\">))`".into()
-                ])));
-            }
-        };
 
         let scalar_with_size_and_align = |(size, align)| {
             TypeLayout::Concrete(Rc::new(MemTypeLayout {
@@ -340,25 +322,43 @@ impl<'a> LayoutCache<'a> {
                 }
             }
         };
-        let short_imm_at = |i| match spv_inst.imms[i] {
-            spv::Imm::Short(_, x) => x,
-            _ => unreachable!(),
-        };
 
         // FIXME(eddyb) !!! what if... types had a min/max size and then...
         // that would allow surrounding offsets to limit their size... but... ugh...
         // ugh this doesn't make any sense. maybe if the front-end specifies
         // offsets with "abstract types", it must configure `qptr::layout`?
-        let layout = if spv_inst.opcode == wk.OpTypeBool {
-            // FIXME(eddyb) make this properly abstract instead of only configurable.
-            scalar_with_size_and_align(self.config.abstract_bool_size_align)
-        } else if spv_inst.opcode == wk.OpTypePointer {
+
+        let (spv_inst, type_and_const_inputs) = match &ty_def.kind {
+            TypeKind::Scalar(scalar::Type::Bool) => {
+                // FIXME(eddyb) make this properly abstract instead of only configurable.
+                return Ok(scalar_with_size_and_align(self.config.abstract_bool_size_align));
+            }
+            TypeKind::Scalar(ty) => return Ok(scalar(ty.bit_width())),
+
+            // FIXME(eddyb) treat `QPtr`s as scalars.
+            TypeKind::QPtr => {
+                return Err(LayoutError(Diag::bug(
+                    ["`layout_of(qptr)` (already lowered?)".into()],
+                )));
+            }
+            TypeKind::SpvInst { spv_inst, type_and_const_inputs } => {
+                (spv_inst, type_and_const_inputs)
+            }
+            TypeKind::SpvStringLiteralForExtInst => {
+                return Err(LayoutError(Diag::bug([
+                    "`layout_of(type_of(OpString<\"...\">))`".into()
+                ])));
+            }
+        };
+        let short_imm_at = |i| match spv_inst.imms[i] {
+            spv::Imm::Short(_, x) => x,
+            _ => unreachable!(),
+        };
+        Ok(if spv_inst.opcode == wk.OpTypePointer {
             // FIXME(eddyb) make this properly abstract instead of only configurable.
             // FIXME(eddyb) categorize `OpTypePointer` by storage class and split on
             // logical vs physical here.
             scalar_with_size_and_align(self.config.logical_ptr_size_align)
-        } else if [wk.OpTypeInt, wk.OpTypeFloat].contains(&spv_inst.opcode) {
-            scalar(short_imm_at(0))
         } else if [wk.OpTypeVector, wk.OpTypeMatrix].contains(&spv_inst.opcode) {
             let len = short_imm_at(0);
             let (min_legacy_align, legacy_align_multiplier) = if spv_inst.opcode == wk.OpTypeVector
@@ -642,8 +642,6 @@ impl<'a> LayoutCache<'a> {
                 spv_inst.opcode.name()
             )
             .into()])));
-        };
-        self.cache.borrow_mut().insert(ty, layout.clone());
-        Ok(layout)
+        })
     }
 }

--- a/src/qptr/lift.rs
+++ b/src/qptr/lift.rs
@@ -285,12 +285,15 @@ impl<'a> LiftToSpvPtrs<'a> {
             attrs: stride_attrs.unwrap_or_default(),
             kind: TypeKind::SpvInst {
                 spv_inst: spv_opcode.into(),
-                type_and_const_inputs: [TypeOrConst::Type(element_type)]
-                    .into_iter()
-                    .chain(fixed_len.map(|len| {
+                type_and_const_inputs: [
+                    Some(TypeOrConst::Type(element_type)),
+                    fixed_len.map(|len| {
                         TypeOrConst::Const(self.cx.intern(scalar::Const::from_u32(len)))
-                    }))
-                    .collect(),
+                    }),
+                ]
+                .into_iter()
+                .flatten()
+                .collect(),
             },
         }))
     }

--- a/src/qptr/lift.rs
+++ b/src/qptr/lift.rs
@@ -7,13 +7,12 @@ use crate::func_at::FuncAtMut;
 use crate::qptr::{shapes, QPtrAttr, QPtrMemUsage, QPtrMemUsageKind, QPtrOp, QPtrUsage};
 use crate::transform::{InnerInPlaceTransform, InnerTransform, Transformed, Transformer};
 use crate::{
-    spv, AddrSpace, Attr, AttrSet, AttrSetDef, Const, ConstDef, ConstKind, Context, ControlNode,
-    ControlNodeKind, DataInst, DataInstDef, DataInstFormDef, DataInstKind, DeclDef, Diag,
-    DiagLevel, EntityDefs, EntityOrientedDenseMap, Func, FuncDecl, FxIndexMap, GlobalVar,
+    scalar, spv, AddrSpace, Attr, AttrSet, AttrSetDef, Const, ConstDef, ConstKind, Context,
+    ControlNode, ControlNodeKind, DataInst, DataInstDef, DataInstFormDef, DataInstKind, DeclDef,
+    Diag, DiagLevel, EntityDefs, EntityOrientedDenseMap, Func, FuncDecl, FxIndexMap, GlobalVar,
     GlobalVarDecl, Module, Type, TypeDef, TypeKind, TypeOrConst, Value,
 };
 use smallvec::SmallVec;
-use std::cell::Cell;
 use std::mem;
 use std::num::NonZeroU32;
 use std::rc::Rc;
@@ -27,8 +26,6 @@ pub struct LiftToSpvPtrs<'a> {
     cx: Rc<Context>,
     wk: &'static spv::spec::WellKnown,
     layout_cache: LayoutCache<'a>,
-
-    cached_u32_type: Cell<Option<Type>>,
 }
 
 impl<'a> LiftToSpvPtrs<'a> {
@@ -37,7 +34,6 @@ impl<'a> LiftToSpvPtrs<'a> {
             cx: cx.clone(),
             wk: &spv::spec::Spec::get().well_known,
             layout_cache: LayoutCache::new(cx, layout_config),
-            cached_u32_type: Default::default(),
         }
     }
 
@@ -291,7 +287,9 @@ impl<'a> LiftToSpvPtrs<'a> {
                 spv_inst: spv_opcode.into(),
                 type_and_const_inputs: [TypeOrConst::Type(element_type)]
                     .into_iter()
-                    .chain(fixed_len.map(|len| TypeOrConst::Const(self.const_u32(len))))
+                    .chain(fixed_len.map(|len| {
+                        TypeOrConst::Const(self.cx.intern(scalar::Const::from_u32(len)))
+                    }))
                     .collect(),
             },
         }))
@@ -327,48 +325,6 @@ impl<'a> LiftToSpvPtrs<'a> {
             attrs: self.cx.intern(attrs),
             kind: TypeKind::SpvInst { spv_inst: wk.OpTypeStruct.into(), type_and_const_inputs },
         }))
-    }
-
-    /// Get the (likely cached) `u32` type.
-    fn u32_type(&self) -> Type {
-        if let Some(cached) = self.cached_u32_type.get() {
-            return cached;
-        }
-        let wk = self.wk;
-        let ty = self.cx.intern(TypeKind::SpvInst {
-            spv_inst: spv::Inst {
-                opcode: wk.OpTypeInt,
-                imms: [
-                    spv::Imm::Short(wk.LiteralInteger, 32),
-                    spv::Imm::Short(wk.LiteralInteger, 0),
-                ]
-                .into_iter()
-                .collect(),
-            },
-            type_and_const_inputs: [].into_iter().collect(),
-        });
-        self.cached_u32_type.set(Some(ty));
-        ty
-    }
-
-    fn const_u32(&self, x: u32) -> Const {
-        let wk = self.wk;
-
-        self.cx.intern(ConstDef {
-            attrs: AttrSet::default(),
-            ty: self.u32_type(),
-            kind: ConstKind::SpvInst {
-                spv_inst_and_const_inputs: Rc::new((
-                    spv::Inst {
-                        opcode: wk.OpConstant,
-                        imms: [spv::Imm::Short(wk.LiteralContextDependentNumber, x)]
-                            .into_iter()
-                            .collect(),
-                    },
-                    [].into_iter().collect(),
-                )),
-            },
-        })
     }
 
     /// Attempt to compute a `TypeLayout` for a given (SPIR-V) `Type`.
@@ -644,7 +600,7 @@ impl LiftToSpvPtrInstsInFunc<'_> {
                         ]))
                     })?;
                     access_chain_inputs
-                        .push(Value::Const(self.lifter.const_u32(idx_as_i32 as u32)));
+                        .push(Value::Const(cx.intern(scalar::Const::from_u32(idx_as_i32 as u32))));
 
                     match &layout.components {
                         Components::Scalar => unreachable!(),
@@ -757,7 +713,7 @@ impl LiftToSpvPtrInstsInFunc<'_> {
                         ]))
                     })?;
                     access_chain_inputs
-                        .push(Value::Const(self.lifter.const_u32(idx_as_i32 as u32)));
+                        .push(Value::Const(cx.intern(scalar::Const::from_u32(idx_as_i32 as u32))));
 
                     layout = match &layout.components {
                         Components::Scalar => unreachable!(),
@@ -945,7 +901,8 @@ impl LiftToSpvPtrInstsInFunc<'_> {
         let mut access_chain_inputs: SmallVec<_> = [ptr].into_iter().collect();
 
         if let TypeLayout::HandleArray(handle, _) = pointee_layout {
-            access_chain_inputs.push(Value::Const(self.lifter.const_u32(0)));
+            access_chain_inputs
+                .push(Value::Const(self.lifter.cx.intern(scalar::Const::from_u32(0))));
             pointee_layout = TypeLayout::Handle(handle);
         }
         match (pointee_layout, access_layout) {
@@ -1014,8 +971,9 @@ impl LiftToSpvPtrInstsInFunc<'_> {
                             format!("{idx} not representable as a positive s32").into()
                         ]))
                     })?;
-                    access_chain_inputs
-                        .push(Value::Const(self.lifter.const_u32(idx_as_i32 as u32)));
+                    access_chain_inputs.push(Value::Const(
+                        self.lifter.cx.intern(scalar::Const::from_u32(idx_as_i32 as u32)),
+                    ));
 
                     pointee_layout = match &pointee_layout.components {
                         Components::Scalar => unreachable!(),

--- a/src/qptr/lift.rs
+++ b/src/qptr/lift.rs
@@ -404,6 +404,8 @@ impl LiftToSpvPtrInstsInFunc<'_> {
             Ok((addr_space, self.lifter.layout_of(pointee_type)?))
         };
         let replacement_data_inst_def = match &data_inst_form_def.kind {
+            DataInstKind::Scalar(_) => return Ok(Transformed::Unchanged),
+
             &DataInstKind::FuncCall(_callee) => {
                 for &v in &data_inst_def.inputs {
                     if self.lifter.as_spv_ptr_type(type_of_val(v)).is_some() {

--- a/src/qptr/lift.rs
+++ b/src/qptr/lift.rs
@@ -404,7 +404,7 @@ impl LiftToSpvPtrInstsInFunc<'_> {
             Ok((addr_space, self.lifter.layout_of(pointee_type)?))
         };
         let replacement_data_inst_def = match &data_inst_form_def.kind {
-            DataInstKind::Scalar(_) => return Ok(Transformed::Unchanged),
+            DataInstKind::Scalar(_) | DataInstKind::Vector(_) => return Ok(Transformed::Unchanged),
 
             &DataInstKind::FuncCall(_callee) => {
                 for &v in &data_inst_def.inputs {

--- a/src/qptr/lower.rs
+++ b/src/qptr/lower.rs
@@ -616,7 +616,7 @@ impl LowerFromSpvPtrInstsInFunc<'_> {
 
         match data_inst_form_def.kind {
             // Known semantics, no need to preserve SPIR-V pointer information.
-            DataInstKind::FuncCall(_) | DataInstKind::QPtr(_) => return,
+            DataInstKind::Scalar(_) | DataInstKind::FuncCall(_) | DataInstKind::QPtr(_) => return,
 
             DataInstKind::SpvInst(_) | DataInstKind::SpvExtInst { .. } => {}
         }

--- a/src/qptr/lower.rs
+++ b/src/qptr/lower.rs
@@ -616,7 +616,10 @@ impl LowerFromSpvPtrInstsInFunc<'_> {
 
         match data_inst_form_def.kind {
             // Known semantics, no need to preserve SPIR-V pointer information.
-            DataInstKind::Scalar(_) | DataInstKind::FuncCall(_) | DataInstKind::QPtr(_) => return,
+            DataInstKind::Scalar(_)
+            | DataInstKind::Vector(_)
+            | DataInstKind::FuncCall(_)
+            | DataInstKind::QPtr(_) => return,
 
             DataInstKind::SpvInst(_) | DataInstKind::SpvExtInst { .. } => {}
         }

--- a/src/qptr/mod.rs
+++ b/src/qptr/mod.rs
@@ -193,16 +193,19 @@ pub enum QPtrOp {
         index_bounds: Option<Range<i32>>,
     },
 
-    /// Read a single value from a `QPtr` (`inputs[0]`).
+    /// Read a single value from a `QPtr` (`inputs[0]`) at `offset`.
     //
     // FIXME(eddyb) limit this to memory, and scalars, maybe vectors at most.
-    Load,
+    Load {
+        offset: i32,
+    },
 
-    /// Write a single value (`inputs[1]`) to a `QPtr` (`inputs[0]`).
+    /// Write a single value (`inputs[1]`) to a `QPtr` (`inputs[0]`) at `offset`.
     //
     // FIXME(eddyb) limit this to memory, and scalars, maybe vectors at most.
-    Store,
+    Store {
+        offset: i32,
+    },
     //
-    // FIXME(eddyb) implement more ops! at the very least copying!
-    // (and lowering could ignore pointercasts, I guess?)
+    // FIXME(eddyb) implement more ops (e.g. copies).
 }

--- a/src/qptr/mod.rs
+++ b/src/qptr/mod.rs
@@ -13,6 +13,7 @@ use std::rc::Rc;
 // NOTE(eddyb) all the modules are declared here, but they're documented "inside"
 // (i.e. using inner doc comments).
 pub mod analyze;
+pub mod const_data;
 mod layout;
 pub mod lift;
 pub mod lower;

--- a/src/qptr/mod.rs
+++ b/src/qptr/mod.rs
@@ -35,7 +35,7 @@ pub enum QPtrAttr {
     // FIXME(eddyb) reduce usage by modeling more of SPIR-V inside SPIR-T.
     ToSpvPtrInput { input_idx: u32, pointee: OrdAssertEq<Type> },
 
-    /// When applied to a `DataInst` with a `QPtr`-typed output value,
+    /// When applied to a `DataInst` with a single `QPtr`-typed output value,
     /// this describes the original `OpTypePointer` produced by an unknown
     /// SPIR-V instruction (likely creating it, without deriving from an input).
     ///

--- a/src/scalar.rs
+++ b/src/scalar.rs
@@ -1,0 +1,198 @@
+//! Scalar (`bool`, integer, and floating-point) types and associated functionality.
+//!
+//! **Note**: pointers are never scalars (like SPIR-V, but unlike other IRs).
+
+// HACK(eddyb) this could be some `struct` with private fields, but this `enum`
+// is only 2 bytes in size, and has better ergonomics overall.
+#[derive(Copy, Clone, PartialEq, Eq, Hash)]
+pub enum Type {
+    Bool,
+    SInt(IntWidth),
+    UInt(IntWidth),
+    Float(FloatWidth),
+}
+
+impl Type {
+    // HACK(eddyb) only common widths, as a convenience, expand as-needed.
+    pub const S32: Type = Type::SInt(IntWidth::I32);
+    pub const U32: Type = Type::UInt(IntWidth::I32);
+    pub const F32: Type = Type::Float(FloatWidth::F32);
+    pub const F64: Type = Type::Float(FloatWidth::F64);
+
+    pub const fn bit_width(self) -> u32 {
+        match self {
+            Type::Bool => 1,
+            Type::SInt(w) | Type::UInt(w) => w.bits(),
+            Type::Float(w) => w.bits(),
+        }
+    }
+}
+
+/// Bit-width of a supported integer type (only power-of-two multiples of a byte).
+#[derive(Copy, Clone, PartialEq, Eq, Hash)]
+pub struct IntWidth {
+    // HACK(eddyb) this is so compact that only 3 bits of this byte are used
+    // to encode integer types from `i8` to `i128`, and so `Type` could all fit
+    // in one byte, but that'd need a new `enum` for `Bool`/`{S,U}Int`/`Float`.
+    log2_bytes: u8,
+}
+
+impl IntWidth {
+    pub const I8: Self = Self::try_from_bits_unwrap(8);
+    pub const I16: Self = Self::try_from_bits_unwrap(16);
+    pub const I32: Self = Self::try_from_bits_unwrap(32);
+    pub const I64: Self = Self::try_from_bits_unwrap(64);
+    pub const I128: Self = Self::try_from_bits_unwrap(128);
+
+    // FIXME(eddyb) remove when `Option::unwrap` is stabilized.
+    const fn try_from_bits_unwrap(bits: u32) -> Self {
+        match Self::try_from_bits(bits) {
+            Some(w) => w,
+            None => unreachable!(),
+        }
+    }
+
+    pub const fn try_from_bits(bits: u32) -> Option<Self> {
+        if bits % 8 != 0 {
+            return None;
+        }
+        let bytes = bits / 8;
+        match bytes.checked_ilog2() {
+            Some(log2_bytes_u32) => {
+                let log2_bytes = log2_bytes_u32 as u8;
+                assert!(log2_bytes as u32 == log2_bytes_u32);
+                Some(Self { log2_bytes })
+            }
+            None => None,
+        }
+    }
+
+    pub const fn bits(self) -> u32 {
+        8 * (1 << self.log2_bytes)
+    }
+}
+
+/// Bit-width of a supported floating-point type (only power-of-two multiples of a byte).
+#[derive(Copy, Clone, PartialEq, Eq, Hash)]
+pub struct FloatWidth(IntWidth);
+
+impl FloatWidth {
+    pub const F32: Self = Self::try_from_bits_unwrap(32);
+    pub const F64: Self = Self::try_from_bits_unwrap(64);
+
+    // FIXME(eddyb) remove when `Option::unwrap` is stabilized.
+    const fn try_from_bits_unwrap(bits: u32) -> Self {
+        match Self::try_from_bits(bits) {
+            Some(w) => w,
+            None => unreachable!(),
+        }
+    }
+
+    pub const fn try_from_bits(bits: u32) -> Option<Self> {
+        match IntWidth::try_from_bits(bits) {
+            Some(w) => Some(Self(w)),
+            None => None,
+        }
+    }
+
+    pub const fn bits(self) -> u32 {
+        self.0.bits()
+    }
+}
+
+// FIXME(eddyb) document the 128-bit limitations.
+// HACK(eddyb) `(Type, u128)` would waste almost half its size on padding, and
+// packing will only impact accessing the `bits`, while allowing e.g. being
+// wrapped in an outer `enum`, before reaching the same size as `(u128, u128)`.
+#[repr(packed)]
+#[derive(Copy, Clone, PartialEq, Eq, Hash)]
+pub struct Const {
+    ty: Type,
+    bits: u128,
+}
+
+impl Const {
+    pub const FALSE: Const = Const::from_bool(false);
+    pub const TRUE: Const = Const::from_bool(true);
+
+    // FIXME(eddyb) document the panic conditions.
+    // FIXME(eddyb) make this public?
+    const fn from_bits_trunc(ty: Type, bits: u128) -> Const {
+        // FIXME(eddyb) this ensures `Const`s cannot be created when that could
+        // potentially need more than 128 bits for e.g. constant-folding.
+        let width = ty.bit_width();
+        assert!(width <= 128);
+
+        Const { ty, bits: bits & (!0u128 >> (128 - width)) }
+    }
+
+    // FIXME(eddyb) document the panic conditions.
+    pub const fn from_bits(ty: Type, bits: u128) -> Const {
+        let ct_trunc = Const::from_bits_trunc(ty, bits);
+        assert!(ct_trunc.bits == bits);
+        ct_trunc
+    }
+
+    pub const fn try_from_bits(ty: Type, bits: u128) -> Option<Const> {
+        let ct_trunc = Const::from_bits_trunc(ty, bits);
+        if ct_trunc.bits == bits { Some(ct_trunc) } else { None }
+    }
+
+    pub const fn from_bool(v: bool) -> Const {
+        Const::from_bits(Type::Bool, v as u128)
+    }
+
+    pub const fn from_u32(v: u32) -> Const {
+        Const::from_bits(Type::U32, v as u128)
+    }
+
+    /// Returns `Some(ct)` iff `ty` is `{S,U}Int` and can represent `v: i128`
+    /// (i.e. `ct` has the same sign and absolute value as `v` does).
+    pub fn int_try_from_i128(ty: Type, v: i128) -> Option<Const> {
+        let ct_trunc = Const::from_bits_trunc(ty, v as u128);
+        (ct_trunc.int_as_i128() == Some(v)).then_some(ct_trunc)
+    }
+
+    pub const fn ty(&self) -> Type {
+        self.ty
+    }
+
+    pub const fn bits(&self) -> u128 {
+        self.bits
+    }
+
+    /// Returns `Some(v)` iff `self` is `{S,U}Int` and representable by `v: i128`
+    /// (i.e. `self` has the same sign and absolute value as `v` does).
+    pub fn int_as_i128(&self) -> Option<i128> {
+        match self.ty {
+            Type::Bool | Type::Float(_) => None,
+            Type::SInt(_) => {
+                let width = self.ty.bit_width();
+                Some((self.bits as i128) << (128 - width) >> (128 - width))
+            }
+            Type::UInt(_) => self.bits.try_into().ok(),
+        }
+    }
+
+    /// Returns `Some(v)` iff `self` is `{S,U}Int` and representable by `v: u128`
+    /// (i.e. `self` is positive and has the same absolute value as `v` does).
+    pub fn int_as_u128(&self) -> Option<u128> {
+        match self.ty {
+            Type::Bool | Type::Float(_) => None,
+            Type::SInt(_) => self.int_as_i128()?.try_into().ok(),
+            Type::UInt(_) => Some(self.bits),
+        }
+    }
+
+    /// Returns `Some(v)` iff `self` is `{S,U}Int` and representable by `v: i32`
+    /// (i.e. `self` has the same sign and absolute value as `v` does).
+    pub fn int_as_i32(&self) -> Option<i32> {
+        self.int_as_i128()?.try_into().ok()
+    }
+
+    /// Returns `Some(v)` iff `self` is `{S,U}Int` and representable by `v: u32`
+    /// (i.e. `self` is positive and has the same absolute value as `v` does).
+    pub fn int_as_u32(&self) -> Option<u32> {
+        self.int_as_u128()?.try_into().ok()
+    }
+}

--- a/src/spv/canonical.rs
+++ b/src/spv/canonical.rs
@@ -165,7 +165,11 @@ def_mappable_ops! {
 }
 
 impl scalar::Const {
-    fn try_decode_from_spv_imms(ty: scalar::Type, imms: &[spv::Imm]) -> Option<scalar::Const> {
+    // HACK(eddyb) this is not private so `spv::lower` can use it for `OpSwitch`.
+    pub(super) fn try_decode_from_spv_imms(
+        ty: scalar::Type,
+        imms: &[spv::Imm],
+    ) -> Option<scalar::Const> {
         // FIXME(eddyb) don't hardcode the 128-bit limitation,
         // but query `scalar::Const` somehow instead.
         if ty.bit_width() > 128 {
@@ -198,7 +202,8 @@ impl scalar::Const {
         }
     }
 
-    fn encode_as_spv_imms(&self) -> impl Iterator<Item = spv::Imm> {
+    // HACK(eddyb) this is not private so `spv::lift` can use it for `OpSwitch`.
+    pub(super) fn encode_as_spv_imms(&self) -> impl Iterator<Item = spv::Imm> {
         let wk = &spec::Spec::get().well_known;
 
         let ty = self.ty();

--- a/src/spv/canonical.rs
+++ b/src/spv/canonical.rs
@@ -1,0 +1,70 @@
+//! Bidirectional (SPIR-V <-> SPIR-T) "canonical mappings".
+//!
+//! Both directions are defined close together as much as possible, to:
+//! - limit code duplication, making it easy to add more mappings
+//! - limit how much they could even go out of sync over time
+//! - prevent naming e.g. SPIR-V opcodes, outside canonicalization
+//
+// FIXME(eddyb) should interning attempts check/apply these canonicalizations?
+
+use crate::spv::{self, spec};
+use crate::ConstKind;
+use lazy_static::lazy_static;
+
+// FIXME(eddyb) these ones could maybe make use of build script generation.
+macro_rules! def_mappable_ops {
+    ($($op:ident),+ $(,)?) => {
+        #[allow(non_snake_case)]
+        struct MappableOps {
+            $($op: spec::Opcode,)+
+        }
+        impl MappableOps {
+            #[inline(always)]
+            #[must_use]
+            pub fn get() -> &'static MappableOps {
+                lazy_static! {
+                    static ref MAPPABLE_OPS: MappableOps = {
+                        let spv_spec = spec::Spec::get();
+                        MappableOps {
+                            $($op: spv_spec.instructions.lookup(stringify!($op)).unwrap(),)+
+                        }
+                    };
+                }
+                &MAPPABLE_OPS
+            }
+        }
+    };
+}
+def_mappable_ops! {
+    OpUndef,
+}
+
+// FIXME(eddyb) decide on a visibility scope - `pub(super)` avoids some mistakes
+// (using these methods outside of `spv::{lower,lift}`), but may be too restrictive.
+impl spv::Inst {
+    pub(super) fn as_canonical_const(&self) -> Option<ConstKind> {
+        let Self { opcode, imms } = self;
+        let (&opcode, imms) = (opcode, &imms[..]);
+
+        let mo = MappableOps::get();
+
+        if opcode == mo.OpUndef {
+            assert_eq!(imms.len(), 0);
+            Some(ConstKind::Undef)
+        } else {
+            None
+        }
+    }
+
+    pub(super) fn from_canonical_const(const_kind: &ConstKind) -> Option<Self> {
+        let mo = MappableOps::get();
+
+        match const_kind {
+            ConstKind::Undef => Some(mo.OpUndef.into()),
+
+            ConstKind::PtrToGlobalVar(_)
+            | ConstKind::SpvInst { .. }
+            | ConstKind::SpvStringLiteralForExtInst(_) => None,
+        }
+    }
+}

--- a/src/spv/canonical.rs
+++ b/src/spv/canonical.rs
@@ -8,7 +8,7 @@
 // FIXME(eddyb) should interning attempts check/apply these canonicalizations?
 
 use crate::spv::{self, spec};
-use crate::ConstKind;
+use crate::{scalar, ConstKind, Context, Type, TypeKind};
 use lazy_static::lazy_static;
 
 // FIXME(eddyb) these ones could maybe make use of build script generation.
@@ -36,23 +36,174 @@ macro_rules! def_mappable_ops {
     };
 }
 def_mappable_ops! {
+    OpTypeBool,
+    OpTypeInt,
+    OpTypeFloat,
+
     OpUndef,
+    OpConstantFalse,
+    OpConstantTrue,
+    OpConstant,
+}
+
+impl scalar::Const {
+    fn try_decode_from_spv_imms(ty: scalar::Type, imms: &[spv::Imm]) -> Option<scalar::Const> {
+        // FIXME(eddyb) don't hardcode the 128-bit limitation,
+        // but query `scalar::Const` somehow instead.
+        if ty.bit_width() > 128 {
+            return None;
+        }
+        let imm_words = usize::try_from(ty.bit_width().div_ceil(32)).unwrap();
+        if imms.len() != imm_words {
+            return None;
+        }
+        let mut bits = 0;
+        for (i, &imm) in imms.iter().enumerate() {
+            let w = match imm {
+                spv::Imm::Short(_, w) if imm_words == 1 => w,
+                spv::Imm::LongStart(_, w) if i == 0 && imm_words > 1 => w,
+                spv::Imm::LongCont(_, w) if i > 0 => w,
+                _ => return None,
+            };
+            bits |= (w as u128) << (i * 32);
+        }
+
+        // HACK(eddyb) signed integers are encoded sign-extended into immediates.
+        if let scalar::Type::SInt(_) = ty {
+            let imm_width = imm_words * 32;
+            scalar::Const::int_try_from_i128(
+                ty,
+                (bits as i128) << (128 - imm_width) >> (128 - imm_width),
+            )
+        } else {
+            scalar::Const::try_from_bits(ty, bits)
+        }
+    }
+
+    fn encode_as_spv_imms(&self) -> impl Iterator<Item = spv::Imm> {
+        let wk = &spec::Spec::get().well_known;
+
+        let ty = self.ty();
+        let imm_words = ty.bit_width().div_ceil(32);
+
+        let bits = self.bits();
+
+        // HACK(eddyb) signed integers are encoded sign-extended into immediates.
+        let bits = if let scalar::Type::SInt(_) = ty {
+            let imm_width = imm_words * 32;
+            (self.int_as_i128().unwrap() as u128) & (!0 >> (128 - imm_width))
+        } else {
+            bits
+        };
+
+        (0..imm_words).map(move |i| {
+            let k = wk.LiteralContextDependentNumber;
+            let w = (bits >> (i * 32)) as u32;
+            if imm_words == 1 {
+                spv::Imm::Short(k, w)
+            } else if i == 0 {
+                spv::Imm::LongStart(k, w)
+            } else {
+                spv::Imm::LongCont(k, w)
+            }
+        })
+    }
 }
 
 // FIXME(eddyb) decide on a visibility scope - `pub(super)` avoids some mistakes
 // (using these methods outside of `spv::{lower,lift}`), but may be too restrictive.
 impl spv::Inst {
-    pub(super) fn as_canonical_const(&self) -> Option<ConstKind> {
+    // HACK(eddyb) exported only for `spv::read`/`LiteralContextDependentNumber`.
+    pub(super) fn int_or_float_type_bit_width(&self) -> Option<u32> {
+        let mo = MappableOps::get();
+
+        match self.imms[..] {
+            [spv::Imm::Short(_, bit_width), _] if self.opcode == mo.OpTypeInt => Some(bit_width),
+            [spv::Imm::Short(_, bit_width)] if self.opcode == mo.OpTypeFloat => Some(bit_width),
+            _ => None,
+        }
+    }
+
+    // FIXME(eddyb) automate bidirectional mappings more (although the need
+    // for conditional, i.e. "partial", mappings, adds a lot of complexity).
+    pub(super) fn as_canonical_type(&self) -> Option<TypeKind> {
         let Self { opcode, imms } = self;
         let (&opcode, imms) = (opcode, &imms[..]);
 
         let mo = MappableOps::get();
 
-        if opcode == mo.OpUndef {
-            assert_eq!(imms.len(), 0);
-            Some(ConstKind::Undef)
-        } else {
-            None
+        let int_width = || scalar::IntWidth::try_from_bits(self.int_or_float_type_bit_width()?);
+        match imms {
+            [] if opcode == mo.OpTypeBool => Some(scalar::Type::Bool.into()),
+            &[_, spv::Imm::Short(_, 0)] if opcode == mo.OpTypeInt => {
+                Some(scalar::Type::UInt(int_width()?).into())
+            }
+            &[_, spv::Imm::Short(_, 1)] if opcode == mo.OpTypeInt => {
+                Some(scalar::Type::SInt(int_width()?).into())
+            }
+            [_] if opcode == mo.OpTypeFloat => Some(
+                scalar::Type::Float(scalar::FloatWidth::try_from_bits(
+                    self.int_or_float_type_bit_width()?,
+                )?)
+                .into(),
+            ),
+            _ => None,
+        }
+    }
+
+    pub(super) fn from_canonical_type(type_kind: &TypeKind) -> Option<Self> {
+        let wk = &spec::Spec::get().well_known;
+        let mo = MappableOps::get();
+
+        match type_kind {
+            &TypeKind::Scalar(ty) => match ty {
+                scalar::Type::Bool => Some(mo.OpTypeBool.into()),
+                scalar::Type::SInt(w) | scalar::Type::UInt(w) => Some(spv::Inst {
+                    opcode: mo.OpTypeInt,
+                    imms: [
+                        spv::Imm::Short(wk.LiteralInteger, w.bits()),
+                        spv::Imm::Short(
+                            wk.LiteralInteger,
+                            matches!(ty, scalar::Type::SInt(_)) as u32,
+                        ),
+                    ]
+                    .into_iter()
+                    .collect(),
+                }),
+                scalar::Type::Float(w) => Some(spv::Inst {
+                    opcode: mo.OpTypeFloat,
+                    imms: [spv::Imm::Short(wk.LiteralInteger, w.bits())].into_iter().collect(),
+                }),
+            },
+
+            TypeKind::QPtr | TypeKind::SpvInst { .. } | TypeKind::SpvStringLiteralForExtInst => {
+                None
+            }
+        }
+    }
+
+    // HACK(eddyb) this only exists as a helper for `spv::lower`.
+    pub(super) fn always_lower_as_const(&self) -> bool {
+        let mo = MappableOps::get();
+        mo.OpUndef == self.opcode
+    }
+
+    // FIXME(eddyb) automate bidirectional mappings more (although the need
+    // for conditional, i.e. "partial", mappings, adds a lot of complexity).
+    pub(super) fn as_canonical_const(&self, cx: &Context, ty: Type) -> Option<ConstKind> {
+        let Self { opcode, imms } = self;
+        let (&opcode, imms) = (opcode, &imms[..]);
+
+        let mo = MappableOps::get();
+
+        match imms {
+            [] if opcode == mo.OpUndef => Some(ConstKind::Undef),
+            [] if opcode == mo.OpConstantFalse => Some(scalar::Const::FALSE.into()),
+            [] if opcode == mo.OpConstantTrue => Some(scalar::Const::TRUE.into()),
+            _ if opcode == mo.OpConstant => {
+                Some(scalar::Const::try_decode_from_spv_imms(ty.as_scalar(cx)?, imms)?.into())
+            }
+            _ => None,
         }
     }
 
@@ -61,6 +212,11 @@ impl spv::Inst {
 
         match const_kind {
             ConstKind::Undef => Some(mo.OpUndef.into()),
+            ConstKind::Scalar(scalar::Const::FALSE) => Some(mo.OpConstantFalse.into()),
+            ConstKind::Scalar(scalar::Const::TRUE) => Some(mo.OpConstantTrue.into()),
+            ConstKind::Scalar(ct) => {
+                Some(spv::Inst { opcode: mo.OpConstant, imms: ct.encode_as_spv_imms().collect() })
+            }
 
             ConstKind::PtrToGlobalVar(_)
             | ConstKind::SpvInst { .. }

--- a/src/spv/lift.rs
+++ b/src/spv/lift.rs
@@ -7,15 +7,15 @@ use crate::{
     cfg, scalar, AddrSpace, Attr, AttrSet, Const, ConstDef, ConstKind, Context, ControlNode,
     ControlNodeKind, ControlNodeOutputDecl, ControlRegion, ControlRegionInputDecl, DataInst,
     DataInstDef, DataInstForm, DataInstFormDef, DataInstKind, DeclDef, EntityList, ExportKey,
-    Exportee, Func, FuncDecl, FuncParam, FxIndexMap, FxIndexSet, GlobalVar, GlobalVarDefBody,
-    Import, Module, ModuleDebugInfo, ModuleDialect, SelectionKind, Type, TypeDef, TypeKind,
-    TypeOrConst, Value,
+    Exportee, Func, FuncDecl, FuncDefBody, FuncParam, FxIndexMap, FxIndexSet, GlobalVar,
+    GlobalVarDefBody, Import, Module, ModuleDebugInfo, ModuleDialect, SelectionKind, Type, TypeDef,
+    TypeKind, TypeOrConst, Value,
 };
 use rustc_hash::FxHashMap;
 use smallvec::SmallVec;
 use std::borrow::Cow;
-use std::collections::{BTreeMap, BTreeSet};
-use std::num::NonZeroU32;
+use std::collections::BTreeMap;
+use std::num::NonZeroUsize;
 use std::path::Path;
 use std::{io, iter, mem, slice};
 
@@ -75,34 +75,29 @@ impl spv::ModuleDebugInfo {
     }
 }
 
-impl FuncDecl {
-    fn spv_func_type(&self, cx: &Context) -> Type {
-        let wk = &spec::Spec::get().well_known;
-
-        cx.intern(TypeDef {
-            attrs: AttrSet::default(),
-            kind: TypeKind::SpvInst {
-                spv_inst: wk.OpTypeFunction.into(),
-                type_and_const_inputs: iter::once(self.ret_type)
-                    .chain(self.params.iter().map(|param| param.ty))
-                    .map(TypeOrConst::Type)
-                    .collect(),
-            },
-        })
-    }
-}
-
-struct NeedsIdsCollector<'a> {
+struct IdAllocator<'a, AI: FnMut() -> spv::Id> {
     cx: &'a Context,
     module: &'a Module,
 
-    ext_inst_imports: BTreeSet<&'a str>,
-    debug_strings: BTreeSet<&'a str>,
+    /// ID allocation callback, kept as a closure (instead of having its state
+    /// be part of `IdAllocator`) to avoid misuse.
+    alloc_id: AI,
 
-    globals: FxIndexSet<Global>,
+    ids: ModuleIds<'a>,
+
     data_inst_forms_seen: FxIndexSet<DataInstForm>,
     global_vars_seen: FxIndexSet<GlobalVar>,
-    funcs: FxIndexSet<Func>,
+}
+
+#[derive(Default)]
+struct ModuleIds<'a> {
+    ext_inst_imports: BTreeMap<&'a str, spv::Id>,
+    debug_strings: BTreeMap<&'a str, spv::Id>,
+
+    // FIXME(eddyb) use `EntityOrientedDenseMap` here.
+    globals: FxIndexMap<Global, spv::Id>,
+    // FIXME(eddyb) use `EntityOrientedDenseMap` here.
+    funcs: FxIndexMap<Func, FuncIds<'a>>,
 }
 
 #[derive(Copy, Clone, PartialEq, Eq, Hash)]
@@ -111,13 +106,27 @@ enum Global {
     Const(Const),
 }
 
-impl Visitor<'_> for NeedsIdsCollector<'_> {
+// FIXME(eddyb) should this use ID ranges instead of `SmallVec<[spv::Id; 4]>`?
+// FIXME(eddyb) this is inconsistently named with `FuncBodyLifting`.
+struct FuncIds<'a> {
+    spv_func_ret_type: Type,
+    // FIXME(eddyb) should we even be interning an `OpTypeFunction` in `Context`?
+    // (it's easier this way, but it could also be tracked in `ModuleIds`)
+    spv_func_type: Type,
+
+    func_id: spv::Id,
+    param_ids: SmallVec<[spv::Id; 4]>,
+
+    body: Option<FuncBodyLifting<'a>>,
+}
+
+impl<AI: FnMut() -> spv::Id> Visitor<'_> for IdAllocator<'_, AI> {
     fn visit_attr_set_use(&mut self, attrs: AttrSet) {
         self.visit_attr_set_def(&self.cx[attrs]);
     }
     fn visit_type_use(&mut self, ty: Type) {
         let global = Global::Type(ty);
-        if self.globals.contains(&global) {
+        if self.ids.globals.contains_key(&global) {
             return;
         }
         let ty_def = &self.cx[ty];
@@ -153,11 +162,11 @@ impl Visitor<'_> for NeedsIdsCollector<'_> {
         }
 
         self.visit_type_def(ty_def);
-        self.globals.insert(global);
+        self.ids.globals.insert(global, (self.alloc_id)());
     }
     fn visit_const_use(&mut self, ct: Const) {
         let global = Global::Const(ct);
-        if self.globals.contains(&global) {
+        if self.ids.globals.contains_key(&global) {
             return;
         }
         let ct_def = &self.cx[ct];
@@ -179,7 +188,7 @@ impl Visitor<'_> for NeedsIdsCollector<'_> {
             | ConstKind::PtrToGlobalVar(_)
             | ConstKind::SpvInst { .. } => {
                 self.visit_const_def(ct_def);
-                self.globals.insert(global);
+                self.ids.globals.insert(global, (self.alloc_id)());
             }
 
             // HACK(eddyb) because this is an `OpString` and needs to go earlier
@@ -197,7 +206,7 @@ impl Visitor<'_> for NeedsIdsCollector<'_> {
                         }
                 );
 
-                self.debug_strings.insert(&self.cx[s]);
+                self.ids.debug_strings.entry(&self.cx[s]).or_insert_with(&mut self.alloc_id);
             }
         }
     }
@@ -213,24 +222,55 @@ impl Visitor<'_> for NeedsIdsCollector<'_> {
         }
     }
     fn visit_func_use(&mut self, func: Func) {
-        if self.funcs.contains(&func) {
+        if self.ids.funcs.contains_key(&func) {
             return;
         }
-        // NOTE(eddyb) inserting first results in a different function ordering
-        // in the resulting module, but the order doesn't matter, and we need
-        // to avoid infinite recursion for recursive functions.
-        self.funcs.insert(func);
-
         let func_decl = &self.module.funcs[func];
-        // FIXME(eddyb) should this be cached in `self.funcs`?
-        self.visit_type_use(func_decl.spv_func_type(self.cx));
+
+        // Synthesize an `OpTypeFunction` type (that SPIR-T itself doesn't carry).
+        let wk = &spec::Spec::get().well_known;
+        let spv_func_ret_type = func_decl.ret_type;
+        let spv_func_type = self.cx.intern(TypeKind::SpvInst {
+            spv_inst: wk.OpTypeFunction.into(),
+            type_and_const_inputs: iter::once(spv_func_ret_type)
+                .chain(func_decl.params.iter().map(|param| param.ty))
+                .map(TypeOrConst::Type)
+                .collect(),
+        });
+        self.visit_type_use(spv_func_type);
+
+        // NOTE(eddyb) inserting first produces a different function ordering
+        // overall in the final module, but the order doesn't matter, and we
+        // need to avoid infinite recursion for recursive functions.
+        self.ids.funcs.insert(
+            func,
+            FuncIds {
+                spv_func_ret_type,
+                spv_func_type,
+                func_id: (self.alloc_id)(),
+                param_ids: func_decl.params.iter().map(|_| (self.alloc_id)()).collect(),
+                body: None,
+            },
+        );
+
         self.visit_func_decl(func_decl);
+
+        // Handle the body last, to minimize recursion hazards (see comment above).
+        match &func_decl.def {
+            DeclDef::Imported(_) => {}
+            DeclDef::Present(func_def_body) => {
+                let func_body_lifting = FuncBodyLifting::from_func_def_body(self, func_def_body);
+                self.ids.funcs.get_mut(&func).unwrap().body = Some(func_body_lifting);
+            }
+        }
     }
 
     fn visit_spv_module_debug_info(&mut self, debug_info: &spv::ModuleDebugInfo) {
         for sources in debug_info.source_languages.values() {
             // The file operand of `OpSource` has to point to an `OpString`.
-            self.debug_strings.extend(sources.file_contents.keys().copied().map(|s| &self.cx[s]));
+            for &s in sources.file_contents.keys() {
+                self.ids.debug_strings.entry(&self.cx[s]).or_insert_with(&mut self.alloc_id);
+            }
         }
     }
     fn visit_attr(&mut self, attr: &Attr) {
@@ -240,7 +280,10 @@ impl Visitor<'_> for NeedsIdsCollector<'_> {
             | Attr::SpvAnnotation { .. }
             | Attr::SpvBitflagsOperand(_) => {}
             Attr::SpvDebugLine { file_path, .. } => {
-                self.debug_strings.insert(&self.cx[file_path.0]);
+                self.ids
+                    .debug_strings
+                    .entry(&self.cx[file_path.0])
+                    .or_insert_with(&mut self.alloc_id);
             }
         }
         attr.inner_visit_with(self);
@@ -260,28 +303,18 @@ impl Visitor<'_> for NeedsIdsCollector<'_> {
             | DataInstKind::SpvInst(_) => {}
 
             DataInstKind::SpvExtInst { ext_set, .. } => {
-                self.ext_inst_imports.insert(&self.cx[ext_set]);
+                self.ids
+                    .ext_inst_imports
+                    .entry(&self.cx[ext_set])
+                    .or_insert_with(&mut self.alloc_id);
             }
         }
         data_inst_form_def.inner_visit_with(self);
     }
 }
 
-struct AllocatedIds<'a> {
-    ext_inst_imports: BTreeMap<&'a str, spv::Id>,
-    debug_strings: BTreeMap<&'a str, spv::Id>,
-
-    // FIXME(eddyb) use `EntityOrientedDenseMap` here.
-    globals: FxIndexMap<Global, spv::Id>,
-    // FIXME(eddyb) use `EntityOrientedDenseMap` here.
-    funcs: FxIndexMap<Func, FuncLifting<'a>>,
-}
-
-// FIXME(eddyb) should this use ID ranges instead of `SmallVec<[spv::Id; 4]>`?
-struct FuncLifting<'a> {
-    func_id: spv::Id,
-    param_ids: SmallVec<[spv::Id; 4]>,
-
+// FIXME(eddyb) this is inconsistently named with `FuncIds`.
+struct FuncBodyLifting<'a> {
     // FIXME(eddyb) use `EntityOrientedDenseMap` here.
     region_inputs_source: FxHashMap<ControlRegion, RegionInputsSource>,
     // FIXME(eddyb) use `EntityOrientedDenseMap` here.
@@ -381,42 +414,6 @@ enum Merge<L> {
     },
 }
 
-impl<'a> NeedsIdsCollector<'a> {
-    fn alloc_ids<E>(
-        self,
-        mut alloc_id: impl FnMut() -> Result<spv::Id, E>,
-    ) -> Result<AllocatedIds<'a>, E> {
-        let Self {
-            cx,
-            module,
-            ext_inst_imports,
-            debug_strings,
-            globals,
-            data_inst_forms_seen: _,
-            global_vars_seen: _,
-            funcs,
-        } = self;
-
-        Ok(AllocatedIds {
-            ext_inst_imports: ext_inst_imports
-                .into_iter()
-                .map(|name| Ok((name, alloc_id()?)))
-                .collect::<Result<_, _>>()?,
-            debug_strings: debug_strings
-                .into_iter()
-                .map(|s| Ok((s, alloc_id()?)))
-                .collect::<Result<_, _>>()?,
-            globals: globals.into_iter().map(|g| Ok((g, alloc_id()?))).collect::<Result<_, _>>()?,
-            funcs: funcs
-                .into_iter()
-                .map(|func| {
-                    Ok((func, FuncLifting::from_func_decl(cx, &module.funcs[func], &mut alloc_id)?))
-                })
-                .collect::<Result<_, _>>()?,
-        })
-    }
-}
-
 /// Helper type for deep traversal of the CFG (as a graph of [`CfgPoint`]s), which
 /// tracks the necessary context for navigating a [`ControlRegion`]/[`ControlNode`].
 #[derive(Copy, Clone)]
@@ -494,41 +491,37 @@ impl<'a, 'p> FuncAt<'a, CfgCursor<'p>> {
 impl<'a> FuncAt<'a, ControlRegion> {
     /// Traverse every [`CfgPoint`] (deeply) contained in this [`ControlRegion`],
     /// in reverse post-order (RPO), with `f` receiving each [`CfgPoint`]
-    /// in turn (wrapped in [`CfgCursor`], for further traversal flexibility),
-    /// and being able to stop iteration by returning `Err`.
+    /// in turn (wrapped in [`CfgCursor`], for further traversal flexibility).
     ///
     /// RPO iteration over a CFG provides certain guarantees, most importantly
     /// that SSA definitions are visited before any of their uses.
-    fn rev_post_order_try_for_each<E>(
-        self,
-        mut f: impl FnMut(CfgCursor<'_>) -> Result<(), E>,
-    ) -> Result<(), E> {
-        self.rev_post_order_try_for_each_inner(&mut f, None)
+    fn rev_post_order_for_each(self, mut f: impl FnMut(CfgCursor<'_>)) {
+        self.rev_post_order_for_each_inner(&mut f, None);
     }
 
-    fn rev_post_order_try_for_each_inner<E>(
+    fn rev_post_order_for_each_inner(
         self,
-        f: &mut impl FnMut(CfgCursor<'_>) -> Result<(), E>,
+        f: &mut impl FnMut(CfgCursor<'_>),
         parent: Option<&CfgCursor<'_, ControlParent>>,
-    ) -> Result<(), E> {
+    ) {
         let region = self.position;
-        f(CfgCursor { point: CfgPoint::RegionEntry(region), parent })?;
+        f(CfgCursor { point: CfgPoint::RegionEntry(region), parent });
         for func_at_control_node in self.at_children() {
-            func_at_control_node.rev_post_order_try_for_each_inner(
+            func_at_control_node.rev_post_order_for_each_inner(
                 f,
                 &CfgCursor { point: ControlParent::Region(region), parent },
-            )?;
+            );
         }
-        f(CfgCursor { point: CfgPoint::RegionExit(region), parent })
+        f(CfgCursor { point: CfgPoint::RegionExit(region), parent });
     }
 }
 
 impl<'a> FuncAt<'a, ControlNode> {
-    fn rev_post_order_try_for_each_inner<E>(
+    fn rev_post_order_for_each_inner(
         self,
-        f: &mut impl FnMut(CfgCursor<'_>) -> Result<(), E>,
+        f: &mut impl FnMut(CfgCursor<'_>),
         parent: &CfgCursor<'_, ControlParent>,
-    ) -> Result<(), E> {
+    ) {
         let child_regions: &[_] = match &self.def().kind {
             ControlNodeKind::Block { .. } => &[],
             ControlNodeKind::Select { cases, .. } => cases,
@@ -537,39 +530,23 @@ impl<'a> FuncAt<'a, ControlNode> {
 
         let control_node = self.position;
         let parent = Some(parent);
-        f(CfgCursor { point: CfgPoint::ControlNodeEntry(control_node), parent })?;
+        f(CfgCursor { point: CfgPoint::ControlNodeEntry(control_node), parent });
         for &region in child_regions {
-            self.at(region).rev_post_order_try_for_each_inner(
+            self.at(region).rev_post_order_for_each_inner(
                 f,
                 Some(&CfgCursor { point: ControlParent::ControlNode(control_node), parent }),
-            )?;
+            );
         }
-        f(CfgCursor { point: CfgPoint::ControlNodeExit(control_node), parent })
+        f(CfgCursor { point: CfgPoint::ControlNodeExit(control_node), parent });
     }
 }
 
-impl<'a> FuncLifting<'a> {
-    fn from_func_decl<E>(
-        cx: &Context,
-        func_decl: &'a FuncDecl,
-        mut alloc_id: impl FnMut() -> Result<spv::Id, E>,
-    ) -> Result<Self, E> {
-        let func_id = alloc_id()?;
-        let param_ids = func_decl.params.iter().map(|_| alloc_id()).collect::<Result<_, _>>()?;
-
-        let func_def_body = match &func_decl.def {
-            DeclDef::Imported(_) => {
-                return Ok(Self {
-                    func_id,
-                    param_ids,
-                    region_inputs_source: Default::default(),
-                    data_inst_output_ids: Default::default(),
-                    label_ids: Default::default(),
-                    blocks: Default::default(),
-                });
-            }
-            DeclDef::Present(def) => def,
-        };
+impl<'a> FuncBodyLifting<'a> {
+    fn from_func_def_body(
+        id_allocator: &mut IdAllocator<'_, impl FnMut() -> spv::Id>,
+        func_def_body: &'a FuncDefBody,
+    ) -> Self {
+        let cx = id_allocator.cx;
 
         let mut region_inputs_source = FxHashMap::default();
         region_inputs_source.insert(func_def_body.body, RegionInputsSource::FuncParams);
@@ -590,17 +567,15 @@ impl<'a> FuncLifting<'a> {
                             .def()
                             .inputs
                             .iter()
-                            .map(|&ControlRegionInputDecl { attrs, ty }| {
-                                Ok(Phi {
-                                    attrs,
-                                    ty,
+                            .map(|&ControlRegionInputDecl { attrs, ty }| Phi {
+                                attrs,
+                                ty,
 
-                                    result_id: alloc_id()?,
-                                    cases: FxIndexMap::default(),
-                                    default_value: None,
-                                })
+                                result_id: (id_allocator.alloc_id)(),
+                                cases: FxIndexMap::default(),
+                                default_value: None,
                             })
-                            .collect::<Result<_, _>>()?
+                            .collect()
                     }
                 }
                 CfgPoint::RegionExit(_) => SmallVec::new(),
@@ -624,17 +599,15 @@ impl<'a> FuncLifting<'a> {
                             loop_body_inputs
                                 .iter()
                                 .enumerate()
-                                .map(|(i, &ControlRegionInputDecl { attrs, ty })| {
-                                    Ok(Phi {
-                                        attrs,
-                                        ty,
+                                .map(|(i, &ControlRegionInputDecl { attrs, ty })| Phi {
+                                    attrs,
+                                    ty,
 
-                                        result_id: alloc_id()?,
-                                        cases: FxIndexMap::default(),
-                                        default_value: Some(initial_inputs[i]),
-                                    })
+                                    result_id: (id_allocator.alloc_id)(),
+                                    cases: FxIndexMap::default(),
+                                    default_value: Some(initial_inputs[i]),
                                 })
-                                .collect::<Result<_, _>>()?
+                                .collect()
                         }
                         _ => SmallVec::new(),
                     }
@@ -644,17 +617,15 @@ impl<'a> FuncLifting<'a> {
                     .def()
                     .outputs
                     .iter()
-                    .map(|&ControlNodeOutputDecl { attrs, ty }| {
-                        Ok(Phi {
-                            attrs,
-                            ty,
+                    .map(|&ControlNodeOutputDecl { attrs, ty }| Phi {
+                        attrs,
+                        ty,
 
-                            result_id: alloc_id()?,
-                            cases: FxIndexMap::default(),
-                            default_value: None,
-                        })
+                        result_id: (id_allocator.alloc_id)(),
+                        cases: FxIndexMap::default(),
+                        default_value: None,
                     })
-                    .collect::<Result<_, _>>()?,
+                    .collect(),
             };
 
             let insts = match point {
@@ -836,14 +807,14 @@ impl<'a> FuncLifting<'a> {
             };
 
             blocks.insert(point, BlockLifting { phis, insts, terminator });
-
-            Ok(())
         };
         match &func_def_body.unstructured_cfg {
-            None => func_def_body.at_body().rev_post_order_try_for_each(visit_cfg_point)?,
+            None => {
+                func_def_body.at_body().rev_post_order_for_each(visit_cfg_point);
+            }
             Some(cfg) => {
                 for region in cfg.rev_post_order(func_def_body) {
-                    func_def_body.at(region).rev_post_order_try_for_each(&mut visit_cfg_point)?;
+                    func_def_body.at(region).rev_post_order_for_each(&mut visit_cfg_point);
                 }
             }
         }
@@ -986,31 +957,26 @@ impl<'a> FuncLifting<'a> {
             .filter(|&func_at_inst| cx[func_at_inst.def().form].output_type.is_some())
             .map(|func_at_inst| func_at_inst.position);
 
-        Ok(Self {
-            func_id,
-            param_ids,
+        Self {
             region_inputs_source,
             data_inst_output_ids: all_insts_with_output
-                .map(|inst| Ok((inst, alloc_id()?)))
-                .collect::<Result<_, _>>()?,
-            label_ids: blocks
-                .keys()
-                .map(|&point| Ok((point, alloc_id()?)))
-                .collect::<Result<_, _>>()?,
+                .map(|inst| (inst, (id_allocator.alloc_id)()))
+                .collect(),
+            label_ids: blocks.keys().map(|&point| (point, (id_allocator.alloc_id)())).collect(),
             blocks,
-        })
+        }
     }
 }
 
-/// "Maybe-decorated "lazy" SPIR-V instruction, allowing separately emitting
+/// Maybe-decorated "lazy" SPIR-V instruction, allowing separately emitting
 /// decorations from attributes, and the instruction itself, without eagerly
 /// allocating all the instructions.
 #[derive(Copy, Clone)]
 enum LazyInst<'a, 'b> {
     Global(Global),
     OpFunction {
-        func_id: spv::Id,
         func_decl: &'a FuncDecl,
+        func_ids: &'b FuncIds<'a>,
     },
     OpFunctionParameter {
         param_id: spv::Id,
@@ -1020,17 +986,17 @@ enum LazyInst<'a, 'b> {
         label_id: spv::Id,
     },
     OpPhi {
-        parent_func: &'b FuncLifting<'a>,
+        parent_func_ids: &'b FuncIds<'a>,
         phi: &'b Phi,
     },
     DataInst {
-        parent_func: &'b FuncLifting<'a>,
+        parent_func_ids: &'b FuncIds<'a>,
         result_id: Option<spv::Id>,
         data_inst_def: &'a DataInstDef,
     },
     Merge(Merge<spv::Id>),
     Terminator {
-        parent_func: &'b FuncLifting<'a>,
+        parent_func_ids: &'b FuncIds<'a>,
         terminator: &'b Terminator<'a>,
     },
     OpFunctionEnd,
@@ -1040,7 +1006,7 @@ impl LazyInst<'_, '_> {
     fn result_id_attrs_and_import(
         self,
         module: &Module,
-        ids: &AllocatedIds<'_>,
+        ids: &ModuleIds<'_>,
     ) -> (Option<spv::Id>, AttrSet, Option<Import>) {
         let cx = module.cx_ref();
 
@@ -1073,21 +1039,21 @@ impl LazyInst<'_, '_> {
                 };
                 (Some(ids.globals[&global]), attrs, import)
             }
-            Self::OpFunction { func_id, func_decl } => {
+            Self::OpFunction { func_decl, func_ids } => {
                 let import = match func_decl.def {
                     DeclDef::Imported(import) => Some(import),
                     DeclDef::Present(_) => None,
                 };
-                (Some(func_id), func_decl.attrs, import)
+                (Some(func_ids.func_id), func_decl.attrs, import)
             }
             Self::OpFunctionParameter { param_id, param } => (Some(param_id), param.attrs, None),
             Self::OpLabel { label_id } => (Some(label_id), AttrSet::default(), None),
-            Self::OpPhi { parent_func: _, phi } => (Some(phi.result_id), phi.attrs, None),
-            Self::DataInst { parent_func: _, result_id, data_inst_def } => {
+            Self::OpPhi { parent_func_ids: _, phi } => (Some(phi.result_id), phi.attrs, None),
+            Self::DataInst { parent_func_ids: _, result_id, data_inst_def } => {
                 (result_id, data_inst_def.attrs, None)
             }
             Self::Merge(_) => (None, AttrSet::default(), None),
-            Self::Terminator { parent_func: _, terminator } => (None, terminator.attrs, None),
+            Self::Terminator { parent_func_ids: _, terminator } => (None, terminator.attrs, None),
             Self::OpFunctionEnd => (None, AttrSet::default(), None),
         }
     }
@@ -1095,12 +1061,12 @@ impl LazyInst<'_, '_> {
     fn to_inst_and_attrs(
         self,
         module: &Module,
-        ids: &AllocatedIds<'_>,
+        ids: &ModuleIds<'_>,
     ) -> (spv::InstWithIds, AttrSet) {
         let wk = &spec::Spec::get().well_known;
         let cx = module.cx_ref();
 
-        let value_to_id = |parent_func: &FuncLifting<'_>, v| match v {
+        let value_to_id = |parent_func_ids: &FuncIds<'_>, v| match v {
             Value::Const(ct) => match cx[ct].kind {
                 ConstKind::SpvStringLiteralForExtInst(s) => ids.debug_strings[&cx[s]],
 
@@ -1108,23 +1074,30 @@ impl LazyInst<'_, '_> {
             },
             Value::ControlRegionInput { region, input_idx } => {
                 let input_idx = usize::try_from(input_idx).unwrap();
-                match parent_func.region_inputs_source.get(&region) {
-                    Some(RegionInputsSource::FuncParams) => parent_func.param_ids[input_idx],
+                let parent_func_body_lifting = parent_func_ids.body.as_ref().unwrap();
+                match parent_func_body_lifting.region_inputs_source.get(&region) {
+                    Some(RegionInputsSource::FuncParams) => parent_func_ids.param_ids[input_idx],
                     Some(&RegionInputsSource::LoopHeaderPhis(loop_node)) => {
-                        parent_func.blocks[&CfgPoint::ControlNodeEntry(loop_node)].phis[input_idx]
+                        parent_func_body_lifting.blocks[&CfgPoint::ControlNodeEntry(loop_node)].phis
+                            [input_idx]
                             .result_id
                     }
                     None => {
-                        parent_func.blocks[&CfgPoint::RegionEntry(region)].phis[input_idx].result_id
+                        parent_func_body_lifting.blocks[&CfgPoint::RegionEntry(region)].phis
+                            [input_idx]
+                            .result_id
                     }
                 }
             }
             Value::ControlNodeOutput { control_node, output_idx } => {
-                parent_func.blocks[&CfgPoint::ControlNodeExit(control_node)].phis
-                    [usize::try_from(output_idx).unwrap()]
+                parent_func_ids.body.as_ref().unwrap().blocks
+                    [&CfgPoint::ControlNodeExit(control_node)]
+                    .phis[usize::try_from(output_idx).unwrap()]
                 .result_id
             }
-            Value::DataInstOutput(inst) => parent_func.data_inst_output_ids[&inst],
+            Value::DataInstOutput(inst) => {
+                parent_func_ids.body.as_ref().unwrap().data_inst_output_ids[&inst]
+            }
         };
 
         let (result_id, attrs, _) = self.result_id_attrs_and_import(module, ids);
@@ -1233,7 +1206,7 @@ impl LazyInst<'_, '_> {
                     }
                 }
             },
-            Self::OpFunction { func_id: _, func_decl } => {
+            Self::OpFunction { func_decl: _, func_ids } => {
                 // FIXME(eddyb) make this less of a search and more of a
                 // lookup by splitting attrs into key and value parts.
                 let func_ctrl = cx[attrs]
@@ -1254,10 +1227,9 @@ impl LazyInst<'_, '_> {
                         opcode: wk.OpFunction,
                         imms: iter::once(spv::Imm::Short(wk.FunctionControl, func_ctrl)).collect(),
                     },
-                    result_type_id: Some(ids.globals[&Global::Type(func_decl.ret_type)]),
+                    result_type_id: Some(ids.globals[&Global::Type(func_ids.spv_func_ret_type)]),
                     result_id,
-                    ids: iter::once(ids.globals[&Global::Type(func_decl.spv_func_type(cx))])
-                        .collect(),
+                    ids: iter::once(ids.globals[&Global::Type(func_ids.spv_func_type)]).collect(),
                 }
             }
             Self::OpFunctionParameter { param_id: _, param } => spv::InstWithIds {
@@ -1272,7 +1244,7 @@ impl LazyInst<'_, '_> {
                 result_id,
                 ids: [].into_iter().collect(),
             },
-            Self::OpPhi { parent_func, phi } => spv::InstWithIds {
+            Self::OpPhi { parent_func_ids, phi } => spv::InstWithIds {
                 without_ids: wk.OpPhi.into(),
                 result_type_id: Some(ids.globals[&Global::Type(phi.ty)]),
                 result_id: Some(phi.result_id),
@@ -1280,11 +1252,14 @@ impl LazyInst<'_, '_> {
                     .cases
                     .iter()
                     .flat_map(|(&source_point, &v)| {
-                        [value_to_id(parent_func, v), parent_func.label_ids[&source_point]]
+                        [
+                            value_to_id(parent_func_ids, v),
+                            parent_func_ids.body.as_ref().unwrap().label_ids[&source_point],
+                        ]
                     })
                     .collect(),
             },
-            Self::DataInst { parent_func, result_id: _, data_inst_def } => {
+            Self::DataInst { parent_func_ids, result_id: _, data_inst_def } => {
                 let DataInstFormDef { kind, output_type } = &cx[data_inst_def.form];
                 let (inst, extra_initial_id_operand) =
                     match spv::Inst::from_canonical_data_inst_kind(kind).ok_or(kind) {
@@ -1316,7 +1291,9 @@ impl LazyInst<'_, '_> {
                     result_id,
                     ids: extra_initial_id_operand
                         .into_iter()
-                        .chain(data_inst_def.inputs.iter().map(|&v| value_to_id(parent_func, v)))
+                        .chain(
+                            data_inst_def.inputs.iter().map(|&v| value_to_id(parent_func_ids, v)),
+                        )
                         .collect(),
                 }
             }
@@ -1341,12 +1318,18 @@ impl LazyInst<'_, '_> {
                 result_id: None,
                 ids: [merge_label_id, continue_label_id].into_iter().collect(),
             },
-            Self::Terminator { parent_func, terminator } => {
+            Self::Terminator { parent_func_ids, terminator } => {
+                let parent_func_body_lifting = parent_func_ids.body.as_ref().unwrap();
                 let mut ids: SmallVec<[_; 4]> = terminator
                     .inputs
                     .iter()
-                    .map(|&v| value_to_id(parent_func, v))
-                    .chain(terminator.targets.iter().map(|&target| parent_func.label_ids[&target]))
+                    .map(|&v| value_to_id(parent_func_ids, v))
+                    .chain(
+                        terminator
+                            .targets
+                            .iter()
+                            .map(|&target| parent_func_body_lifting.label_ids[&target]),
+                    )
                     .collect();
 
                 // FIXME(eddyb) move some of this to `spv::canonical`.
@@ -1418,19 +1401,6 @@ impl Module {
             }
         };
 
-        // Collect uses scattered throughout the module, that require def IDs.
-        let mut needs_ids_collector = NeedsIdsCollector {
-            cx: &cx,
-            module: self,
-            ext_inst_imports: BTreeSet::new(),
-            debug_strings: BTreeSet::new(),
-            globals: FxIndexSet::default(),
-            data_inst_forms_seen: FxIndexSet::default(),
-            global_vars_seen: FxIndexSet::default(),
-            funcs: FxIndexSet::default(),
-        };
-        needs_ids_collector.visit_module(self);
-
         // Because `GlobalVar`s are given IDs by the `Const`s that point to them
         // (i.e. `ConstKind::PtrToGlobalVar`), any `GlobalVar`s in other positions
         // require extra care to ensure the ID-giving `Const` is visited.
@@ -1443,84 +1413,115 @@ impl Module {
             });
             Global::Const(ptr_to_global_var)
         };
-        for &gv in &needs_ids_collector.global_vars_seen {
-            needs_ids_collector.globals.insert(global_var_to_id_giving_global(gv));
-        }
 
-        // IDs can be allocated once we have the full sets needing them, whether
-        // sorted by contents, or ordered by the first occurence in the module.
-        let mut id_bound = NonZeroU32::MIN;
-        let ids = needs_ids_collector.alloc_ids(|| {
-            let id = id_bound;
+        // Collect uses scattered throughout the module, allocating IDs for them.
+        let (ids, id_bound) = {
+            let mut id_bound = NonZeroUsize::MIN;
+            let mut id_allocator = IdAllocator {
+                cx: &cx,
+                module: self,
+                alloc_id: || {
+                    let id = id_bound;
+                    id_bound =
+                        id_bound.checked_add(1).expect("overflowing `usize` should be impossible");
 
-            match id_bound.checked_add(1) {
-                Some(new_bound) => {
-                    id_bound = new_bound;
-                    Ok(id)
-                }
-                None => Err(io::Error::new(
+                    // NOTE(eddyb) `MAX` is just a placeholder - the check for overflows
+                    // is done below, after all IDs that may be allocated, have been
+                    // (this is in order to not need this closure to return a `Result`).
+                    id.try_into().unwrap_or(spv::Id::new(u32::MAX).unwrap())
+                },
+                ids: ModuleIds::default(),
+                data_inst_forms_seen: FxIndexSet::default(),
+                global_vars_seen: FxIndexSet::default(),
+            };
+            id_allocator.visit_module(self);
+
+            // See comment on `global_var_to_id_giving_global` for why this is here.
+            for &gv in &id_allocator.global_vars_seen {
+                id_allocator
+                    .ids
+                    .globals
+                    .entry(global_var_to_id_giving_global(gv))
+                    .or_insert_with(&mut id_allocator.alloc_id);
+            }
+
+            let ids = id_allocator.ids;
+
+            let id_bound = spv::Id::try_from(id_bound).ok().ok_or_else(|| {
+                io::Error::new(
                     io::ErrorKind::InvalidData,
                     "ID bound of SPIR-V module doesn't fit in 32 bits",
-                )),
-            }
-        })?;
+                )
+            })?;
+
+            (ids, id_bound)
+        };
 
         // HACK(eddyb) allow `move` closures below to reference `cx` or `ids`
         // without causing unwanted moves out of them.
         let (cx, ids) = (&*cx, &ids);
 
         let global_and_func_insts = ids.globals.keys().copied().map(LazyInst::Global).chain(
-            ids.funcs.iter().flat_map(|(&func, func_lifting)| {
+            ids.funcs.iter().flat_map(|(&func, func_ids)| {
                 let func_decl = &self.funcs[func];
-                let func_def_body = match &func_decl.def {
-                    DeclDef::Imported(_) => None,
-                    DeclDef::Present(def) => Some(def),
+                let body_with_lifting = match (&func_decl.def, &func_ids.body) {
+                    (DeclDef::Imported(_), None) => None,
+                    (DeclDef::Present(def), Some(func_body_lifting)) => {
+                        Some((def, func_body_lifting))
+                    }
+                    _ => unreachable!(),
                 };
 
-                iter::once(LazyInst::OpFunction { func_id: func_lifting.func_id, func_decl })
-                    .chain(func_lifting.param_ids.iter().zip(&func_decl.params).map(
-                        |(&param_id, param)| LazyInst::OpFunctionParameter { param_id, param },
-                    ))
-                    .chain(func_lifting.blocks.iter().flat_map(move |(point, block)| {
+                let param_insts =
+                    func_ids.param_ids.iter().zip(&func_decl.params).map(|(&param_id, param)| {
+                        LazyInst::OpFunctionParameter { param_id, param }
+                    });
+                let body_insts = body_with_lifting.map(|(func_def_body, func_body_lifting)| {
+                    func_body_lifting.blocks.iter().flat_map(move |(point, block)| {
                         let BlockLifting { phis, insts, terminator } = block;
 
-                        iter::once(LazyInst::OpLabel { label_id: func_lifting.label_ids[point] })
-                            .chain(
-                                phis.iter()
-                                    .map(|phi| LazyInst::OpPhi { parent_func: func_lifting, phi }),
-                            )
-                            .chain(
-                                insts
-                                    .iter()
-                                    .copied()
-                                    .flat_map(move |insts| func_def_body.unwrap().at(insts))
-                                    .map(move |func_at_inst| {
-                                        let data_inst_def = func_at_inst.def();
-                                        LazyInst::DataInst {
-                                            parent_func: func_lifting,
-                                            result_id: cx[data_inst_def.form].output_type.map(
-                                                |_| {
-                                                    func_lifting.data_inst_output_ids
-                                                        [&func_at_inst.position]
-                                                },
-                                            ),
-                                            data_inst_def,
-                                        }
-                                    }),
-                            )
-                            .chain(terminator.merge.map(|merge| {
-                                LazyInst::Merge(match merge {
-                                    Merge::Selection(merge) => {
-                                        Merge::Selection(func_lifting.label_ids[&merge])
+                        iter::once(LazyInst::OpLabel {
+                            label_id: func_body_lifting.label_ids[point],
+                        })
+                        .chain(
+                            phis.iter()
+                                .map(|phi| LazyInst::OpPhi { parent_func_ids: func_ids, phi }),
+                        )
+                        .chain(
+                            insts
+                                .iter()
+                                .copied()
+                                .flat_map(move |insts| func_def_body.at(insts))
+                                .map(move |func_at_inst| {
+                                    let data_inst_def = func_at_inst.def();
+                                    LazyInst::DataInst {
+                                        parent_func_ids: func_ids,
+                                        result_id: cx[data_inst_def.form].output_type.map(|_| {
+                                            func_body_lifting.data_inst_output_ids
+                                                [&func_at_inst.position]
+                                        }),
+                                        data_inst_def,
                                     }
-                                    Merge::Loop { loop_merge, loop_continue } => Merge::Loop {
-                                        loop_merge: func_lifting.label_ids[&loop_merge],
-                                        loop_continue: func_lifting.label_ids[&loop_continue],
-                                    },
-                                })
-                            }))
-                            .chain([LazyInst::Terminator { parent_func: func_lifting, terminator }])
-                    }))
+                                }),
+                        )
+                        .chain(terminator.merge.map(|merge| {
+                            LazyInst::Merge(match merge {
+                                Merge::Selection(merge) => {
+                                    Merge::Selection(func_body_lifting.label_ids[&merge])
+                                }
+                                Merge::Loop { loop_merge, loop_continue } => Merge::Loop {
+                                    loop_merge: func_body_lifting.label_ids[&loop_merge],
+                                    loop_continue: func_body_lifting.label_ids[&loop_continue],
+                                },
+                            })
+                        }))
+                        .chain([LazyInst::Terminator { parent_func_ids: func_ids, terminator }])
+                    })
+                });
+
+                iter::once(LazyInst::OpFunction { func_decl, func_ids })
+                    .chain(param_insts)
+                    .chain(body_insts.into_iter().flatten())
                     .chain([LazyInst::OpFunctionEnd])
             }),
         );

--- a/src/spv/lift.rs
+++ b/src/spv/lift.rs
@@ -6,18 +6,30 @@ use crate::visit::{InnerVisit, Visitor};
 use crate::{
     cfg, scalar, AddrSpace, Attr, AttrSet, Const, ConstDef, ConstKind, Context, ControlNode,
     ControlNodeKind, ControlNodeOutputDecl, ControlRegion, ControlRegionInputDecl, DataInst,
-    DataInstDef, DataInstForm, DataInstFormDef, DataInstKind, DeclDef, EntityList, ExportKey,
-    Exportee, Func, FuncDecl, FuncDefBody, FuncParam, FxIndexMap, FxIndexSet, GlobalVar,
-    GlobalVarDefBody, Import, Module, ModuleDebugInfo, ModuleDialect, SelectionKind, Type, TypeDef,
-    TypeKind, TypeOrConst, Value,
+    DataInstDef, DataInstForm, DataInstFormDef, DataInstKind, DeclDef, EntityList,
+    EntityOrientedDenseMap, ExportKey, Exportee, Func, FuncDecl, FuncDefBody, FuncParam,
+    FxIndexMap, FxIndexSet, GlobalVar, GlobalVarDefBody, Import, Module, ModuleDebugInfo,
+    ModuleDialect, SelectionKind, Type, TypeDef, TypeKind, TypeOrConst, Value,
 };
+use itertools::Itertools;
 use rustc_hash::FxHashMap;
 use smallvec::SmallVec;
 use std::borrow::Cow;
 use std::collections::BTreeMap;
 use std::num::NonZeroUsize;
+use std::ops::Range;
 use std::path::Path;
 use std::{io, iter, mem, slice};
+
+// HACK(eddyb) getting around the lack of a `Step` impl on `spv::Id` (`NonZeroU32`).
+trait IdRangeExt {
+    fn iter(&self) -> iter::Map<Range<u32>, fn(u32) -> spv::Id>;
+}
+impl IdRangeExt for Range<spv::Id> {
+    fn iter(&self) -> iter::Map<Range<u32>, fn(u32) -> spv::Id> {
+        (self.start.get()..self.end.get()).map(|i| spv::Id::new(i).unwrap())
+    }
+}
 
 impl spv::Dialect {
     fn capability_insts(&self) -> impl Iterator<Item = spv::InstWithIds> + '_ {
@@ -75,13 +87,21 @@ impl spv::ModuleDebugInfo {
     }
 }
 
-struct IdAllocator<'a, AI: FnMut() -> spv::Id> {
+/// ID allocation callback, kept as a closure (instead of having its state
+/// be part of `Lifter`) to avoid misuse.
+trait AllocIds: FnMut(usize) -> Range<spv::Id> {
+    fn one(&mut self) -> spv::Id {
+        self(1).start
+    }
+}
+
+impl<F: FnMut(usize) -> Range<spv::Id>> AllocIds for F {}
+
+struct Lifter<'a, AI: AllocIds> {
     cx: &'a Context,
     module: &'a Module,
 
-    /// ID allocation callback, kept as a closure (instead of having its state
-    /// be part of `IdAllocator`) to avoid misuse.
-    alloc_id: AI,
+    alloc_ids: AI,
 
     ids: ModuleIds<'a>,
 
@@ -106,7 +126,6 @@ enum Global {
     Const(Const),
 }
 
-// FIXME(eddyb) should this use ID ranges instead of `SmallVec<[spv::Id; 4]>`?
 // FIXME(eddyb) this is inconsistently named with `FuncBodyLifting`.
 struct FuncIds<'a> {
     spv_func_ret_type: Type,
@@ -115,12 +134,12 @@ struct FuncIds<'a> {
     spv_func_type: Type,
 
     func_id: spv::Id,
-    param_ids: SmallVec<[spv::Id; 4]>,
+    param_ids: Range<spv::Id>,
 
     body: Option<FuncBodyLifting<'a>>,
 }
 
-impl<AI: FnMut() -> spv::Id> Visitor<'_> for IdAllocator<'_, AI> {
+impl<AI: AllocIds> Visitor<'_> for Lifter<'_, AI> {
     fn visit_attr_set_use(&mut self, attrs: AttrSet) {
         self.visit_attr_set_def(&self.cx[attrs]);
     }
@@ -162,7 +181,7 @@ impl<AI: FnMut() -> spv::Id> Visitor<'_> for IdAllocator<'_, AI> {
         }
 
         self.visit_type_def(ty_def);
-        self.ids.globals.insert(global, (self.alloc_id)());
+        self.ids.globals.insert(global, self.alloc_ids.one());
     }
     fn visit_const_use(&mut self, ct: Const) {
         let global = Global::Const(ct);
@@ -188,7 +207,7 @@ impl<AI: FnMut() -> spv::Id> Visitor<'_> for IdAllocator<'_, AI> {
             | ConstKind::PtrToGlobalVar(_)
             | ConstKind::SpvInst { .. } => {
                 self.visit_const_def(ct_def);
-                self.ids.globals.insert(global, (self.alloc_id)());
+                self.ids.globals.insert(global, self.alloc_ids.one());
             }
 
             // HACK(eddyb) because this is an `OpString` and needs to go earlier
@@ -206,7 +225,7 @@ impl<AI: FnMut() -> spv::Id> Visitor<'_> for IdAllocator<'_, AI> {
                         }
                 );
 
-                self.ids.debug_strings.entry(&self.cx[s]).or_insert_with(&mut self.alloc_id);
+                self.ids.debug_strings.entry(&self.cx[s]).or_insert_with(|| self.alloc_ids.one());
             }
         }
     }
@@ -229,14 +248,26 @@ impl<AI: FnMut() -> spv::Id> Visitor<'_> for IdAllocator<'_, AI> {
 
         // Synthesize an `OpTypeFunction` type (that SPIR-T itself doesn't carry).
         let wk = &spec::Spec::get().well_known;
-        let spv_func_ret_type = func_decl.ret_type;
-        let spv_func_type = self.cx.intern(TypeKind::SpvInst {
-            spv_inst: wk.OpTypeFunction.into(),
-            type_and_const_inputs: iter::once(spv_func_ret_type)
-                .chain(func_decl.params.iter().map(|param| param.ty))
-                .map(TypeOrConst::Type)
-                .collect(),
-        });
+        let spv_func_ret_type = match &func_decl.ret_types[..] {
+            &[ty] => ty,
+            // Reaggregate multiple return types into an `OpTypeStruct`.
+            ret_types => {
+                let opcode = if ret_types.is_empty() { wk.OpTypeVoid } else { wk.OpTypeStruct };
+                self.cx.intern(spv::Inst::from(opcode).into_canonical_type_with(
+                    self.cx,
+                    ret_types.iter().copied().map(TypeOrConst::Type).collect(),
+                ))
+            }
+        };
+        let spv_func_type = self.cx.intern(
+            spv::Inst::from(wk.OpTypeFunction).into_canonical_type_with(
+                self.cx,
+                iter::once(spv_func_ret_type)
+                    .chain(func_decl.params.iter().map(|param| param.ty))
+                    .map(TypeOrConst::Type)
+                    .collect(),
+            ),
+        );
         self.visit_type_use(spv_func_type);
 
         // NOTE(eddyb) inserting first produces a different function ordering
@@ -247,15 +278,16 @@ impl<AI: FnMut() -> spv::Id> Visitor<'_> for IdAllocator<'_, AI> {
             FuncIds {
                 spv_func_ret_type,
                 spv_func_type,
-                func_id: (self.alloc_id)(),
-                param_ids: func_decl.params.iter().map(|_| (self.alloc_id)()).collect(),
+                func_id: self.alloc_ids.one(),
+                param_ids: (self.alloc_ids)(func_decl.params.len()),
                 body: None,
             },
         );
 
         self.visit_func_decl(func_decl);
 
-        // Handle the body last, to minimize recursion hazards (see comment above).
+        // Handle the body last, to minimize recursion hazards (see comment above),
+        // and to allow `FuncBodyLifting` to look up its dependencies in `self.ids`.
         match &func_decl.def {
             DeclDef::Imported(_) => {}
             DeclDef::Present(func_def_body) => {
@@ -269,7 +301,7 @@ impl<AI: FnMut() -> spv::Id> Visitor<'_> for IdAllocator<'_, AI> {
         for sources in debug_info.source_languages.values() {
             // The file operand of `OpSource` has to point to an `OpString`.
             for &s in sources.file_contents.keys() {
-                self.ids.debug_strings.entry(&self.cx[s]).or_insert_with(&mut self.alloc_id);
+                self.ids.debug_strings.entry(&self.cx[s]).or_insert_with(|| self.alloc_ids.one());
             }
         }
     }
@@ -283,7 +315,7 @@ impl<AI: FnMut() -> spv::Id> Visitor<'_> for IdAllocator<'_, AI> {
                 self.ids
                     .debug_strings
                     .entry(&self.cx[file_path.0])
-                    .or_insert_with(&mut self.alloc_id);
+                    .or_insert_with(|| self.alloc_ids.one());
             }
         }
         attr.inner_visit_with(self);
@@ -300,13 +332,13 @@ impl<AI: FnMut() -> spv::Id> Visitor<'_> for IdAllocator<'_, AI> {
             DataInstKind::Scalar(_)
             | DataInstKind::Vector(_)
             | DataInstKind::FuncCall(_)
-            | DataInstKind::SpvInst(_) => {}
+            | DataInstKind::SpvInst(..) => {}
 
             DataInstKind::SpvExtInst { ext_set, .. } => {
                 self.ids
                     .ext_inst_imports
                     .entry(&self.cx[ext_set])
-                    .or_insert_with(&mut self.alloc_id);
+                    .or_insert_with(|| self.alloc_ids.one());
             }
         }
         data_inst_form_def.inner_visit_with(self);
@@ -315,10 +347,8 @@ impl<AI: FnMut() -> spv::Id> Visitor<'_> for IdAllocator<'_, AI> {
 
 // FIXME(eddyb) this is inconsistently named with `FuncIds`.
 struct FuncBodyLifting<'a> {
-    // FIXME(eddyb) use `EntityOrientedDenseMap` here.
-    region_inputs_source: FxHashMap<ControlRegion, RegionInputsSource>,
-    // FIXME(eddyb) use `EntityOrientedDenseMap` here.
-    data_inst_output_ids: FxHashMap<DataInst, spv::Id>,
+    region_inputs_source: EntityOrientedDenseMap<ControlRegion, RegionInputsSource>,
+    data_insts: EntityOrientedDenseMap<DataInst, DataInstLifting>,
 
     label_ids: FxHashMap<CfgPoint, spv::Id>,
     blocks: FxIndexMap<CfgPoint, BlockLifting<'a>>,
@@ -332,6 +362,40 @@ struct FuncBodyLifting<'a> {
 enum RegionInputsSource {
     FuncParams,
     LoopHeaderPhis(ControlNode),
+}
+
+struct DataInstLifting {
+    result_id: Option<spv::Id>,
+
+    /// If the SPIR-V result type is "aggregate" (`OpTypeStruct`/`OpTypeArray`),
+    /// this describes how to extract its leaves, which is necessary as on the
+    /// SPIR-T side, [`Value::DataInstOutput`] can only refer to individual leaves.
+    disaggregate_result: Option<DisaggregateToLeaves>,
+
+    /// `reaggregate_inputs[i]` describes how to recreate the "aggregate" value
+    /// demanded by [`spv::InstLowering`]'s `disaggregated_inputs[i]`.
+    reaggregate_inputs: SmallVec<[ReaggregateFromLeaves; 1]>,
+}
+
+/// All the information necessary to decompose a SPIR-V "aggregate" value into
+/// its leaves, with one `OpCompositeExtract` per leaf.
+//
+// FIXME(eddyb) it might be more efficient to only extract actually used leaves,
+// or chain partial extracts following nesting structure - but this is simpler.
+struct DisaggregateToLeaves {
+    op_composite_extract_result_ids: Range<spv::Id>,
+}
+
+/// All the information necessary to recreate a SPIR-V "aggregate" value, with
+/// one `OpCompositeInsert` per leaf (starting with an `OpUndef` of that type).
+//
+// FIXME(eddyb) it might be more efficient to use other strategies, such as
+// `OpCompositeConstruct`, special-casing constants, reusing whole results
+// of other `DataInstDef`s with an aggregate result, etc. - but this is simpler
+// for now, and it reuses the "one instruction per leaf" used for extractions.
+struct ReaggregateFromLeaves {
+    op_undef: Const,
+    op_composite_insert_result_ids: Range<spv::Id>,
 }
 
 /// Any of the possible points in structured or unstructured SPIR-T control-flow,
@@ -376,6 +440,11 @@ struct Terminator<'a> {
     attrs: AttrSet,
 
     kind: Cow<'a, cfg::ControlInstKind>,
+
+    /// If this is a [`cfg::ControlInstKind::Return`] with `inputs.len() > 1`,
+    /// this ID is for the `OpCompositeConstruct` needed to produce the single
+    /// `OpTypStruct` (`spv_func_ret_type`) value required by `OpReturnValue`.
+    reaggregated_return_value_id: Option<spv::Id>,
 
     // FIXME(eddyb) use `Cow` or something, but ideally the "owned" case always
     // has at most one input, so allocating a whole `Vec` for that seems unwise.
@@ -543,12 +612,13 @@ impl<'a> FuncAt<'a, ControlNode> {
 
 impl<'a> FuncBodyLifting<'a> {
     fn from_func_def_body(
-        id_allocator: &mut IdAllocator<'_, impl FnMut() -> spv::Id>,
+        lifter: &mut Lifter<'_, impl AllocIds>,
         func_def_body: &'a FuncDefBody,
     ) -> Self {
-        let cx = id_allocator.cx;
+        let wk = &spec::Spec::get().well_known;
+        let cx = lifter.cx;
 
-        let mut region_inputs_source = FxHashMap::default();
+        let mut region_inputs_source = EntityOrientedDenseMap::new();
         region_inputs_source.insert(func_def_body.body, RegionInputsSource::FuncParams);
 
         // Create a SPIR-V block for every CFG point needing one.
@@ -558,7 +628,7 @@ impl<'a> FuncBodyLifting<'a> {
 
             let phis = match point {
                 CfgPoint::RegionEntry(region) => {
-                    if region_inputs_source.contains_key(&region) {
+                    if region_inputs_source.get(region).is_some() {
                         // Region inputs handled by the parent of the region.
                         SmallVec::new()
                     } else {
@@ -571,7 +641,7 @@ impl<'a> FuncBodyLifting<'a> {
                                 attrs,
                                 ty,
 
-                                result_id: (id_allocator.alloc_id)(),
+                                result_id: lifter.alloc_ids.one(),
                                 cases: FxIndexMap::default(),
                                 default_value: None,
                             })
@@ -603,7 +673,7 @@ impl<'a> FuncBodyLifting<'a> {
                                     attrs,
                                     ty,
 
-                                    result_id: (id_allocator.alloc_id)(),
+                                    result_id: lifter.alloc_ids.one(),
                                     cases: FxIndexMap::default(),
                                     default_value: Some(initial_inputs[i]),
                                 })
@@ -621,7 +691,7 @@ impl<'a> FuncBodyLifting<'a> {
                         attrs,
                         ty,
 
-                        result_id: (id_allocator.alloc_id)(),
+                        result_id: lifter.alloc_ids.one(),
                         cases: FxIndexMap::default(),
                         default_value: None,
                     })
@@ -652,6 +722,12 @@ impl<'a> FuncBodyLifting<'a> {
                         Terminator {
                             attrs: *attrs,
                             kind: Cow::Borrowed(kind),
+                            reaggregated_return_value_id: match kind {
+                                cfg::ControlInstKind::Return if inputs.len() > 1 => {
+                                    Some(lifter.alloc_ids.one())
+                                }
+                                _ => None,
+                            },
                             // FIXME(eddyb) borrow these whenever possible.
                             inputs: inputs.clone(),
                             targets: targets
@@ -669,10 +745,16 @@ impl<'a> FuncBodyLifting<'a> {
                     } else {
                         // Structured return out of the function body.
                         assert!(region == func_def_body.body);
+                        let inputs = func_def_body.at_body().def().outputs.clone();
                         Terminator {
                             attrs: AttrSet::default(),
                             kind: Cow::Owned(cfg::ControlInstKind::Return),
-                            inputs: func_def_body.at_body().def().outputs.clone(),
+                            reaggregated_return_value_id: if inputs.len() > 1 {
+                                Some(lifter.alloc_ids.one())
+                            } else {
+                                None
+                            },
+                            inputs,
                             targets: [].into_iter().collect(),
                             target_phi_values: FxIndexMap::default(),
                             merge: None,
@@ -691,6 +773,7 @@ impl<'a> FuncBodyLifting<'a> {
                         ControlNodeKind::Select { kind, scrutinee, cases } => Terminator {
                             attrs: AttrSet::default(),
                             kind: Cow::Owned(cfg::ControlInstKind::SelectBranch(kind.clone())),
+                            reaggregated_return_value_id: None,
                             inputs: [*scrutinee].into_iter().collect(),
                             targets: cases
                                 .iter()
@@ -704,6 +787,7 @@ impl<'a> FuncBodyLifting<'a> {
                             Terminator {
                                 attrs: AttrSet::default(),
                                 kind: Cow::Owned(cfg::ControlInstKind::Branch),
+                                reaggregated_return_value_id: None,
                                 inputs: [].into_iter().collect(),
                                 targets: [CfgPoint::RegionEntry(*body)].into_iter().collect(),
                                 target_phi_values: FxIndexMap::default(),
@@ -742,6 +826,7 @@ impl<'a> FuncBodyLifting<'a> {
                         ControlNodeKind::Select { .. } => Terminator {
                             attrs: AttrSet::default(),
                             kind: Cow::Owned(cfg::ControlInstKind::Branch),
+                            reaggregated_return_value_id: None,
                             inputs: [].into_iter().collect(),
                             targets: [parent_exit].into_iter().collect(),
                             target_phi_values: region_outputs
@@ -768,6 +853,7 @@ impl<'a> FuncBodyLifting<'a> {
                                 Terminator {
                                     attrs: AttrSet::default(),
                                     kind: Cow::Owned(cfg::ControlInstKind::Branch),
+                                    reaggregated_return_value_id: None,
                                     inputs: [].into_iter().collect(),
                                     targets: [backedge].into_iter().collect(),
                                     target_phi_values,
@@ -779,6 +865,7 @@ impl<'a> FuncBodyLifting<'a> {
                                     kind: Cow::Owned(cfg::ControlInstKind::SelectBranch(
                                         SelectionKind::BoolCond,
                                     )),
+                                    reaggregated_return_value_id: None,
                                     inputs: [repeat_condition].into_iter().collect(),
                                     targets: [backedge, parent_exit].into_iter().collect(),
                                     target_phi_values,
@@ -794,6 +881,7 @@ impl<'a> FuncBodyLifting<'a> {
                 (_, Some(succ_cursor)) => Terminator {
                     attrs: AttrSet::default(),
                     kind: Cow::Owned(cfg::ControlInstKind::Branch),
+                    reaggregated_return_value_id: None,
                     inputs: [].into_iter().collect(),
                     targets: [succ_cursor.point].into_iter().collect(),
                     target_phi_values: FxIndexMap::default(),
@@ -865,11 +953,19 @@ impl<'a> FuncBodyLifting<'a> {
             let BlockLifting { terminator: original_terminator, .. } = &blocks[block_idx];
 
             let is_trivial_branch = {
-                let Terminator { attrs, kind, inputs, targets, target_phi_values, merge } =
-                    original_terminator;
+                let Terminator {
+                    attrs,
+                    kind,
+                    reaggregated_return_value_id,
+                    inputs,
+                    targets,
+                    target_phi_values,
+                    merge,
+                } = original_terminator;
 
                 *attrs == AttrSet::default()
                     && matches!(**kind, cfg::ControlInstKind::Branch)
+                    && reaggregated_return_value_id.is_none()
                     && inputs.is_empty()
                     && targets.len() == 1
                     && target_phi_values.is_empty()
@@ -896,6 +992,7 @@ impl<'a> FuncBodyLifting<'a> {
                             Terminator {
                                 attrs: Default::default(),
                                 kind: Cow::Owned(cfg::ControlInstKind::Unreachable),
+                                reaggregated_return_value_id: None,
                                 inputs: Default::default(),
                                 targets: Default::default(),
                                 target_phi_values: Default::default(),
@@ -950,27 +1047,104 @@ impl<'a> FuncBodyLifting<'a> {
             }
         }
 
-        let all_insts_with_output = blocks
+        let mut data_insts = EntityOrientedDenseMap::new();
+        let all_func_at_data_insts = blocks
             .values()
             .flat_map(|block| block.insts.iter().copied())
-            .flat_map(|insts| func_def_body.at(insts))
-            .filter(|&func_at_inst| cx[func_at_inst.def().form].output_type.is_some())
-            .map(|func_at_inst| func_at_inst.position);
+            .flat_map(|insts| func_def_body.at(insts));
+        for func_at_inst in all_func_at_data_insts {
+            let data_inst_form_def = &cx[func_at_inst.def().form];
+
+            let mut new_spv_inst_lowering = spv::InstLowering::default();
+            let spv_inst_lowering = match &data_inst_form_def.kind {
+                // Disallowed while visiting.
+                DataInstKind::QPtr(_) => unreachable!(),
+
+                DataInstKind::Scalar(_) | DataInstKind::Vector(_) => {
+                    // FIXME(eddyb) deduplicate creating this `OpTypeStruct`.
+                    if data_inst_form_def.output_types.len() > 1 {
+                        let tuple_ty = cx.intern(
+                            spv::Inst::from(wk.OpTypeStruct).into_canonical_type_with(
+                                cx,
+                                data_inst_form_def
+                                    .output_types
+                                    .iter()
+                                    .copied()
+                                    .map(TypeOrConst::Type)
+                                    .collect(),
+                            ),
+                        );
+                        lifter.visit_type_use(tuple_ty);
+                        new_spv_inst_lowering.disaggregated_output = Some(tuple_ty);
+                    }
+                    &new_spv_inst_lowering
+                }
+
+                DataInstKind::FuncCall(callee) => {
+                    if data_inst_form_def.output_types.len() > 1 {
+                        new_spv_inst_lowering.disaggregated_output =
+                            Some(lifter.ids.funcs[callee].spv_func_ret_type);
+                    }
+                    &new_spv_inst_lowering
+                }
+
+                DataInstKind::SpvInst(_, lowering) | DataInstKind::SpvExtInst { lowering, .. } => {
+                    lowering
+                }
+            };
+
+            let reaggregate_inputs = spv_inst_lowering
+                .disaggregated_inputs
+                .iter()
+                .map(|&(_, ty)| {
+                    let op_undef = cx.intern(ConstDef {
+                        attrs: AttrSet::default(),
+                        ty,
+                        kind: ConstKind::Undef,
+                    });
+                    lifter.visit_const_use(op_undef);
+                    let op_composite_insert_result_ids =
+                        (lifter.alloc_ids)(cx[ty].disaggregated_leaf_count());
+                    ReaggregateFromLeaves { op_undef, op_composite_insert_result_ids }
+                })
+                .collect();
+
+            // `OpFunctionCall always has a result (but may be `OpTypeVoid`-typed).
+            let has_result = matches!(data_inst_form_def.kind, DataInstKind::FuncCall(_))
+                || spv_inst_lowering.disaggregated_output.is_some()
+                || !data_inst_form_def.output_types.is_empty();
+            let result_id = if has_result { Some(lifter.alloc_ids.one()) } else { None };
+
+            let disaggregate_result =
+                spv_inst_lowering.disaggregated_output.map(|ty| DisaggregateToLeaves {
+                    op_composite_extract_result_ids: (lifter.alloc_ids)(
+                        cx[ty].disaggregated_leaf_count(),
+                    ),
+                });
+
+            data_insts.insert(
+                func_at_inst.position,
+                DataInstLifting { result_id, disaggregate_result, reaggregate_inputs },
+            );
+        }
 
         Self {
             region_inputs_source,
-            data_inst_output_ids: all_insts_with_output
-                .map(|inst| (inst, (id_allocator.alloc_id)()))
-                .collect(),
-            label_ids: blocks.keys().map(|&point| (point, (id_allocator.alloc_id)())).collect(),
+            data_insts,
+
+            label_ids: blocks.keys().map(|&point| (point, lifter.alloc_ids.one())).collect(),
             blocks,
         }
     }
 }
 
 /// Maybe-decorated "lazy" SPIR-V instruction, allowing separately emitting
-/// decorations from attributes, and the instruction itself, without eagerly
-/// allocating all the instructions.
+/// *both* decorations (from certain [`Attr`]s), *and* the instruction itself,
+/// without eagerly allocating all the instructions.
+///
+/// Note that SPIR-T disaggregating SPIR-V `OpTypeStruct`/`OpTypeArray`s values
+/// may require additional [`spv::Inst`]s for each `LazyInst`, either for
+/// reaggregating inputs, or taking apart aggregate outputs.
 #[derive(Copy, Clone)]
 enum LazyInst<'a, 'b> {
     Global(Global),
@@ -991,15 +1165,25 @@ enum LazyInst<'a, 'b> {
     },
     DataInst {
         parent_func_ids: &'b FuncIds<'a>,
-        result_id: Option<spv::Id>,
         data_inst_def: &'a DataInstDef,
+        data_inst_lifting: &'b DataInstLifting,
     },
+    // FIXME(eddyb) should merge instructions be generated by `Terminator`?
     Merge(Merge<spv::Id>),
     Terminator {
         parent_func_ids: &'b FuncIds<'a>,
         terminator: &'b Terminator<'a>,
     },
     OpFunctionEnd,
+}
+
+/// [`Attr::SpvDebugLine`], extracted from [`AttrSet`], and used for emitting
+/// `OpLine`/`OpNoLine` SPIR-V instructions.
+#[derive(Copy, Clone, PartialEq, Eq)]
+struct SpvDebugLine {
+    file_path_id: spv::Id,
+    line: u32,
+    col: u32,
 }
 
 impl LazyInst<'_, '_> {
@@ -1049,8 +1233,8 @@ impl LazyInst<'_, '_> {
             Self::OpFunctionParameter { param_id, param } => (Some(param_id), param.attrs, None),
             Self::OpLabel { label_id } => (Some(label_id), AttrSet::default(), None),
             Self::OpPhi { parent_func_ids: _, phi } => (Some(phi.result_id), phi.attrs, None),
-            Self::DataInst { parent_func_ids: _, result_id, data_inst_def } => {
-                (result_id, data_inst_def.attrs, None)
+            Self::DataInst { parent_func_ids: _, data_inst_def, data_inst_lifting } => {
+                (data_inst_lifting.result_id, data_inst_def.attrs, None)
             }
             Self::Merge(_) => (None, AttrSet::default(), None),
             Self::Terminator { parent_func_ids: _, terminator } => (None, terminator.attrs, None),
@@ -1058,11 +1242,16 @@ impl LazyInst<'_, '_> {
         }
     }
 
-    fn to_inst_and_attrs(
+    /// Expand this `LazyInst` to one or more (see disaggregation/reaggregation
+    /// note in [`LazyInst`]'s doc comment for when it can be more than one)
+    /// [`spv::Inst`]s (with their respective [`SpvDebugLine`]s, if applicable),
+    /// with `each_spv_inst_with_debug_line` being called for each one.
+    fn for_each_spv_inst_with_debug_line(
         self,
         module: &Module,
         ids: &ModuleIds<'_>,
-    ) -> (spv::InstWithIds, AttrSet) {
+        mut each_spv_inst_with_debug_line: impl FnMut(spv::InstWithIds, Option<SpvDebugLine>),
+    ) {
         let wk = &spec::Spec::get().well_known;
         let cx = module.cx_ref();
 
@@ -1075,8 +1264,16 @@ impl LazyInst<'_, '_> {
             Value::ControlRegionInput { region, input_idx } => {
                 let input_idx = usize::try_from(input_idx).unwrap();
                 let parent_func_body_lifting = parent_func_ids.body.as_ref().unwrap();
-                match parent_func_body_lifting.region_inputs_source.get(&region) {
-                    Some(RegionInputsSource::FuncParams) => parent_func_ids.param_ids[input_idx],
+                match parent_func_body_lifting.region_inputs_source.get(region) {
+                    Some(RegionInputsSource::FuncParams) => {
+                        let param_id = parent_func_ids
+                            .param_ids
+                            .start
+                            .checked_add(input_idx.try_into().unwrap())
+                            .unwrap();
+                        assert!(parent_func_ids.param_ids.contains(&param_id));
+                        param_id
+                    }
                     Some(&RegionInputsSource::LoopHeaderPhis(loop_node)) => {
                         parent_func_body_lifting.blocks[&CfgPoint::ControlNodeEntry(loop_node)].phis
                             [input_idx]
@@ -1095,14 +1292,42 @@ impl LazyInst<'_, '_> {
                     .phis[usize::try_from(output_idx).unwrap()]
                 .result_id
             }
-            Value::DataInstOutput(inst) => {
-                parent_func_ids.body.as_ref().unwrap().data_inst_output_ids[&inst]
+            Value::DataInstOutput { inst, output_idx } => {
+                let output_idx = usize::try_from(output_idx).unwrap();
+                let data_inst_lifting = &parent_func_ids.body.as_ref().unwrap().data_insts[inst];
+                if let Some(disaggregate_result) = &data_inst_lifting.disaggregate_result {
+                    let result_id = disaggregate_result
+                        .op_composite_extract_result_ids
+                        .start
+                        .checked_add(output_idx.try_into().unwrap())
+                        .unwrap();
+                    assert!(
+                        disaggregate_result.op_composite_extract_result_ids.contains(&result_id)
+                    );
+                    result_id
+                } else {
+                    assert_eq!(output_idx, 0);
+                    data_inst_lifting.result_id.unwrap()
+                }
             }
         };
 
         let (result_id, attrs, _) = self.result_id_attrs_and_import(module, ids);
-        let inst = match self {
-            Self::Global(global) => match global {
+
+        // FIXME(eddyb) make this less of a search and more of a
+        // lookup by splitting attrs into key and value parts.
+        let spv_debug_line = cx[attrs].attrs.iter().find_map(|attr| match *attr {
+            Attr::SpvDebugLine { file_path, line, col } => {
+                Some(SpvDebugLine { file_path_id: ids.debug_strings[&cx[file_path.0]], line, col })
+            }
+            _ => None,
+        });
+
+        // HACK(eddyb) there is no need to allow `spv_debug_line` to vary per-inst.
+        let mut each_inst = |inst| each_spv_inst_with_debug_line(inst, spv_debug_line);
+
+        match self {
+            Self::Global(global) => each_inst(match global {
                 Global::Type(ty) => {
                     let ty_def = &cx[ty];
                     match spv::Inst::from_canonical_type(cx, &ty_def.kind)
@@ -1114,7 +1339,7 @@ impl LazyInst<'_, '_> {
                         }
 
                         Ok((spv_inst, type_and_const_inputs))
-                        | Err(TypeKind::SpvInst { spv_inst, type_and_const_inputs }) => {
+                        | Err(TypeKind::SpvInst { spv_inst, type_and_const_inputs, .. }) => {
                             spv::InstWithIds {
                                 without_ids: spv_inst.clone(),
                                 result_type_id: None,
@@ -1205,7 +1430,7 @@ impl LazyInst<'_, '_> {
                         Err(ConstKind::SpvStringLiteralForExtInst(_)) => unreachable!(),
                     }
                 }
-            },
+            }),
             Self::OpFunction { func_decl: _, func_ids } => {
                 // FIXME(eddyb) make this less of a search and more of a
                 // lookup by splitting attrs into key and value parts.
@@ -1222,7 +1447,7 @@ impl LazyInst<'_, '_> {
                     })
                     .unwrap_or(0);
 
-                spv::InstWithIds {
+                each_inst(spv::InstWithIds {
                     without_ids: spv::Inst {
                         opcode: wk.OpFunction,
                         imms: iter::once(spv::Imm::Short(wk.FunctionControl, func_ctrl)).collect(),
@@ -1230,21 +1455,21 @@ impl LazyInst<'_, '_> {
                     result_type_id: Some(ids.globals[&Global::Type(func_ids.spv_func_ret_type)]),
                     result_id,
                     ids: iter::once(ids.globals[&Global::Type(func_ids.spv_func_type)]).collect(),
-                }
+                });
             }
-            Self::OpFunctionParameter { param_id: _, param } => spv::InstWithIds {
+            Self::OpFunctionParameter { param_id: _, param } => each_inst(spv::InstWithIds {
                 without_ids: wk.OpFunctionParameter.into(),
                 result_type_id: Some(ids.globals[&Global::Type(param.ty)]),
                 result_id,
                 ids: [].into_iter().collect(),
-            },
-            Self::OpLabel { label_id: _ } => spv::InstWithIds {
+            }),
+            Self::OpLabel { label_id: _ } => each_inst(spv::InstWithIds {
                 without_ids: wk.OpLabel.into(),
                 result_type_id: None,
                 result_id,
                 ids: [].into_iter().collect(),
-            },
-            Self::OpPhi { parent_func_ids, phi } => spv::InstWithIds {
+            }),
+            Self::OpPhi { parent_func_ids, phi } => each_inst(spv::InstWithIds {
                 without_ids: wk.OpPhi.into(),
                 result_type_id: Some(ids.globals[&Global::Type(phi.ty)]),
                 result_id: Some(phi.result_id),
@@ -1258,46 +1483,148 @@ impl LazyInst<'_, '_> {
                         ]
                     })
                     .collect(),
-            },
-            Self::DataInst { parent_func_ids, result_id: _, data_inst_def } => {
-                let DataInstFormDef { kind, output_type } = &cx[data_inst_def.form];
-                let (inst, extra_initial_id_operand) =
-                    match spv::Inst::from_canonical_data_inst_kind(kind).ok_or(kind) {
-                        Ok(spv_inst) => (spv_inst, None),
+            }),
+            Self::DataInst { parent_func_ids, data_inst_def, data_inst_lifting } => {
+                let DataInstFormDef { kind, output_types } = &cx[data_inst_def.form];
 
-                        Err(DataInstKind::Scalar(_) | DataInstKind::Vector(_)) => {
-                            unreachable!("should've been handled as canonical")
+                let mut id_operands = SmallVec::new();
+
+                let mut new_spv_inst_lowering = spv::InstLowering::default();
+                let mut override_result_type = None;
+                let (inst, spv_inst_lowering) = match spv::Inst::from_canonical_data_inst_kind(kind)
+                    .ok_or(kind)
+                {
+                    Ok(spv_inst) => {
+                        // FIXME(eddyb) deduplicate creating this `OpTypeStruct`.
+                        if output_types.len() > 1 {
+                            new_spv_inst_lowering.disaggregated_output = Some(cx.intern(
+                                spv::Inst::from(wk.OpTypeStruct).into_canonical_type_with(
+                                    cx,
+                                    output_types.iter().copied().map(TypeOrConst::Type).collect(),
+                                ),
+                            ));
                         }
+                        (spv_inst, &new_spv_inst_lowering)
+                    }
 
-                        // Disallowed while visiting.
-                        Err(DataInstKind::QPtr(_)) => unreachable!(),
+                    Err(DataInstKind::Scalar(_) | DataInstKind::Vector(_)) => {
+                        unreachable!("should've been handled as canonical")
+                    }
 
-                        Err(&DataInstKind::FuncCall(callee)) => {
-                            (wk.OpFunctionCall.into(), Some(ids.funcs[&callee].func_id))
+                    // Disallowed while visiting.
+                    Err(DataInstKind::QPtr(_)) => unreachable!(),
+
+                    // `OpFunctionCall always has a result (but may be `OpTypeVoid`-typed).
+                    Err(DataInstKind::FuncCall(callee)) => {
+                        let callee_ids = &ids.funcs[callee];
+                        override_result_type = Some(callee_ids.spv_func_ret_type);
+                        if output_types.len() > 1 {
+                            new_spv_inst_lowering.disaggregated_output = override_result_type;
                         }
-                        Err(DataInstKind::SpvInst(inst)) => (inst.clone(), None),
-                        Err(&DataInstKind::SpvExtInst { ext_set, inst }) => (
+                        id_operands.push(callee_ids.func_id);
+                        (wk.OpFunctionCall.into(), &new_spv_inst_lowering)
+                    }
+                    Err(DataInstKind::SpvInst(inst, lowering)) => (inst.clone(), lowering),
+                    Err(DataInstKind::SpvExtInst { ext_set, inst, lowering }) => {
+                        id_operands.push(ids.ext_inst_imports[&cx[*ext_set]]);
+                        (
                             spv::Inst {
                                 opcode: wk.OpExtInst,
-                                imms: iter::once(spv::Imm::Short(wk.LiteralExtInstInteger, inst))
+                                imms: [spv::Imm::Short(wk.LiteralExtInstInteger, *inst)]
+                                    .into_iter()
                                     .collect(),
                             },
-                            Some(ids.ext_inst_imports[&cx[ext_set]]),
-                        ),
-                    };
-                spv::InstWithIds {
-                    without_ids: inst,
-                    result_type_id: output_type.map(|ty| ids.globals[&Global::Type(ty)]),
-                    result_id,
-                    ids: extra_initial_id_operand
-                        .into_iter()
-                        .chain(
-                            data_inst_def.inputs.iter().map(|&v| value_to_id(parent_func_ids, v)),
+                            lowering,
                         )
-                        .collect(),
+                    }
+                };
+
+                let int_imm = |i| spv::Imm::Short(wk.LiteralInteger, i);
+
+                // Emit any `OpCompositeInsert`s needed by the inputs, first,
+                // while gathering the `id_operands` for the instruction itself.
+                let mut reaggregate_inputs = data_inst_lifting.reaggregate_inputs.iter();
+                for id_operand in spv_inst_lowering.reaggreate_inputs(&data_inst_def.inputs) {
+                    let value_to_id = |v| value_to_id(parent_func_ids, v);
+                    let id_operand = match id_operand {
+                        spv::ReaggregatedIdOperand::Direct(v) => value_to_id(v),
+                        spv::ReaggregatedIdOperand::Aggregate { ty, leaves } => {
+                            let result_type_id = Some(ids.globals[&Global::Type(ty)]);
+
+                            let ReaggregateFromLeaves { op_undef, op_composite_insert_result_ids } =
+                                reaggregate_inputs.next().unwrap();
+                            let mut aggregate_id = ids.globals[&Global::Const(*op_undef)];
+                            let leaf_paths = ty
+                                .disaggregated_leaf_types(cx)
+                                .map_with_parent_component_path(|_, leaf_path| {
+                                    leaf_path.iter().map(|&(_, i)| i).map(int_imm).collect()
+                                });
+                            for ((leaf_path_imms, op_composite_insert_result_id), &leaf_value) in
+                                leaf_paths
+                                    .zip_eq(op_composite_insert_result_ids.iter())
+                                    .zip_eq(leaves)
+                            {
+                                each_inst(spv::InstWithIds {
+                                    without_ids: spv::Inst {
+                                        opcode: wk.OpCompositeInsert,
+                                        imms: leaf_path_imms,
+                                    },
+                                    result_type_id,
+                                    result_id: Some(op_composite_insert_result_id),
+                                    ids: [value_to_id(leaf_value), aggregate_id]
+                                        .into_iter()
+                                        .collect(),
+                                });
+                                aggregate_id = op_composite_insert_result_id;
+                            }
+                            aggregate_id
+                        }
+                    };
+                    id_operands.push(id_operand);
+                }
+                assert!(reaggregate_inputs.next().is_none());
+
+                let result_type =
+                    override_result_type.or(spv_inst_lowering.disaggregated_output).or_else(|| {
+                        assert!(output_types.len() <= 1);
+                        output_types.first().copied()
+                    });
+                each_inst(spv::InstWithIds {
+                    without_ids: inst,
+                    result_type_id: result_type.map(|ty| ids.globals[&Global::Type(ty)]),
+                    result_id,
+                    ids: id_operands,
+                });
+
+                // Emit any `OpCompositeExtract`s needed for the result, last.
+                if let Some(DisaggregateToLeaves { op_composite_extract_result_ids }) =
+                    &data_inst_lifting.disaggregate_result
+                {
+                    let aggregate_id = result_id.unwrap();
+                    let leaf_types_and_paths = spv_inst_lowering
+                        .disaggregated_output
+                        .unwrap()
+                        .disaggregated_leaf_types(cx)
+                        .map_with_parent_component_path(|leaf_type, leaf_path| {
+                            (leaf_type, leaf_path.iter().map(|&(_, i)| i).map(int_imm).collect())
+                        });
+                    for ((leaf_type, leaf_path_imms), op_composite_extract_result_id) in
+                        leaf_types_and_paths.zip_eq(op_composite_extract_result_ids.iter())
+                    {
+                        each_inst(spv::InstWithIds {
+                            without_ids: spv::Inst {
+                                opcode: wk.OpCompositeExtract,
+                                imms: leaf_path_imms,
+                            },
+                            result_type_id: Some(ids.globals[&Global::Type(leaf_type)]),
+                            result_id: Some(op_composite_extract_result_id),
+                            ids: [aggregate_id].into_iter().collect(),
+                        });
+                    }
                 }
             }
-            Self::Merge(Merge::Selection(merge_label_id)) => spv::InstWithIds {
+            // FIXME(eddyb) should merge instructions be generated by `Terminator`?
+            Self::Merge(Merge::Selection(merge_label_id)) => each_inst(spv::InstWithIds {
                 without_ids: spv::Inst {
                     opcode: wk.OpSelectionMerge,
                     imms: [spv::Imm::Short(wk.SelectionControl, 0)].into_iter().collect(),
@@ -1305,11 +1632,11 @@ impl LazyInst<'_, '_> {
                 result_type_id: None,
                 result_id: None,
                 ids: [merge_label_id].into_iter().collect(),
-            },
+            }),
             Self::Merge(Merge::Loop {
                 loop_merge: merge_label_id,
                 loop_continue: continue_label_id,
-            }) => spv::InstWithIds {
+            }) => each_inst(spv::InstWithIds {
                 without_ids: spv::Inst {
                     opcode: wk.OpLoopMerge,
                     imms: [spv::Imm::Short(wk.LoopControl, 0)].into_iter().collect(),
@@ -1317,10 +1644,10 @@ impl LazyInst<'_, '_> {
                 result_type_id: None,
                 result_id: None,
                 ids: [merge_label_id, continue_label_id].into_iter().collect(),
-            },
+            }),
             Self::Terminator { parent_func_ids, terminator } => {
                 let parent_func_body_lifting = parent_func_ids.body.as_ref().unwrap();
-                let mut ids: SmallVec<[_; 4]> = terminator
+                let mut id_operands = terminator
                     .inputs
                     .iter()
                     .map(|&v| value_to_id(parent_func_ids, v))
@@ -1332,6 +1659,23 @@ impl LazyInst<'_, '_> {
                     )
                     .collect();
 
+                if let Some(reaggregated_value_id) = terminator.reaggregated_return_value_id {
+                    assert!(
+                        matches!(*terminator.kind, cfg::ControlInstKind::Return)
+                            && terminator.inputs.len() > 1
+                    );
+
+                    each_inst(spv::InstWithIds {
+                        without_ids: wk.OpCompositeConstruct.into(),
+                        result_type_id: Some(
+                            ids.globals[&Global::Type(parent_func_ids.spv_func_ret_type)],
+                        ),
+                        result_id: Some(reaggregated_value_id),
+                        ids: id_operands,
+                    });
+                    id_operands = [reaggregated_value_id].into_iter().collect();
+                }
+
                 // FIXME(eddyb) move some of this to `spv::canonical`.
                 let inst = match &*terminator.kind {
                     cfg::ControlInstKind::Unreachable => wk.OpUnreachable.into(),
@@ -1339,6 +1683,8 @@ impl LazyInst<'_, '_> {
                         if terminator.inputs.is_empty() {
                             wk.OpReturn.into()
                         } else {
+                            // Multiple return values get reaggregated above.
+                            assert_eq!(id_operands.len(), 1);
                             wk.OpReturnValue.into()
                         }
                     }
@@ -1353,8 +1699,8 @@ impl LazyInst<'_, '_> {
                     }
                     cfg::ControlInstKind::SelectBranch(SelectionKind::Switch { case_consts }) => {
                         // HACK(eddyb) move the default case from last back to first.
-                        let default_target = ids.pop().unwrap();
-                        ids.insert(1, default_target);
+                        let default_target = id_operands.pop().unwrap();
+                        id_operands.insert(1, default_target);
 
                         spv::Inst {
                             opcode: wk.OpSwitch,
@@ -1365,16 +1711,20 @@ impl LazyInst<'_, '_> {
                         }
                     }
                 };
-                spv::InstWithIds { without_ids: inst, result_type_id: None, result_id: None, ids }
+                each_inst(spv::InstWithIds {
+                    without_ids: inst,
+                    result_type_id: None,
+                    result_id: None,
+                    ids: id_operands,
+                });
             }
-            Self::OpFunctionEnd => spv::InstWithIds {
+            Self::OpFunctionEnd => each_inst(spv::InstWithIds {
                 without_ids: wk.OpFunctionEnd.into(),
                 result_type_id: None,
                 result_id: None,
                 ids: [].into_iter().collect(),
-            },
-        };
-        (inst, attrs)
+            }),
+        }
     }
 }
 
@@ -1417,35 +1767,38 @@ impl Module {
         // Collect uses scattered throughout the module, allocating IDs for them.
         let (ids, id_bound) = {
             let mut id_bound = NonZeroUsize::MIN;
-            let mut id_allocator = IdAllocator {
+            let mut lifter = Lifter {
                 cx: &cx,
                 module: self,
-                alloc_id: || {
-                    let id = id_bound;
-                    id_bound =
-                        id_bound.checked_add(1).expect("overflowing `usize` should be impossible");
+                alloc_ids: |count| {
+                    let start = id_bound;
+                    let end =
+                        start.checked_add(count).expect("overflowing `usize` should be impossible");
+                    id_bound = end;
 
                     // NOTE(eddyb) `MAX` is just a placeholder - the check for overflows
                     // is done below, after all IDs that may be allocated, have been
                     // (this is in order to not need this closure to return a `Result`).
-                    id.try_into().unwrap_or(spv::Id::new(u32::MAX).unwrap())
+                    let from_usize =
+                        |id| spv::Id::try_from(id).unwrap_or(spv::Id::new(u32::MAX).unwrap());
+                    from_usize(start)..from_usize(end)
                 },
                 ids: ModuleIds::default(),
                 data_inst_forms_seen: FxIndexSet::default(),
                 global_vars_seen: FxIndexSet::default(),
             };
-            id_allocator.visit_module(self);
+            lifter.visit_module(self);
 
             // See comment on `global_var_to_id_giving_global` for why this is here.
-            for &gv in &id_allocator.global_vars_seen {
-                id_allocator
+            for &gv in &lifter.global_vars_seen {
+                lifter
                     .ids
                     .globals
                     .entry(global_var_to_id_giving_global(gv))
-                    .or_insert_with(&mut id_allocator.alloc_id);
+                    .or_insert_with(|| lifter.alloc_ids.one());
             }
 
-            let ids = id_allocator.ids;
+            let ids = lifter.ids;
 
             let id_bound = spv::Id::try_from(id_bound).ok().ok_or_else(|| {
                 io::Error::new(
@@ -1472,10 +1825,11 @@ impl Module {
                     _ => unreachable!(),
                 };
 
-                let param_insts =
-                    func_ids.param_ids.iter().zip(&func_decl.params).map(|(&param_id, param)| {
-                        LazyInst::OpFunctionParameter { param_id, param }
-                    });
+                let param_insts = func_ids
+                    .param_ids
+                    .iter()
+                    .zip_eq(&func_decl.params)
+                    .map(|(param_id, param)| LazyInst::OpFunctionParameter { param_id, param });
                 let body_insts = body_with_lifting.map(|(func_def_body, func_body_lifting)| {
                     func_body_lifting.blocks.iter().flat_map(move |(point, block)| {
                         let BlockLifting { phis, insts, terminator } = block;
@@ -1496,11 +1850,9 @@ impl Module {
                                     let data_inst_def = func_at_inst.def();
                                     LazyInst::DataInst {
                                         parent_func_ids: func_ids,
-                                        result_id: cx[data_inst_def.form].output_type.map(|_| {
-                                            func_body_lifting.data_inst_output_ids
-                                                [&func_at_inst.position]
-                                        }),
                                         data_inst_def,
+                                        data_inst_lifting: &func_body_lifting.data_insts
+                                            [func_at_inst.position],
                                     }
                                 }),
                         )
@@ -1771,55 +2123,56 @@ impl Module {
         let mut current_debug_line = None;
         let mut current_block_id = None; // HACK(eddyb) for `current_debug_line` resets.
         for lazy_inst in global_and_func_insts {
-            let (inst, attrs) = lazy_inst.to_inst_and_attrs(self, ids);
-
-            // Reset line debuginfo when crossing/leaving blocks.
-            let new_block_id = if inst.opcode == wk.OpLabel {
-                Some(inst.result_id.unwrap())
-            } else if inst.opcode == wk.OpFunctionEnd {
-                None
-            } else {
-                current_block_id
-            };
-            if current_block_id != new_block_id {
-                current_debug_line = None;
-            }
-            current_block_id = new_block_id;
-
-            // Determine whether to emit `OpLine`/`OpNoLine` before `inst`,
-            // in order to end up with the expected line debuginfo.
-            // FIXME(eddyb) make this less of a search and more of a
-            // lookup by splitting attrs into key and value parts.
-            let new_debug_line = cx[attrs].attrs.iter().find_map(|attr| match *attr {
-                Attr::SpvDebugLine { file_path, line, col } => {
-                    Some((ids.debug_strings[&cx[file_path.0]], line, col))
+            let mut result: Result<(), _> = Ok(());
+            lazy_inst.for_each_spv_inst_with_debug_line(self, ids, |inst, new_debug_line| {
+                if result.is_err() {
+                    return;
                 }
-                _ => None,
-            });
-            if current_debug_line != new_debug_line {
-                let (opcode, imms, ids) = match new_debug_line {
-                    Some((file_path_id, line, col)) => (
-                        wk.OpLine,
-                        [
-                            spv::Imm::Short(wk.LiteralInteger, line),
-                            spv::Imm::Short(wk.LiteralInteger, col),
-                        ]
-                        .into_iter()
-                        .collect(),
-                        iter::once(file_path_id).collect(),
-                    ),
-                    None => (wk.OpNoLine, [].into_iter().collect(), [].into_iter().collect()),
-                };
-                emitter.push_inst(&spv::InstWithIds {
-                    without_ids: spv::Inst { opcode, imms },
-                    result_type_id: None,
-                    result_id: None,
-                    ids,
-                })?;
-            }
-            current_debug_line = new_debug_line;
 
-            emitter.push_inst(&inst)?;
+                // Reset line debuginfo when crossing/leaving blocks.
+                let new_block_id = if inst.opcode == wk.OpLabel {
+                    Some(inst.result_id.unwrap())
+                } else if inst.opcode == wk.OpFunctionEnd {
+                    None
+                } else {
+                    current_block_id
+                };
+                if current_block_id != new_block_id {
+                    current_debug_line = None;
+                }
+                current_block_id = new_block_id;
+
+                // Determine whether to emit `OpLine`/`OpNoLine` before `inst`,
+                // in order to end up with the expected line debuginfo.
+                if current_debug_line != new_debug_line {
+                    let (opcode, imms, ids) = match new_debug_line {
+                        Some(SpvDebugLine { file_path_id, line, col }) => (
+                            wk.OpLine,
+                            [
+                                spv::Imm::Short(wk.LiteralInteger, line),
+                                spv::Imm::Short(wk.LiteralInteger, col),
+                            ]
+                            .into_iter()
+                            .collect(),
+                            iter::once(file_path_id).collect(),
+                        ),
+                        None => (wk.OpNoLine, [].into_iter().collect(), [].into_iter().collect()),
+                    };
+                    result = emitter.push_inst(&spv::InstWithIds {
+                        without_ids: spv::Inst { opcode, imms },
+                        result_type_id: None,
+                        result_id: None,
+                        ids,
+                    });
+                    if result.is_err() {
+                        return;
+                    }
+                }
+                current_debug_line = new_debug_line;
+
+                result = emitter.push_inst(&inst);
+            });
+            result?;
         }
 
         Ok(emitter)

--- a/src/spv/lift.rs
+++ b/src/spv/lift.rs
@@ -1309,6 +1309,14 @@ impl LazyInst<'_, '_> {
                 ids: [merge_label_id, continue_label_id].into_iter().collect(),
             },
             Self::Terminator { parent_func, terminator } => {
+                let mut ids: SmallVec<[_; 4]> = terminator
+                    .inputs
+                    .iter()
+                    .map(|&v| value_to_id(parent_func, v))
+                    .chain(terminator.targets.iter().map(|&target| parent_func.label_ids[&target]))
+                    .collect();
+
+                // FIXME(eddyb) move some of this to `spv::canonical`.
                 let inst = match &*terminator.kind {
                     cfg::ControlInstKind::Unreachable => wk.OpUnreachable.into(),
                     cfg::ControlInstKind::Return => {
@@ -1327,23 +1335,21 @@ impl LazyInst<'_, '_> {
                     cfg::ControlInstKind::SelectBranch(SelectionKind::BoolCond) => {
                         wk.OpBranchConditional.into()
                     }
-                    cfg::ControlInstKind::SelectBranch(SelectionKind::SpvInst(inst)) => {
-                        inst.clone()
+                    cfg::ControlInstKind::SelectBranch(SelectionKind::Switch { case_consts }) => {
+                        // HACK(eddyb) move the default case from last back to first.
+                        let default_target = ids.pop().unwrap();
+                        ids.insert(1, default_target);
+
+                        spv::Inst {
+                            opcode: wk.OpSwitch,
+                            imms: case_consts
+                                .iter()
+                                .flat_map(|ct| ct.encode_as_spv_imms())
+                                .collect(),
+                        }
                     }
                 };
-                spv::InstWithIds {
-                    without_ids: inst,
-                    result_type_id: None,
-                    result_id: None,
-                    ids: terminator
-                        .inputs
-                        .iter()
-                        .map(|&v| value_to_id(parent_func, v))
-                        .chain(
-                            terminator.targets.iter().map(|&target| parent_func.label_ids[&target]),
-                        )
-                        .collect(),
-                }
+                spv::InstWithIds { without_ids: inst, result_type_id: None, result_id: None, ids }
             }
             Self::OpFunctionEnd => spv::InstWithIds {
                 without_ids: wk.OpFunctionEnd.into(),

--- a/src/spv/lift.rs
+++ b/src/spv/lift.rs
@@ -121,8 +121,22 @@ impl Visitor<'_> for NeedsIdsCollector<'_> {
             return;
         }
         let ty_def = &self.cx[ty];
+
+        // HACK(eddyb) there isn't a great way to handle canonical types, but
+        // perhaps this result should be recorded in `self.globals`?
+        if let Some((_spv_inst, type_and_const_inputs)) =
+            spv::Inst::from_canonical_type(self.cx, &ty_def.kind)
+        {
+            for ty_or_ct in type_and_const_inputs {
+                match ty_or_ct {
+                    TypeOrConst::Type(ty) => self.visit_type_use(ty),
+                    TypeOrConst::Const(ct) => self.visit_const_use(ct),
+                }
+            }
+        }
+
         match ty_def.kind {
-            TypeKind::Scalar(_) | TypeKind::SpvInst { .. } => {}
+            TypeKind::Scalar(_) | TypeKind::Vector(_) | TypeKind::SpvInst { .. } => {}
 
             // FIXME(eddyb) this should be a proper `Result`-based error instead,
             // and/or `spv::lift` should mutate the module for legalization.
@@ -137,6 +151,7 @@ impl Visitor<'_> for NeedsIdsCollector<'_> {
                 );
             }
         }
+
         self.visit_type_def(ty_def);
         self.globals.insert(global);
     }
@@ -146,9 +161,21 @@ impl Visitor<'_> for NeedsIdsCollector<'_> {
             return;
         }
         let ct_def = &self.cx[ct];
+
+        // HACK(eddyb) there isn't a great way to handle canonical consts, but
+        // perhaps this result should be recorded in `self.globals`?
+        if let Some((_spv_inst, const_inputs)) =
+            spv::Inst::from_canonical_const(self.cx, &ct_def.kind)
+        {
+            for ct in const_inputs {
+                self.visit_const_use(ct);
+            }
+        }
+
         match ct_def.kind {
             ConstKind::Undef
             | ConstKind::Scalar(_)
+            | ConstKind::Vector(_)
             | ConstKind::PtrToGlobalVar(_)
             | ConstKind::SpvInst { .. } => {
                 self.visit_const_def(ct_def);
@@ -1030,9 +1057,10 @@ impl LazyInst<'_, '_> {
                                 (gv_decl.attrs, import)
                             }
 
-                            ConstKind::Undef | ConstKind::Scalar(_) | ConstKind::SpvInst { .. } => {
-                                (ct_def.attrs, None)
-                            }
+                            ConstKind::Undef
+                            | ConstKind::Scalar(_)
+                            | ConstKind::Vector(_)
+                            | ConstKind::SpvInst { .. } => (ct_def.attrs, None),
 
                             // Not inserted into `globals` while visiting.
                             ConstKind::SpvStringLiteralForExtInst(_) => unreachable!(),
@@ -1100,19 +1128,16 @@ impl LazyInst<'_, '_> {
             Self::Global(global) => match global {
                 Global::Type(ty) => {
                     let ty_def = &cx[ty];
-                    match spv::Inst::from_canonical_type(&ty_def.kind).ok_or(&ty_def.kind) {
-                        Ok(spv_inst) => spv::InstWithIds {
-                            without_ids: spv_inst,
-                            result_type_id: None,
-                            result_id,
-                            ids: [].into_iter().collect(),
-                        },
-
-                        Err(TypeKind::Scalar(_)) => {
+                    match spv::Inst::from_canonical_type(cx, &ty_def.kind)
+                        .as_ref()
+                        .ok_or(&ty_def.kind)
+                    {
+                        Err(TypeKind::Scalar(_) | TypeKind::Vector(_)) => {
                             unreachable!("should've been handled as canonical")
                         }
 
-                        Err(TypeKind::SpvInst { spv_inst, type_and_const_inputs }) => {
+                        Ok((spv_inst, type_and_const_inputs))
+                        | Err(TypeKind::SpvInst { spv_inst, type_and_const_inputs }) => {
                             spv::InstWithIds {
                                 without_ids: spv_inst.clone(),
                                 result_type_id: None,
@@ -1137,15 +1162,32 @@ impl LazyInst<'_, '_> {
                 }
                 Global::Const(ct) => {
                     let ct_def = &cx[ct];
-                    match spv::Inst::from_canonical_const(&ct_def.kind).ok_or(&ct_def.kind) {
-                        Ok(spv_inst) => spv::InstWithIds {
+                    match spv::Inst::from_canonical_const(cx, &ct_def.kind).ok_or(&ct_def.kind) {
+                        // FIXME(eddyb) this duplicates the `ConstKind::SpvInst`
+                        // case, only due to an inability to pattern-match `Rc`.
+                        Ok((spv_inst, const_inputs)) => spv::InstWithIds {
                             without_ids: spv_inst,
                             result_type_id: Some(ids.globals[&Global::Type(ct_def.ty)]),
                             result_id,
-                            ids: [].into_iter().collect(),
+                            ids: const_inputs
+                                .iter()
+                                .map(|&ct| ids.globals[&Global::Const(ct)])
+                                .collect(),
                         },
+                        Err(ConstKind::SpvInst { spv_inst_and_const_inputs }) => {
+                            let (spv_inst, const_inputs) = &**spv_inst_and_const_inputs;
+                            spv::InstWithIds {
+                                without_ids: spv_inst.clone(),
+                                result_type_id: Some(ids.globals[&Global::Type(ct_def.ty)]),
+                                result_id,
+                                ids: const_inputs
+                                    .iter()
+                                    .map(|&ct| ids.globals[&Global::Const(ct)])
+                                    .collect(),
+                            }
+                        }
 
-                        Err(ConstKind::Undef | ConstKind::Scalar(_)) => {
+                        Err(ConstKind::Undef | ConstKind::Scalar(_) | ConstKind::Vector(_)) => {
                             unreachable!("should've been handled as canonical")
                         }
 
@@ -1179,19 +1221,6 @@ impl LazyInst<'_, '_> {
                                 result_type_id: Some(ids.globals[&Global::Type(ct_def.ty)]),
                                 result_id,
                                 ids: initializer.into_iter().collect(),
-                            }
-                        }
-
-                        Err(ConstKind::SpvInst { spv_inst_and_const_inputs }) => {
-                            let (spv_inst, const_inputs) = &**spv_inst_and_const_inputs;
-                            spv::InstWithIds {
-                                without_ids: spv_inst.clone(),
-                                result_type_id: Some(ids.globals[&Global::Type(ct_def.ty)]),
-                                result_id,
-                                ids: const_inputs
-                                    .iter()
-                                    .map(|&ct| ids.globals[&Global::Const(ct)])
-                                    .collect(),
                             }
                         }
 

--- a/src/spv/lift.rs
+++ b/src/spv/lift.rs
@@ -254,7 +254,11 @@ impl Visitor<'_> for NeedsIdsCollector<'_> {
                 unreachable!("`DataInstKind::QPtr` should be legalized away before lifting");
             }
 
-            DataInstKind::Scalar(_) | DataInstKind::FuncCall(_) | DataInstKind::SpvInst(_) => {}
+            DataInstKind::Scalar(_)
+            | DataInstKind::Vector(_)
+            | DataInstKind::FuncCall(_)
+            | DataInstKind::SpvInst(_) => {}
+
             DataInstKind::SpvExtInst { ext_set, .. } => {
                 self.ext_inst_imports.insert(&self.cx[ext_set]);
             }
@@ -1286,7 +1290,7 @@ impl LazyInst<'_, '_> {
                     match spv::Inst::from_canonical_data_inst_kind(kind).ok_or(kind) {
                         Ok(spv_inst) => (spv_inst, None),
 
-                        Err(DataInstKind::Scalar(_)) => {
+                        Err(DataInstKind::Scalar(_) | DataInstKind::Vector(_)) => {
                             unreachable!("should've been handled as canonical")
                         }
 

--- a/src/spv/lower.rs
+++ b/src/spv/lower.rs
@@ -1292,7 +1292,13 @@ impl Module {
                     // some "structured regions" replacement for the CFG.
                 } else {
                     let mut ids = &ids[..];
-                    let kind = if opcode == wk.OpFunctionCall {
+                    let kind = if let Some(kind) = raw_inst.without_ids.as_canonical_data_inst_kind(
+                        &cx,
+                        result_type.map(|ty| [ty]).as_ref().map_or(&[][..], |tys| &tys[..]),
+                    ) {
+                        // FIXME(eddyb) sanity-check the number/types of inputs.
+                        kind
+                    } else if opcode == wk.OpFunctionCall {
                         assert!(imms.is_empty());
                         let callee_id = ids[0];
                         let maybe_callee = id_defs

--- a/src/spv/lower.rs
+++ b/src/spv/lower.rs
@@ -589,15 +589,9 @@ impl Module {
 
                 let ty = cx.intern(TypeDef {
                     attrs: mem::take(&mut attrs),
-                    kind: match inst.as_canonical_type() {
-                        Some(type_kind) => {
-                            assert_eq!(type_and_const_inputs.len(), 0);
-                            type_kind
-                        }
-                        None => {
-                            TypeKind::SpvInst { spv_inst: inst.without_ids, type_and_const_inputs }
-                        }
-                    },
+                    kind: inst.as_canonical_type(&cx, &type_and_const_inputs).unwrap_or(
+                        TypeKind::SpvInst { spv_inst: inst.without_ids, type_and_const_inputs },
+                    ),
                 });
                 id_defs.insert(id, IdDef::Type(ty));
 
@@ -626,15 +620,11 @@ impl Module {
                 let ct = cx.intern(ConstDef {
                     attrs: mem::take(&mut attrs),
                     ty,
-                    kind: match inst.as_canonical_const(&cx, ty) {
-                        Some(const_kind) => {
-                            assert_eq!(const_inputs.len(), 0);
-                            const_kind
-                        }
-                        None => ConstKind::SpvInst {
+                    kind: inst.as_canonical_const(&cx, ty, &const_inputs).unwrap_or_else(|| {
+                        ConstKind::SpvInst {
                             spv_inst_and_const_inputs: Rc::new((inst.without_ids, const_inputs)),
-                        },
-                    },
+                        }
+                    }),
                 });
                 id_defs.insert(id, IdDef::Const(ct));
 

--- a/src/spv/mod.rs
+++ b/src/spv/mod.rs
@@ -2,6 +2,7 @@
 
 // NOTE(eddyb) all the modules are declared here, but they're documented "inside"
 // (i.e. using inner doc comments).
+pub mod canonical;
 pub mod lift;
 pub mod lower;
 pub mod print;

--- a/src/spv/mod.rs
+++ b/src/spv/mod.rs
@@ -10,11 +10,12 @@ pub mod read;
 pub mod spec;
 pub mod write;
 
-use crate::{FxIndexMap, InternedStr};
+use crate::{Context, FxIndexMap, InternedStr, Type, TypeDef, TypeKind, TypeOrConst};
 use smallvec::SmallVec;
 use std::collections::{BTreeMap, BTreeSet};
 use std::iter;
 use std::num::NonZeroU32;
+use std::ops::Range;
 use std::string::FromUtf8Error;
 
 /// Semantic properties of a SPIR-V module (not tied to any IDs).
@@ -49,6 +50,316 @@ pub struct DebugSourceLang {
 #[derive(Clone, Default)]
 pub struct DebugSources {
     pub file_contents: FxIndexMap<InternedStr, String>,
+}
+
+/// Most SPIR-V types can be used as SPIR-V (SSA) value types, but some require
+/// non-trivial lowering into SPIR-T [`Value`](crate::Value)s (e.g. expanding
+/// one SPIR-V value into any number of *valid* SPIR-T values).
+//
+// FIXME(eddyb) aggregates without known leaf counts using `Direct` is worse than
+// treating them as an error (and e.g. generating `Diag`s), but it's also simpler.
+#[derive(Clone, Default, PartialEq, Eq, Hash)]
+pub enum ValueLowering {
+    /// SPIR-V values of this type map to SPIR-T [`Value`](crate::Value)s with the same type
+    /// (see [`Value`](crate::Value) documentation for more details, and valid types).
+    #[default]
+    Direct,
+
+    /// SPIR-V values of this type can't be kept intract in SPIR-T, but instead
+    /// require decomposion into their "leaves", i.e. valid SPIR-T [`Value`](crate::Value)s.
+    Disaggregate(AggregateShape),
+}
+
+#[derive(Clone, PartialEq, Eq, Hash)]
+pub enum AggregateShape {
+    Struct { per_field_leaf_range_end: SmallVec<[u32; 4]> },
+    Array { fixed_len: u32, total_leaf_count: u32 },
+}
+
+impl AggregateShape {
+    // FIXME(eddyb) force this to be used via some kind of forced canonicalization.
+    pub fn compute(
+        cx: &Context,
+        spv_inst: &Inst,
+        type_and_const_inputs: &[TypeOrConst],
+    ) -> Option<Self> {
+        let wk = &spec::Spec::get().well_known;
+
+        if spv_inst.opcode == wk.OpTypeStruct {
+            let mut leaf_count = 0u32;
+            let mut per_field_leaf_range_end = SmallVec::new();
+            for &ty_or_ct in type_and_const_inputs {
+                let field_type = match ty_or_ct {
+                    TypeOrConst::Type(ty) => ty,
+                    TypeOrConst::Const(_) => return None,
+                };
+                let field_leaf_count = cx[field_type].disaggregated_leaf_count_u32();
+
+                leaf_count = leaf_count.checked_add(field_leaf_count)?;
+                per_field_leaf_range_end.push(leaf_count);
+            }
+            Some(Self::Struct { per_field_leaf_range_end })
+        } else if spv_inst.opcode == wk.OpTypeArray {
+            let (elem_type, len) = match type_and_const_inputs[..] {
+                [TypeOrConst::Type(elem_type), TypeOrConst::Const(len)] => (elem_type, len),
+                _ => return None,
+            };
+
+            // NOTE(eddyb) this can legally be `None` when the length of
+            // the array is given by a specialization constant.
+            let fixed_len = len.as_scalar(cx).and_then(|len| len.int_as_u32());
+            let fixed_len = fixed_len?;
+
+            let elem_leaf_count = cx[elem_type].disaggregated_leaf_count_u32();
+
+            Some(Self::Array {
+                fixed_len,
+                total_leaf_count: elem_leaf_count.checked_mul(fixed_len)?,
+            })
+        } else {
+            None
+        }
+    }
+}
+
+// FIXME(eddyb) not the best place to put these utilities, but they're used in
+// both `spv::lower` and `spv::lift` (and they use private methods defined here).
+// FIXME(eddyb) consider moving some of this to `spv::canonical`.
+impl TypeDef {
+    fn spv_value_lowering(&self) -> &ValueLowering {
+        match &self.kind {
+            TypeKind::Scalar(_)
+            | TypeKind::Vector(_)
+            | TypeKind::QPtr
+            | TypeKind::SpvStringLiteralForExtInst => &ValueLowering::Direct,
+            TypeKind::SpvInst { value_lowering, .. } => value_lowering,
+        }
+    }
+
+    fn disaggregated_leaf_count(&self) -> usize {
+        self.disaggregated_leaf_count_u32() as usize
+    }
+
+    fn disaggregated_leaf_count_u32(&self) -> u32 {
+        match self.spv_value_lowering() {
+            ValueLowering::Direct => 1,
+            ValueLowering::Disaggregate(AggregateShape::Struct { per_field_leaf_range_end }) => {
+                per_field_leaf_range_end.last().copied().unwrap_or(0)
+            }
+            &ValueLowering::Disaggregate(AggregateShape::Array { total_leaf_count, .. }) => {
+                total_leaf_count
+            }
+        }
+    }
+}
+
+/// Tree-like (preorder) traversal tool for [`ValueLowering::Disaggregate`] types.
+struct AggregateCursor<'a> {
+    cx: &'a Context,
+    // FIXME(eddyb) should this cache any references into `&Context`?
+    current: Type,
+    parent_component_path: SmallVec<[(Type, u32); 8]>,
+}
+
+impl AggregateCursor<'_> {
+    // HACK(eddyb) this returns `true` iff a new node was found.
+    fn try_advance(&mut self) -> bool {
+        // FIXME(eddyb) this isn't the best organization possible.
+        let cx = self.cx;
+        let get_component = move |ty: Type, idx: u32| -> Option<Type> {
+            let ty_def = &cx[ty];
+            let type_input_idx = match ty_def.spv_value_lowering() {
+                ValueLowering::Direct => return None,
+                ValueLowering::Disaggregate(AggregateShape::Struct { .. }) => idx,
+                &ValueLowering::Disaggregate(AggregateShape::Array { fixed_len, .. }) => {
+                    if idx >= fixed_len {
+                        return None;
+                    }
+                    0
+                }
+            };
+            let type_and_const_inputs = match &ty_def.kind {
+                TypeKind::Scalar(_)
+                | TypeKind::Vector(_)
+                | TypeKind::QPtr
+                | TypeKind::SpvStringLiteralForExtInst => &[][..],
+                TypeKind::SpvInst { type_and_const_inputs, .. } => &type_and_const_inputs[..],
+            };
+            let expect_type = |ty_or_ct| match ty_or_ct {
+                TypeOrConst::Type(ty) => ty,
+                TypeOrConst::Const(_) => unreachable!(),
+            };
+            Some(expect_type(*type_and_const_inputs.get(usize::try_from(type_input_idx).ok()?)?))
+        };
+
+        // Try descending first, into the first child.
+        if let Some(first_child_type) = get_component(self.current, 0) {
+            self.parent_component_path.push((self.current, 0));
+            self.current = first_child_type;
+            return true;
+        }
+
+        // Try ascending until there is a next sibling to descend into, but only
+        // modifying `self` iff any such node is found, otherwise calling this
+        // method without checking its success, could result in infinite cycles.
+        for depth in (0..self.parent_component_path.len()).rev() {
+            let (ancestor_type, ancestor_child_idx) = &mut self.parent_component_path[depth];
+            if let Some(sibling_idx) = ancestor_child_idx.checked_add(1) {
+                if let Some(sibling_type) = get_component(*ancestor_type, sibling_idx) {
+                    *ancestor_child_idx = sibling_idx;
+                    self.current = sibling_type;
+                    self.parent_component_path.truncate(depth + 1);
+                    return true;
+                }
+            }
+        }
+
+        false
+    }
+
+    // FIXME(eddyb) can't find a great name for this - crucially, if this is a
+    // leaf, it's a noop, it doesn't find the next leaf!
+    // HACK(eddyb) this returns `true` iff a leaf node was found.
+    fn try_ensure_at_leaf(&mut self) -> bool {
+        loop {
+            if let ValueLowering::Direct = self.cx[self.current].spv_value_lowering() {
+                return true;
+            }
+            if !self.try_advance() {
+                return false;
+            }
+        }
+    }
+}
+
+/// Recursively flattening iterator for [`ValueLowering::Disaggregate`] types.
+struct DisaggregatedLeafTypes<'a>(Option<AggregateCursor<'a>>);
+
+impl Iterator for DisaggregatedLeafTypes<'_> {
+    type Item = Type;
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        // HACK(eddyb) only compute a size hint for the fresh iterator.
+        if let Self(Some(cursor)) = self {
+            if cursor.parent_component_path.is_empty() {
+                let leaf_count = cursor.cx[cursor.current].disaggregated_leaf_count();
+                return (leaf_count, Some(leaf_count));
+            }
+        }
+        (0, None)
+    }
+
+    fn next(&mut self) -> Option<Type> {
+        let cursor = self.0.as_mut()?;
+        let next = cursor.try_ensure_at_leaf().then_some(cursor.current);
+
+        // Record advancement failure, ensuring future calls to `next` return `None`.
+        if !(next.is_some() && cursor.try_advance()) {
+            *self = Self(None);
+        }
+
+        next
+    }
+}
+
+// HACK(eddyb) `impl Trait` helper for when a non-bound lifetime needs capturing.
+// FIXME(eddyb) should `map_with_parent_component_path` even use `impl Trait`?
+trait Captures<'a> {}
+impl<T> Captures<'_> for T {}
+
+impl<'a> DisaggregatedLeafTypes<'a> {
+    // HACK(eddyb) like `map`, but acessing the `parent_component_path` of
+    // the inner `AggregateCursor`, when it is possitioned at each leaf.
+    fn map_with_parent_component_path<T>(
+        self,
+        mut f: impl FnMut(Type, &[(Type, u32)]) -> T,
+    ) -> impl Iterator<Item = T> + Captures<'a> {
+        let Self(mut cursor_slot) = self;
+        iter::from_fn(move || {
+            let cursor = cursor_slot.as_mut()?;
+            let next = cursor
+                .try_ensure_at_leaf()
+                .then(|| f(cursor.current, &cursor.parent_component_path));
+
+            // Record advancement failure, ensuring future calls to `next` return `None`.
+            if !(next.is_some() && cursor.try_advance()) {
+                cursor_slot = None;
+            }
+
+            next
+        })
+    }
+}
+
+// FIXME(eddyb) not the best place to put these utilities, but they're used in
+// both `spv::lower` and `spv::lift` (and they use private methods defined here).
+// FIXME(eddyb) consider moving some of this to `spv::canonical`.
+impl Type {
+    fn disaggregated_leaf_types(self, cx: &Context) -> DisaggregatedLeafTypes<'_> {
+        DisaggregatedLeafTypes(Some(AggregateCursor {
+            cx,
+            current: self,
+            parent_component_path: SmallVec::new(),
+        }))
+    }
+}
+
+/// Aspects of how a [`spv::Inst`](Inst) was produced by [`spv::lower`](lower),
+/// which were otherwise lost in the SPIR-T form, but are still required for
+/// [`spv::lift`](lift) to reproduce the original SPIR-V instruction.
+///
+/// Primarily used within [`DataInstKind`](crate::DataInstKind) due to SPIR-V
+/// instructions that take or produce "aggregates" (`OpTypeStruct`/`OpTypeArray`)
+/// and which may require the exact original types (i.e. may not be valid when
+/// using a fresh `OpTypeStruct` of the flattened non-"aggregate" components).
+#[derive(Clone, Default, PartialEq, Eq, Hash)]
+pub struct InstLowering {
+    // FIXME(eddyb) should this be named "result" instead of "output", somewhat
+    // standardizing the idea that 1 SPIR-V "result" maps to N SPIR-T "outputs"?
+    pub disaggregated_output: Option<Type>,
+
+    // FIXME(eddyb) only store the starts, and get the leaf counts from the `Type`.
+    pub disaggregated_inputs: SmallVec<[(Range<u32>, Type); 1]>,
+}
+
+/// Helper type for [`InstLowering::reaggreate_inputs`], which corresponds to
+/// one or more inputs of a SPIR-V instruction (after being lowered to SPIR-T),
+/// according to the [`InstLowering`] (and its `disaggregated_inputs` field).
+#[derive(Copy, Clone)]
+pub enum ReaggregatedIdOperand<'a, T> {
+    Direct(T),
+    Aggregate { ty: Type, leaves: &'a [T] },
+}
+
+impl InstLowering {
+    pub fn reaggreate_inputs<'a, T: Copy>(
+        &'a self,
+        inputs: &'a [T],
+    ) -> impl Iterator<Item = ReaggregatedIdOperand<'a, T>> + Clone {
+        // HACK(eddyb) the `None` at the end handles remainining direct inputs.
+        let mut prev_end = 0;
+        self.disaggregated_inputs.iter().map(Some).chain([None]).flat_map(
+            move |maybe_disaggregated| {
+                // FIXME(eddyb) the range manipulation is all over the place here.
+                let direct_range = prev_end
+                    ..maybe_disaggregated.map_or(inputs.len(), |(range, _)| range.start as usize);
+                assert!(direct_range.start <= direct_range.end);
+                prev_end = direct_range.end;
+
+                let direct_inputs =
+                    inputs[direct_range].iter().copied().map(ReaggregatedIdOperand::Direct);
+
+                let aggregate_input = maybe_disaggregated.map(|(range, ty)| {
+                    let leaves_range = range.start as usize..range.end as usize;
+                    prev_end = leaves_range.end;
+
+                    ReaggregatedIdOperand::Aggregate { ty: *ty, leaves: &inputs[leaves_range] }
+                });
+
+                direct_inputs.chain(aggregate_input)
+            },
+        )
+    }
 }
 
 /// A SPIR-V instruction, in its minimal form (opcode and immediate operands).

--- a/src/spv/spec.rs
+++ b/src/spv/spec.rs
@@ -136,7 +136,6 @@ def_well_known! {
         OpConstantFalse,
         OpConstantTrue,
         OpConstant,
-        OpUndef,
 
         OpVariable,
 

--- a/src/spv/spec.rs
+++ b/src/spv/spec.rs
@@ -117,9 +117,6 @@ def_well_known! {
         OpNoLine,
 
         OpTypeVoid,
-        OpTypeBool,
-        OpTypeInt,
-        OpTypeFloat,
         OpTypeVector,
         OpTypeMatrix,
         OpTypeArray,
@@ -132,10 +129,6 @@ def_well_known! {
         OpTypeSampler,
         OpTypeSampledImage,
         OpTypeAccelerationStructureKHR,
-
-        OpConstantFalse,
-        OpConstantTrue,
-        OpConstant,
 
         OpVariable,
 

--- a/src/spv/spec.rs
+++ b/src/spv/spec.rs
@@ -129,6 +129,7 @@ def_well_known! {
         OpTypeSampledImage,
         OpTypeAccelerationStructureKHR,
 
+        // FIXME(eddyb) hide these from code, lowering should handle most cases.
         OpConstantComposite,
 
         OpVariable,
@@ -159,6 +160,11 @@ def_well_known! {
         OpPtrAccessChain,
         OpInBoundsPtrAccessChain,
         OpBitcast,
+
+        // FIXME(eddyb) hide these from code, lowering should handle most cases.
+        OpCompositeInsert,
+        OpCompositeExtract,
+        OpCompositeConstruct,
     ],
     operand_kind: OperandKind = [
         Capability,

--- a/src/spv/spec.rs
+++ b/src/spv/spec.rs
@@ -117,7 +117,6 @@ def_well_known! {
         OpNoLine,
 
         OpTypeVoid,
-        OpTypeVector,
         OpTypeMatrix,
         OpTypeArray,
         OpTypeRuntimeArray,
@@ -129,6 +128,8 @@ def_well_known! {
         OpTypeSampler,
         OpTypeSampledImage,
         OpTypeAccelerationStructureKHR,
+
+        OpConstantComposite,
 
         OpVariable,
 

--- a/src/spv/spec.rs
+++ b/src/spv/spec.rs
@@ -131,6 +131,7 @@ def_well_known! {
 
         // FIXME(eddyb) hide these from code, lowering should handle most cases.
         OpConstantComposite,
+        OpSpecConstantComposite,
 
         OpVariable,
 

--- a/src/spv/spec.rs
+++ b/src/spv/spec.rs
@@ -155,6 +155,7 @@ def_well_known! {
 
         OpLoad,
         OpStore,
+        OpCopyMemory,
         OpArrayLength,
         OpAccessChain,
         OpInBoundsAccessChain,

--- a/src/spv/spec.rs
+++ b/src/spv/spec.rs
@@ -175,6 +175,7 @@ def_well_known! {
         LiteralExtInstInteger,
         LiteralString,
         LiteralContextDependentNumber,
+        LiteralSpecConstantOpInteger,
     ],
     // FIXME(eddyb) find a way to namespace these to avoid conflicts.
     addressing_model: u32 = [

--- a/src/transform.rs
+++ b/src/transform.rs
@@ -424,7 +424,9 @@ impl InnerTransform for TypeDef {
         transform!({
             attrs -> transformer.transform_attr_set_use(*attrs),
             kind -> match kind {
-                TypeKind::QPtr | TypeKind::SpvStringLiteralForExtInst => Transformed::Unchanged,
+                TypeKind::Scalar(_)
+                | TypeKind::QPtr
+                | TypeKind::SpvStringLiteralForExtInst => Transformed::Unchanged,
 
                 TypeKind::SpvInst { spv_inst, type_and_const_inputs } => Transformed::map_iter(
                     type_and_const_inputs.iter(),
@@ -458,6 +460,7 @@ impl InnerTransform for ConstDef {
             ty -> transformer.transform_type_use(*ty),
             kind -> match kind {
                 ConstKind::Undef
+                | ConstKind::Scalar(_)
                 | ConstKind::SpvStringLiteralForExtInst(_) => Transformed::Unchanged,
 
                 ConstKind::PtrToGlobalVar(gv) => transform!({

--- a/src/transform.rs
+++ b/src/transform.rs
@@ -425,6 +425,7 @@ impl InnerTransform for TypeDef {
             attrs -> transformer.transform_attr_set_use(*attrs),
             kind -> match kind {
                 TypeKind::Scalar(_)
+                | TypeKind::Vector(_)
                 | TypeKind::QPtr
                 | TypeKind::SpvStringLiteralForExtInst => Transformed::Unchanged,
 
@@ -461,6 +462,7 @@ impl InnerTransform for ConstDef {
             kind -> match kind {
                 ConstKind::Undef
                 | ConstKind::Scalar(_)
+                | ConstKind::Vector(_)
                 | ConstKind::SpvStringLiteralForExtInst(_) => Transformed::Unchanged,
 
                 ConstKind::PtrToGlobalVar(gv) => transform!({

--- a/src/transform.rs
+++ b/src/transform.rs
@@ -724,6 +724,7 @@ impl InnerTransform for DataInstFormDef {
                     | QPtrOp::Store => Transformed::Unchanged,
                 },
                 DataInstKind::Scalar(_)
+                | DataInstKind::Vector(_)
                 | DataInstKind::SpvInst(_)
                 | DataInstKind::SpvExtInst { .. } => Transformed::Unchanged,
             },

--- a/src/transform.rs
+++ b/src/transform.rs
@@ -457,6 +457,9 @@ impl InnerTransform for ConstDef {
             attrs -> transformer.transform_attr_set_use(*attrs),
             ty -> transformer.transform_type_use(*ty),
             kind -> match kind {
+                ConstKind::Undef
+                | ConstKind::SpvStringLiteralForExtInst(_) => Transformed::Unchanged,
+
                 ConstKind::PtrToGlobalVar(gv) => transform!({
                     gv -> transformer.transform_global_var_use(*gv),
                 } => ConstKind::PtrToGlobalVar(gv)),
@@ -470,7 +473,6 @@ impl InnerTransform for ConstDef {
                         spv_inst_and_const_inputs: Rc::new((spv_inst.clone(), new_iter.collect())),
                     })
                 }
-                ConstKind::SpvStringLiteralForExtInst(_) => Transformed::Unchanged
             },
         } => Self {
             attrs,

--- a/src/transform.rs
+++ b/src/transform.rs
@@ -721,7 +721,9 @@ impl InnerTransform for DataInstFormDef {
                     | QPtrOp::Load
                     | QPtrOp::Store => Transformed::Unchanged,
                 },
-                DataInstKind::SpvInst(_) | DataInstKind::SpvExtInst { .. } => Transformed::Unchanged,
+                DataInstKind::Scalar(_)
+                | DataInstKind::SpvInst(_)
+                | DataInstKind::SpvExtInst { .. } => Transformed::Unchanged,
             },
             // FIXME(eddyb) this should be replaced with an impl of `InnerTransform`
             // for `Option<T>` or some other helper, to avoid "manual transpose".

--- a/src/transform.rs
+++ b/src/transform.rs
@@ -429,7 +429,7 @@ impl InnerTransform for TypeDef {
                 | TypeKind::QPtr
                 | TypeKind::SpvStringLiteralForExtInst => Transformed::Unchanged,
 
-                TypeKind::SpvInst { spv_inst, type_and_const_inputs } => Transformed::map_iter(
+                TypeKind::SpvInst { spv_inst, type_and_const_inputs, value_lowering } => Transformed::map_iter(
                     type_and_const_inputs.iter(),
                     |ty_or_ct| match *ty_or_ct {
                         TypeOrConst::Type(ty) => transform!({
@@ -443,6 +443,7 @@ impl InnerTransform for TypeDef {
                 ).map(|new_iter| TypeKind::SpvInst {
                     spv_inst: spv_inst.clone(),
                     type_and_const_inputs: new_iter.collect(),
+                    value_lowering: value_lowering.clone(),
                 }),
             },
         } => Self {
@@ -532,10 +533,12 @@ impl InnerInPlaceTransform for GlobalVarDefBody {
 
 impl InnerInPlaceTransform for FuncDecl {
     fn inner_in_place_transform_with(&mut self, transformer: &mut impl Transformer) {
-        let Self { attrs, ret_type, params, def } = self;
+        let Self { attrs, ret_types, params, def } = self;
 
         transformer.transform_attr_set_use(*attrs).apply_to(attrs);
-        transformer.transform_type_use(*ret_type).apply_to(ret_type);
+        for ty in ret_types {
+            transformer.transform_type_use(*ty).apply_to(ty);
+        }
         for param in params {
             param.inner_transform_with(transformer).apply_to(param);
         }
@@ -708,11 +711,15 @@ impl InnerInPlaceTransform for FuncAtMut<'_, DataInst> {
 
 impl InnerTransform for DataInstFormDef {
     fn inner_transform_with(&self, transformer: &mut impl Transformer) -> Transformed<Self> {
-        let Self { kind, output_type } = self;
+        let Self { kind, output_types } = self;
 
         transform!({
             kind -> match kind {
-                DataInstKind::FuncCall(func) => transformer.transform_func_use(*func).map(DataInstKind::FuncCall),
+                DataInstKind::Scalar(_)
+                | DataInstKind::Vector(_) => Transformed::Unchanged,
+                DataInstKind::FuncCall(func) => transform!({
+                    func -> transformer.transform_func_use(*func)
+                } => DataInstKind::FuncCall(func)),
                 DataInstKind::QPtr(op) => match op {
                     QPtrOp::FuncLocalVar(_)
                     | QPtrOp::HandleArrayIndex
@@ -723,19 +730,36 @@ impl InnerTransform for DataInstFormDef {
                     | QPtrOp::Load {..}
                     | QPtrOp::Store {..} => Transformed::Unchanged,
                 },
-                DataInstKind::Scalar(_)
-                | DataInstKind::Vector(_)
-                | DataInstKind::SpvInst(_)
-                | DataInstKind::SpvExtInst { .. } => Transformed::Unchanged,
+                DataInstKind::SpvInst(spv_inst, lowering) => transform!({
+                    lowering -> lowering.inner_transform_with(transformer)
+                } => DataInstKind::SpvInst(spv_inst.clone(), lowering)),
+                DataInstKind::SpvExtInst { ext_set, inst, lowering } => transform!({
+                    lowering -> lowering.inner_transform_with(transformer)
+                } => DataInstKind::SpvExtInst { ext_set: *ext_set, inst: *inst, lowering }),
             },
-            // FIXME(eddyb) this should be replaced with an impl of `InnerTransform`
-            // for `Option<T>` or some other helper, to avoid "manual transpose".
-            output_type -> output_type.map(|ty| transformer.transform_type_use(ty))
-                .map_or(Transformed::Unchanged, |t| t.map(Some)),
+            output_types -> Transformed::map_iter(output_types.iter(), |&ty| transformer.transform_type_use(ty))
+                .map(|new_iter| new_iter.collect()),
         } => Self {
             kind,
-            output_type,
+            output_types,
         })
+    }
+}
+
+impl InnerTransform for spv::InstLowering {
+    fn inner_transform_with(&self, transformer: &mut impl Transformer) -> Transformed<Self> {
+        let Self { disaggregated_output, disaggregated_inputs } = self;
+
+        transform!({
+            // FIXME(eddyb) this should be replaced with an impl of `InnerTransform`
+            // for `Option<T>` or some other helper, to avoid "manual transpose".
+            disaggregated_output -> disaggregated_output.map(|ty| transformer.transform_type_use(ty))
+                .map_or(Transformed::Unchanged, |t| t.map(Some)),
+            disaggregated_inputs -> Transformed::map_iter(
+                disaggregated_inputs.iter(),
+                |(range, ty)| transformer.transform_type_use(*ty).map(|ty| (range.clone(), ty))
+            ).map(|new_iter| new_iter.collect()),
+        } => Self { disaggregated_output, disaggregated_inputs })
     }
 }
 
@@ -773,7 +797,7 @@ impl InnerTransform for Value {
 
             Self::ControlRegionInput { region: _, input_idx: _ }
             | Self::ControlNodeOutput { control_node: _, output_idx: _ }
-            | Self::DataInstOutput(_) => Transformed::Unchanged,
+            | Self::DataInstOutput { inst: _, output_idx: _ } => Transformed::Unchanged,
         }
     }
 }

--- a/src/transform.rs
+++ b/src/transform.rs
@@ -720,8 +720,8 @@ impl InnerTransform for DataInstFormDef {
                     | QPtrOp::BufferDynLen { .. }
                     | QPtrOp::Offset(_)
                     | QPtrOp::DynOffset { .. }
-                    | QPtrOp::Load
-                    | QPtrOp::Store => Transformed::Unchanged,
+                    | QPtrOp::Load {..}
+                    | QPtrOp::Store {..} => Transformed::Unchanged,
                 },
                 DataInstKind::Scalar(_)
                 | DataInstKind::Vector(_)

--- a/src/transform.rs
+++ b/src/transform.rs
@@ -640,7 +640,7 @@ impl InnerInPlaceTransform for FuncAtMut<'_, ControlNode> {
                 }
             }
             ControlNodeKind::Select {
-                kind: SelectionKind::BoolCond | SelectionKind::SpvInst(_),
+                kind: SelectionKind::BoolCond | SelectionKind::Switch { case_consts: _ },
                 scrutinee,
                 cases: _,
             } => {
@@ -747,7 +747,7 @@ impl InnerInPlaceTransform for cfg::ControlInst {
             | cfg::ControlInstKind::ExitInvocation(cfg::ExitInvocationKind::SpvInst(_))
             | cfg::ControlInstKind::Branch
             | cfg::ControlInstKind::SelectBranch(
-                SelectionKind::BoolCond | SelectionKind::SpvInst(_),
+                SelectionKind::BoolCond | SelectionKind::Switch { case_consts: _ },
             ) => {}
         }
         for v in inputs {

--- a/src/vector.rs
+++ b/src/vector.rs
@@ -1,0 +1,123 @@
+//! Vector types (small arrays of [`scalar`](crate::scalar)s) and associated functionality.
+//!
+//! **Note**: these are similar to SIMD types in other IRs, but SPIR-V often uses
+//! its `OpTypeVector` to represent geometrical vectors, colors, etc. without any
+//! expectation of SIMD execution (which most GPU execution models use implicitly,
+//! i.e. one non-uniform scalar becomes a hardware SIMD vector, while a high-level
+//! "vector" of N "lanes", becomes N separate hardware SIMD vectors).
+
+use crate::scalar;
+use smallvec::SmallVec;
+use std::num::NonZeroU8;
+use std::rc::Rc;
+
+// FIXME(eddyb) this entire module shorthands "element" as "elem", is that good?
+
+#[derive(Copy, Clone, PartialEq, Eq, Hash)]
+pub struct Type {
+    pub elem: scalar::Type,
+    // FIXME(eddyb) maybe wrap this in a type that abstracts away the encoding?
+    pub elem_count: NonZeroU8,
+}
+
+// FIXME(eddyb) document the 128-bit limitations inherited from `scalar::Const`.
+#[derive(Clone, PartialEq, Eq, Hash)]
+pub struct Const(ConstRepr);
+
+// HACK(eddyb) `#[repr(packed)]` not allowed on `enum`s themselves.
+#[repr(packed)]
+#[derive(Copy, Clone, PartialEq, Eq, Hash)]
+struct Packed<T>(T);
+
+// FIXME(eddyb) maybe build an abstraction for "N-dimensional" bit arrays?
+#[derive(Clone, PartialEq, Eq, Hash)]
+#[repr(u8)]
+enum ConstRepr {
+    // HACK(eddyb) `(Type, u128)` would waste almost half its size on padding, and
+    // packing will only impact accessing the bits, while allowing e.g. being
+    // wrapped in an outer `enum`, before reaching the same size as `(u128, u128)`.
+    Inline(Type, Packed<u128>),
+
+    // HACK(eddyb) this does raise the alignment, but the size and alignment are
+    // kept at one pointer (so likely half of `u128`) - `Packed<Rc<_>>` is sadly
+    // not an option because `#[derive(...)]` + `#[repr(packed)]` often requires
+    // `Copy` in order to be able to safely take references (to a copy of a field).
+    Boxed(Type, Rc<Vec<u128>>),
+}
+
+impl Const {
+    pub const fn ty(&self) -> Type {
+        match self.0 {
+            ConstRepr::Inline(ty, _) | ConstRepr::Boxed(ty, _) => ty,
+        }
+    }
+
+    pub fn from_elems(ty: Type, elems: impl IntoIterator<Item = scalar::Const>) -> Const {
+        let elem_width = ty.elem.bit_width();
+        assert!(elem_width <= 128);
+
+        let expected_elem_count = u32::from(ty.elem_count.get());
+
+        let num_limbs = elem_width.checked_mul(expected_elem_count).unwrap().div_ceil(128);
+        assert_ne!(num_limbs, 0);
+        let mut limbs = SmallVec::<[u128; 1]>::from_elem(0, usize::try_from(num_limbs).unwrap());
+
+        let mut found_elem_count = 0;
+        for ct in elems {
+            let i: u32 = found_elem_count;
+            found_elem_count = found_elem_count.checked_add(1).unwrap();
+            if i >= expected_elem_count {
+                continue;
+            }
+
+            // FIXME(eddyb) get better names (perhaps from miri-like memory?).
+            let first_bit_idx = i.checked_mul(elem_width).unwrap();
+            let limb_idx = first_bit_idx / 128;
+            let intra_limb_first_bit_idx = first_bit_idx % 128;
+            assert!(intra_limb_first_bit_idx + elem_width <= 128);
+
+            limbs[usize::try_from(limb_idx).unwrap()] |= ct.bits() << intra_limb_first_bit_idx;
+        }
+        assert_eq!(found_elem_count, expected_elem_count);
+
+        match limbs.into_inner() {
+            Ok([limb]) => Const(ConstRepr::Inline(ty, Packed(limb))),
+            Err(limbs) => Const(ConstRepr::Boxed(ty, Rc::new(limbs.into_vec()))),
+        }
+    }
+
+    pub fn get_elem(&self, i: usize) -> Option<scalar::Const> {
+        let ty = self.ty();
+        if i >= usize::from(ty.elem_count.get()) {
+            return None;
+        }
+        let i = u32::try_from(i).unwrap();
+        let elem_width = ty.elem.bit_width();
+        assert!(elem_width <= 128);
+
+        // FIXME(eddyb) get better names (perhaps from miri-like memory?).
+        let first_bit_idx = i.checked_mul(elem_width).unwrap();
+        let limb_idx = first_bit_idx / 128;
+        let intra_limb_first_bit_idx = first_bit_idx % 128;
+        assert!(intra_limb_first_bit_idx + elem_width <= 128);
+
+        let limb = match &self.0 {
+            ConstRepr::Inline(_, limb) => {
+                assert_eq!(limb_idx, 0);
+                limb.0
+            }
+            ConstRepr::Boxed(_, limbs) => limbs[usize::try_from(limb_idx).unwrap()],
+        };
+
+        Some(scalar::Const::from_bits(
+            ty.elem,
+            (limb >> intra_limb_first_bit_idx) & (!0 >> (128 - elem_width)),
+        ))
+    }
+
+    pub fn elems(&self) -> impl Iterator<Item = scalar::Const> + '_ {
+        let ty = self.ty();
+        // FIXME(eddyb) there should be a more efficient way to do this.
+        (0..usize::from(ty.elem_count.get())).map(|i| self.get_elem(i).unwrap())
+    }
+}

--- a/src/vector.rs
+++ b/src/vector.rs
@@ -121,3 +121,60 @@ impl Const {
         (0..usize::from(ty.elem_count.get())).map(|i| self.get_elem(i).unwrap())
     }
 }
+
+/// Pure operations with vector inputs and/or outputs.
+#[derive(Copy, Clone, PartialEq, Eq, Hash, derive_more::From)]
+pub enum Op {
+    Distribute(scalar::Op),
+    Reduce(ReduceOp),
+
+    // FIXME(eddyb) find a better name for this category of ops.
+    Whole(WholeOp),
+}
+
+#[derive(Copy, Clone, PartialEq, Eq, Hash)]
+pub enum ReduceOp {
+    // FIXME(eddyb) also support all the new integer dot product instructions.
+    Dot,
+    // FIXME(eddyb) model these using their respective `BoolBinOp`s?
+    Any,
+    All,
+}
+
+impl ReduceOp {
+    pub fn name(self) -> &'static str {
+        match self {
+            ReduceOp::Dot => "vec.dot",
+            ReduceOp::Any => "vec.any",
+            ReduceOp::All => "vec.all",
+        }
+    }
+}
+
+// FIXME(eddyb) find a better name for this category of ops.
+// FIXME(eddyb) also support `OpVectorShuffle`.
+#[derive(Copy, Clone, PartialEq, Eq, Hash)]
+pub enum WholeOp {
+    // FIXME(eddyb) better name for this (pack? make? "construct" is too long).
+    New,
+    Extract { elem_idx: u8 },
+    Insert { elem_idx: u8 },
+    DynExtract,
+    DynInsert,
+
+    // FIXME(eddyb) may need a better name to indicate "scalar product".
+    Mul,
+}
+
+impl WholeOp {
+    pub fn name(self) -> &'static str {
+        match self {
+            WholeOp::New => "vec.new",
+            WholeOp::Extract { .. } => "vec.extract",
+            WholeOp::Insert { .. } => "vec.insert",
+            WholeOp::DynExtract => "vec.dyn_extract",
+            WholeOp::DynInsert => "vec.dyn_insert",
+            WholeOp::Mul => "vec.mul",
+        }
+    }
+}

--- a/src/visit.rs
+++ b/src/visit.rs
@@ -542,6 +542,7 @@ impl InnerVisit for DataInstFormDef {
                 | QPtrOp::Store => {}
             },
             DataInstKind::Scalar(_)
+            | DataInstKind::Vector(_)
             | DataInstKind::SpvInst(_)
             | DataInstKind::SpvExtInst { .. } => {}
         }

--- a/src/visit.rs
+++ b/src/visit.rs
@@ -475,7 +475,7 @@ impl<'a> FuncAt<'a, ControlNode> {
                 }
             }
             ControlNodeKind::Select {
-                kind: SelectionKind::BoolCond | SelectionKind::SpvInst(_),
+                kind: SelectionKind::BoolCond | SelectionKind::Switch { case_consts: _ },
                 scrutinee,
                 cases,
             } => {
@@ -556,7 +556,7 @@ impl InnerVisit for cfg::ControlInst {
             | cfg::ControlInstKind::ExitInvocation(cfg::ExitInvocationKind::SpvInst(_))
             | cfg::ControlInstKind::Branch
             | cfg::ControlInstKind::SelectBranch(
-                SelectionKind::BoolCond | SelectionKind::SpvInst(_),
+                SelectionKind::BoolCond | SelectionKind::Switch { case_consts: _ },
             ) => {}
         }
         for v in inputs {

--- a/src/visit.rs
+++ b/src/visit.rs
@@ -315,7 +315,7 @@ impl InnerVisit for TypeDef {
 
         visitor.visit_attr_set_use(*attrs);
         match kind {
-            TypeKind::QPtr | TypeKind::SpvStringLiteralForExtInst => {}
+            TypeKind::Scalar(_) | TypeKind::QPtr | TypeKind::SpvStringLiteralForExtInst => {}
 
             TypeKind::SpvInst { spv_inst: _, type_and_const_inputs } => {
                 for &ty_or_ct in type_and_const_inputs {
@@ -336,7 +336,7 @@ impl InnerVisit for ConstDef {
         visitor.visit_attr_set_use(*attrs);
         visitor.visit_type_use(*ty);
         match kind {
-            ConstKind::Undef | ConstKind::SpvStringLiteralForExtInst(_) => {}
+            ConstKind::Undef | ConstKind::Scalar(_) | ConstKind::SpvStringLiteralForExtInst(_) => {}
 
             &ConstKind::PtrToGlobalVar(gv) => visitor.visit_global_var_use(gv),
             ConstKind::SpvInst { spv_inst_and_const_inputs } => {

--- a/src/visit.rs
+++ b/src/visit.rs
@@ -535,7 +535,9 @@ impl InnerVisit for DataInstFormDef {
                 | QPtrOp::Load
                 | QPtrOp::Store => {}
             },
-            DataInstKind::SpvInst(_) | DataInstKind::SpvExtInst { .. } => {}
+            DataInstKind::Scalar(_)
+            | DataInstKind::SpvInst(_)
+            | DataInstKind::SpvExtInst { .. } => {}
         }
         if let Some(ty) = *output_type {
             visitor.visit_type_use(ty);

--- a/src/visit.rs
+++ b/src/visit.rs
@@ -538,8 +538,8 @@ impl InnerVisit for DataInstFormDef {
                 | QPtrOp::BufferDynLen { .. }
                 | QPtrOp::Offset(_)
                 | QPtrOp::DynOffset { .. }
-                | QPtrOp::Load
-                | QPtrOp::Store => {}
+                | QPtrOp::Load { .. }
+                | QPtrOp::Store { .. } => {}
             },
             DataInstKind::Scalar(_)
             | DataInstKind::Vector(_)

--- a/src/visit.rs
+++ b/src/visit.rs
@@ -315,7 +315,10 @@ impl InnerVisit for TypeDef {
 
         visitor.visit_attr_set_use(*attrs);
         match kind {
-            TypeKind::Scalar(_) | TypeKind::QPtr | TypeKind::SpvStringLiteralForExtInst => {}
+            TypeKind::Scalar(_)
+            | TypeKind::Vector(_)
+            | TypeKind::QPtr
+            | TypeKind::SpvStringLiteralForExtInst => {}
 
             TypeKind::SpvInst { spv_inst: _, type_and_const_inputs } => {
                 for &ty_or_ct in type_and_const_inputs {
@@ -336,7 +339,10 @@ impl InnerVisit for ConstDef {
         visitor.visit_attr_set_use(*attrs);
         visitor.visit_type_use(*ty);
         match kind {
-            ConstKind::Undef | ConstKind::Scalar(_) | ConstKind::SpvStringLiteralForExtInst(_) => {}
+            ConstKind::Undef
+            | ConstKind::Scalar(_)
+            | ConstKind::Vector(_)
+            | ConstKind::SpvStringLiteralForExtInst(_) => {}
 
             &ConstKind::PtrToGlobalVar(gv) => visitor.visit_global_var_use(gv),
             ConstKind::SpvInst { spv_inst_and_const_inputs } => {

--- a/src/visit.rs
+++ b/src/visit.rs
@@ -336,6 +336,8 @@ impl InnerVisit for ConstDef {
         visitor.visit_attr_set_use(*attrs);
         visitor.visit_type_use(*ty);
         match kind {
+            ConstKind::Undef | ConstKind::SpvStringLiteralForExtInst(_) => {}
+
             &ConstKind::PtrToGlobalVar(gv) => visitor.visit_global_var_use(gv),
             ConstKind::SpvInst { spv_inst_and_const_inputs } => {
                 let (_spv_inst, const_inputs) = &**spv_inst_and_const_inputs;
@@ -343,7 +345,6 @@ impl InnerVisit for ConstDef {
                     visitor.visit_const_use(ct);
                 }
             }
-            ConstKind::SpvStringLiteralForExtInst(_) => {}
         }
     }
 }

--- a/src/visit.rs
+++ b/src/visit.rs
@@ -320,7 +320,7 @@ impl InnerVisit for TypeDef {
             | TypeKind::QPtr
             | TypeKind::SpvStringLiteralForExtInst => {}
 
-            TypeKind::SpvInst { spv_inst: _, type_and_const_inputs } => {
+            TypeKind::SpvInst { spv_inst: _, type_and_const_inputs, value_lowering: _ } => {
                 for &ty_or_ct in type_and_const_inputs {
                     match ty_or_ct {
                         TypeOrConst::Type(ty) => visitor.visit_type_use(ty),
@@ -396,10 +396,12 @@ impl InnerVisit for GlobalVarDefBody {
 
 impl InnerVisit for FuncDecl {
     fn inner_visit_with<'a>(&'a self, visitor: &mut impl Visitor<'a>) {
-        let Self { attrs, ret_type, params, def } = self;
+        let Self { attrs, ret_types, params, def } = self;
 
         visitor.visit_attr_set_use(*attrs);
-        visitor.visit_type_use(*ret_type);
+        for &ty in ret_types {
+            visitor.visit_type_use(ty);
+        }
         for param in params {
             param.inner_visit_with(visitor);
         }
@@ -527,9 +529,10 @@ impl InnerVisit for DataInstDef {
 
 impl InnerVisit for DataInstFormDef {
     fn inner_visit_with<'a>(&'a self, visitor: &mut impl Visitor<'a>) {
-        let Self { kind, output_type } = self;
+        let Self { kind, output_types } = self;
 
         match kind {
+            DataInstKind::Scalar(_) | DataInstKind::Vector(_) => {}
             &DataInstKind::FuncCall(func) => visitor.visit_func_use(func),
             DataInstKind::QPtr(op) => match *op {
                 QPtrOp::FuncLocalVar(_)
@@ -541,12 +544,25 @@ impl InnerVisit for DataInstFormDef {
                 | QPtrOp::Load { .. }
                 | QPtrOp::Store { .. } => {}
             },
-            DataInstKind::Scalar(_)
-            | DataInstKind::Vector(_)
-            | DataInstKind::SpvInst(_)
-            | DataInstKind::SpvExtInst { .. } => {}
+            DataInstKind::SpvInst(_, lowering)
+            | DataInstKind::SpvExtInst { ext_set: _, inst: _, lowering } => {
+                lowering.inner_visit_with(visitor);
+            }
         }
-        if let Some(ty) = *output_type {
+        for &ty in output_types {
+            visitor.visit_type_use(ty);
+        }
+    }
+}
+
+impl InnerVisit for spv::InstLowering {
+    fn inner_visit_with<'a>(&'a self, visitor: &mut impl Visitor<'a>) {
+        let Self { disaggregated_output, disaggregated_inputs } = self;
+
+        if let Some(ty) = *disaggregated_output {
+            visitor.visit_type_use(ty);
+        }
+        for &(_, ty) in disaggregated_inputs {
             visitor.visit_type_use(ty);
         }
     }
@@ -583,7 +599,7 @@ impl InnerVisit for Value {
             Self::Const(ct) => visitor.visit_const_use(ct),
             Self::ControlRegionInput { region: _, input_idx: _ }
             | Self::ControlNodeOutput { control_node: _, output_idx: _ }
-            | Self::DataInstOutput(_) => {}
+            | Self::DataInstOutput { inst: _, output_idx: _ } => {}
         }
     }
 }


### PR DESCRIPTION
This should allow us to always reason about the *leaves* of "aggregates", without any superfluous nesting - especially relevant to logical pointers, which SPIR-V disallows wrapping in any other data types, and which `qptr` would prefer to always interact with directly.

**TODO**:
* global initializers should have disaggregated leaves for initializers
  * potential compromise: use `GlobalVarShape::TypedInterface` when an initializer is present
* longer PR description (add comparison!), and CHANGELOG entry (reuse details from `Value` docs additions?)