### PR TITLE
print: use `spv.OpFoo(A: imm, B: ID, C: imm, ...)` instead of `spv.OpFoo<imms>(IDs)`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased] - ReleaseDate
 
 ### Changed 🛠
+- [PR#33](https://github.com/EmbarkStudios/spirt/pull/33) replaced the `spv.OpFoo<imms>(IDs)`
+  style of pretty-printing with `spv.OpFoo(A: imm, B: ID, C: imm, ...)` (unified parenthesized
+  list of operands, with deemphasized operand names in `foo:` "named arguments" style)
 - [PR#28](https://github.com/EmbarkStudios/spirt/pull/28) moved two `DataInstDef`
   fields (`kind` and `output_type`) to `DataInstForm`, a new interned type
 - [PR#30](https://github.com/EmbarkStudios/spirt/pull/30) replaced the old `spv-lower-dump`

--- a/README.md
+++ b/README.md
@@ -134,8 +134,8 @@ fn main() -> @location(0) i32 {
 <!-- BEGIN tests/data/for-loop.wgsl.spvasm.structured.spirt -->
 ```cxx
 #{
-  spv.OpDecorate<spv.Decoration.Flat>,
-  spv.OpDecorate<spv.Decoration.Location(0)>,
+  spv.OpDecorate(spv.Decoration.Flat),
+  spv.OpDecorate(spv.Decoration.Location(0)),
 }
 global_var0 in spv.StorageClass.Output: s32
 

--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ fn main() -> @location(0) i32 {
 ```cxx
 #{
   spv.OpDecorate(spv.Decoration.Flat),
-  spv.OpDecorate(spv.Decoration.Location(0)),
+  spv.OpDecorate(spv.Decoration.Location(Location: 0)),
 }
 global_var0 in spv.StorageClass.Output: s32
 
@@ -147,7 +147,7 @@ func0() -> spv.OpTypeVoid {
       v7 = spv.OpIAdd(v1, 1s32): s32
       (true, v6, v7)
     } else {
-      spv.OpStore(&global_var0, v0)
+      spv.OpStore(Pointer: &global_var0, Object: v0)
       (false, spv.OpUndef: s32, spv.OpUndef: s32)
     }
     (v4, v5) -> (v0, v1)

--- a/src/spv/print.rs
+++ b/src/spv/print.rs
@@ -258,8 +258,7 @@ impl<IMMS: Iterator<Item = spv::Imm>, ID, IDS: Iterator<Item = ID>> OperandPrint
 
 /// Print a single SPIR-V operand from only immediates, potentially composed of
 /// an enumerand with parameters (which consumes more immediates).
-// FIXME(eddyb) the return type should likely be `TokensForOperand<!>`.
-pub fn operand_from_imms(imms: impl IntoIterator<Item = spv::Imm>) -> TokensForOperand<String> {
+pub fn operand_from_imms<T>(imms: impl IntoIterator<Item = spv::Imm>) -> TokensForOperand<T> {
     let mut printer = OperandPrinter {
         imms: imms.into_iter().peekable(),
         ids: iter::empty().peekable(),

--- a/src/spv/print.rs
+++ b/src/spv/print.rs
@@ -20,6 +20,10 @@ pub enum Token<ID> {
     /// a block comment (i.e. the [`String`] is always of the form `"/* ... */"`).
     Error(String),
 
+    // NOTE(eddyb) this implies a suffix `: ` not included in the string, and
+    // optionally some processing of the name (e.g. removing spaces).
+    OperandName(&'static str),
+
     // FIXME(eddyb) perhaps encode the hierarchical structure of e.g. enumerand
     // parameters, so that the SPIR-T printer can do layout for them.
     Punctuation(&'static str),
@@ -57,6 +61,7 @@ impl TokensForOperand<String> {
             .into_iter()
             .flat_map(|token| {
                 let (first, second): (Cow<'_, str>, _) = match token {
+                    Token::OperandName(s) => (s.into(), Some(": ".into())),
                     Token::OperandKindNamespacePrefix(s) => (s.into(), Some(".".into())),
                     Token::Punctuation(s) | Token::EnumerandName(s) => (s.into(), None),
                     Token::Error(s)
@@ -91,7 +96,7 @@ impl<IMMS: Iterator<Item = spv::Imm>, ID, IDS: Iterator<Item = ID>> OperandPrint
 
     fn enumerant_params(&mut self, enumerant: &spec::Enumerant) {
         let mut first = true;
-        for (mode, kind) in enumerant.all_params() {
+        for (mode, name_and_kind) in enumerant.all_params_with_names() {
             if mode == spec::OperandMode::Optional && self.is_exhausted() {
                 break;
             }
@@ -101,7 +106,8 @@ impl<IMMS: Iterator<Item = spv::Imm>, ID, IDS: Iterator<Item = ID>> OperandPrint
                 .push(Token::Punctuation(if first { "(" } else { ", " }));
             first = false;
 
-            self.operand(kind);
+            let (name, kind) = name_and_kind.name_and_kind();
+            self.operand(name, kind);
         }
         if !first {
             self.out.tokens.push(Token::Punctuation(")"));
@@ -157,7 +163,11 @@ impl<IMMS: Iterator<Item = spv::Imm>, ID, IDS: Iterator<Item = ID>> OperandPrint
         self.out.tokens.push(literal_token);
     }
 
-    fn operand(&mut self, kind: spec::OperandKind) {
+    fn operand(&mut self, operand_name: &'static str, kind: spec::OperandKind) {
+        if !operand_name.is_empty() {
+            self.out.tokens.push(Token::OperandName(operand_name));
+        }
+
         let (name, def) = kind.name_and_def();
 
         // FIXME(eddyb) should this be a hard error?
@@ -246,13 +256,17 @@ impl<IMMS: Iterator<Item = spv::Imm>, ID, IDS: Iterator<Item = ID>> OperandPrint
     }
 
     fn inst_operands(mut self, opcode: spec::Opcode) -> impl Iterator<Item = TokensForOperand<ID>> {
-        opcode.def().all_operands().map_while(move |(mode, kind)| {
-            if mode == spec::OperandMode::Optional && self.is_exhausted() {
-                return None;
-            }
-            self.operand(kind);
-            Some(mem::take(&mut self.out))
-        })
+        opcode
+            .def()
+            .all_operands_with_names()
+            .map_while(move |(mode, name_and_kind)| {
+                if mode == spec::OperandMode::Optional && self.is_exhausted() {
+                    return None;
+                }
+                let (name, kind) = name_and_kind.name_and_kind();
+                self.operand(name, kind);
+                Some(mem::take(&mut self.out))
+            })
     }
 }
 
@@ -268,7 +282,7 @@ pub fn operand_from_imms<T>(imms: impl IntoIterator<Item = spv::Imm>) -> TokensF
         spv::Imm::Short(kind, _) | spv::Imm::LongStart(kind, _) => kind,
         spv::Imm::LongCont(..) => unreachable!(),
     };
-    printer.operand(kind);
+    printer.operand("", kind);
     assert!(printer.imms.next().is_none());
     printer.out
 }


### PR DESCRIPTION
There's two main changes here:
- removal of *all* angle brackets (`<...>`) from SPIR-T pretty-printing
  - they used to be used for *immediates* (almost as if they were "const generics", to distinguish them from regular inputs/arguments, which used parens)
  - may have had some use in quickly visualizing what the "immediates"/"inputs" split may be, but I don't recall actually relying on that, and it's probably better to have SPIR-T-"native" forms for any aspects of SPIR-V we care about
  - new style uses the standard SPIR-V order (interleaving immediates and ID operands)
  - long term this *may* make it easier to parse a SPIR-T textual form (but there are no current plans for that)
- introduction of "named argument" labels (`foo:` before an operand)
  - for SPIR-V ops and enumerands, this should help with readability, especially when dealing with a larger number of operands (e.g. for image/raytracing ops)
  - with immediates interleaved with other operands, this felt potentially helpful in reducing ambiguities that could've been introduced (when the `<...>` distinction was removed, specifically)
  - where overly noisy this again introduces an incentive to have SPIR-T-"native" forms

Comparison (using Kajiya's `assets/shaders/raster_simple_ps.hlsl`, compiled by DXC):
|[**Before**](https://htmlpreview.github.io/?https://gist.github.com/eddyb/7cd8378f5fc87316359fa1c3c11e8bf2/raw/0-before-spirt%252333-raster_simple_ps.hlsl.structured.spirt.html)<br><sub>(click for complete pretty HTML example)</sub>|[**After**](https://htmlpreview.github.io/?https://gist.github.com/eddyb/7cd8378f5fc87316359fa1c3c11e8bf2/raw/1-after-spirt%252333-raster_simple_ps.hlsl.structured.spirt.html)<br><sub>(click for complete pretty HTML example)</sub>|
|-|-|
|![image](https://github.com/EmbarkStudios/spirt/assets/77424/7347fa79-7c39-45fb-a3a9-339edbff99bc)|![image](https://github.com/EmbarkStudios/spirt/assets/77424/dab3ae6f-1fc0-42e5-8a82-c0b959c5e91c)|
|![image](https://github.com/EmbarkStudios/spirt/assets/77424/b5283b3e-151f-4e68-99f4-f1656c143e4d)|![image](https://github.com/EmbarkStudios/spirt/assets/77424/3cc64b20-e5da-45e7-a70d-cebccd0a913f)|