### PR TITLE
print: always print attributes inline and with per-attribute `#[...]` syntax.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased] - ReleaseDate
 
 ### Changed 🛠
+- [PR#35](https://github.com/EmbarkStudios/spirt/pull/35) abandoned the custom
+  `#{A, B, C}` "attribute set" style in favor of Rust-like `#[A]` `#[B]` `#[C]`
+  (and always printing them inline, without any `attrs123` shorthands)
 - [PR#33](https://github.com/EmbarkStudios/spirt/pull/33) replaced the `spv.OpFoo<imms>(IDs)`
   style of pretty-printing with `spv.OpFoo(A: imm, B: ID, C: imm, ...)` (unified parenthesized
   list of operands, with deemphasized operand names in `foo:` "named arguments" style)

--- a/README.md
+++ b/README.md
@@ -133,10 +133,8 @@ fn main() -> @location(0) i32 {
 <!-- NOTE(eddyb) BEGIN/END below processed by .github/workflows/check-examples.sh -->
 <!-- BEGIN tests/data/for-loop.wgsl.spvasm.structured.spirt -->
 ```cxx
-#{
-  spv.OpDecorate(spv.Decoration.Flat),
-  spv.OpDecorate(spv.Decoration.Location(Location: 0)),
-}
+#[spv.Decoration.Flat]
+#[spv.Decoration.Location(Location: 0)]
 global_var0 in spv.StorageClass.Output: s32
 
 func0() -> spv.OpTypeVoid {


### PR DESCRIPTION
This moves us from my ad-hoc `#{A, B, C}` to a Rust-style `#[A] #[B] #[C]` attribute syntax, and removes the idea of a "attribute set shorthand" (`attrs123 = #{...}` followed by uses of `#attrs123`), which was more annoying than useful (attributes can't refer to other attributes so there was no "exponential deduplication" need for it).

With `#[...]` syntax, it also makes sense to never say e.g. `OpDecorate` (as the operand itself will contain the word `Decoration`), or to use `#[name = "..."]` Rust-style syntax for `OpName`.

(I didn't touch `OpMember{Name,Decorate}`, might be worth having a SPIR-T `struct` type declaration syntax just to clean those up but it feels even more ad-hoc than usual - maybe it might make more sense after #36?)

Comparison (using Kajiya's `assets/shaders/raster_simple_ps.hlsl`, compiled by DXC, like #33):
|[**Before**](https://htmlpreview.github.io/?https://gist.github.com/eddyb/124d807950059893678ad55f51ee5107/raw/0-before-spirt%252335-raster_simple_ps.hlsl.structured.spirt.html)<br><sub>(click for complete pretty HTML example)</sub>|[**After**](https://htmlpreview.github.io/?https://gist.github.com/eddyb/124d807950059893678ad55f51ee5107/raw/1-after-spirt%252335-raster_simple_ps.hlsl.structured.spirt.html)<br><sub>(click for complete pretty HTML example)</sub>|
|-|-|
|![image](https://github.com/EmbarkStudios/spirt/assets/77424/82ee846a-0ed7-4f6b-be4f-7c6ccd1ba2fa)|![image](https://github.com/EmbarkStudios/spirt/assets/77424/f725b9bd-7715-4c96-8e4e-e573e41a8478)|