### PR TITLE
print: use `OpName`s to replace the `T1`/`F2`/`v3` style, when unambiguous.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased] - ReleaseDate
 
 ### Changed 🛠
+- [PR#36](https://github.com/EmbarkStudios/spirt/pull/36) started using `OpName`s
+  in pretty-printing, to replace the `T1`/`F2`/`v3` "anonymous" style, when unambiguous
 - [PR#40](https://github.com/EmbarkStudios/spirt/pull/40) increased the pretty-printed
   HTML `font-size` from `15px` to `17px`, to improve readability
 - [PR#39](https://github.com/EmbarkStudios/spirt/pull/39) shortened pretty-printed names

--- a/src/print/multiversion.rs
+++ b/src/print/multiversion.rs
@@ -243,8 +243,8 @@ impl Versions<pretty::FragmentPostLayout> {
                                             // which can go before indents.
                                             while let [TextOp::Text(pretty::INDENT), rest @ ..]
                                             | [
-                                                TextOp::PushStyles(_),
-                                                TextOp::PopStyles(_),
+                                                TextOp::PushAnchor { .. },
+                                                TextOp::PopAnchor { .. },
                                                 rest @ ..,
                                             ] = line
                                             {
@@ -329,7 +329,7 @@ struct AnchorAligner<'a> {
     /// into `merged_lines`), which the next column will align to.
     //
     // FIXME(eddyb) does this need additional interning?
-    anchor_def_to_merged_line_idx: FxIndexMap<&'a String, usize>,
+    anchor_def_to_merged_line_idx: FxIndexMap<&'a str, usize>,
 
     // FIXME(eddyb) fine-tune this inline size.
     // FIXME(eddyb) maybe don't keep most of this data around anyway?
@@ -456,14 +456,14 @@ impl<'a> AnchorAligner<'a> {
             .enumerate()
         {
             for op in new_line_text_ops {
-                if let TextOp::PushStyles(styles) = op {
-                    if let Some(anchor) = &styles.anchor {
-                        if styles.anchor_is_def {
-                            new_anchor_def_to_line_idx
-                                .entry(anchor)
-                                .or_insert(new_line_idx);
-                        }
-                    }
+                if let TextOp::PushAnchor {
+                    is_def: true,
+                    anchor,
+                } = *op
+                {
+                    new_anchor_def_to_line_idx
+                        .entry(anchor)
+                        .or_insert(new_line_idx);
                 }
             }
         }

--- a/src/print/pretty.rs
+++ b/src/print/pretty.rs
@@ -118,6 +118,7 @@ pub mod palettes {
     /// Minimalist palette, chosen to work with both light and dark backgrounds.
     pub mod simple {
         pub const DARK_GRAY: [u8; 3] = [0x44, 0x44, 0x44];
+        pub const LIGHT_GRAY: [u8; 3] = [0x88, 0x88, 0x88];
 
         pub const RED: [u8; 3] = [0xcc, 0x55, 0x55];
         pub const GREEN: [u8; 3] = [0x44, 0x99, 0x44];

--- a/src/spv/mod.rs
+++ b/src/spv/mod.rs
@@ -117,7 +117,7 @@ pub type Id = NonZeroU32;
 /// Given a single `LiteralString` (as one [`Imm::Short`] or a [`Imm::LongStart`]
 /// followed by some number of [`Imm::LongCont`] - will panic otherwise), returns a
 /// Rust [`String`] if the literal is valid UTF-8, or the validation error otherwise.
-fn extract_literal_string(imms: &[Imm]) -> Result<String, FromUtf8Error> {
+pub fn extract_literal_string(imms: &[Imm]) -> Result<String, FromUtf8Error> {
     let wk = &spec::Spec::get().well_known;
 
     let mut words = match *imms {
@@ -148,7 +148,7 @@ fn extract_literal_string(imms: &[Imm]) -> Result<String, FromUtf8Error> {
 }
 
 // FIXME(eddyb) this shouldn't just panic when `s.contains('\0')`.
-fn encode_literal_string(s: &str) -> impl Iterator<Item = Imm> + '_ {
+pub fn encode_literal_string(s: &str) -> impl Iterator<Item = Imm> + '_ {
     let wk = &spec::Spec::get().well_known;
 
     let bytes = s.as_bytes();


### PR DESCRIPTION
I've also made the `T1` style use subscripts (so more like `T₁`), because I wasn't happy with the aesthetics of having digits exactly as large as the prefix.

The reason I haven't done the subscript change earlier is e.g. `v5` already looks great, and `v₅` and `T₅` still looks different because the `T` is larger than the `v` - the missing trick was to make the subscripts larger when the prefix is uppercase, which seems to balance things out.

Comparison (using Kajiya's `assets/shaders/ircache/raster_origins_vs.hlsl`, compiled by DXC, like #39):
|[**Before**](https://htmlpreview.github.io/?https://gist.github.com/eddyb/22a1468ce5341e822e95204a91406897/raw/0-before-spirt%252336-raster_origins_vs.hlsl.structured.spirt.html)<br><sub>(click for complete pretty HTML example)</sub>|[**After**](https://htmlpreview.github.io/?https://gist.github.com/eddyb/22a1468ce5341e822e95204a91406897/raw/1-after-spirt%252336-raster_origins_vs.hlsl.structured.spirt.html)<br><sub>(click for complete pretty HTML example)</sub>|
|-|-|
|![image](https://github.com/EmbarkStudios/spirt/assets/77424/c6a6c00d-1e80-49e8-a87d-d45c4287cdd2)|![image](https://github.com/EmbarkStudios/spirt/assets/77424/d595c9d2-5098-42b4-90dc-4df25d890195)|
|![image](https://github.com/EmbarkStudios/spirt/assets/77424/6ef0ae99-eaea-4453-b804-13eed6afd8d4)|![image](https://github.com/EmbarkStudios/spirt/assets/77424/acd6224f-f1b5-4c72-a8f8-980418447279)|