### PR TITLE
print: separate "roots" from "nodes" and only use dynamic dispatch for roots.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased] - ReleaseDate
 
 ### Changed 🛠
+- [PR#38](https://github.com/EmbarkStudios/spirt/pull/38) split off `print::Node::Root`,
+  allowing "roots" and "non-root nodes" to have different APIs, and dynamic dispatch
+  to be limited to "roots" (as "non-root nodes" are a small finite set of types)
 - [PR#35](https://github.com/EmbarkStudios/spirt/pull/35) abandoned the custom
   `#{A, B, C}` "attribute set" style in favor of Rust-like `#[A]` `#[B]` `#[C]`
   (and always printing them inline, without any `attrs123` shorthands)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ exclude = [".github", "release.toml", "tests/data"]
 [dependencies]
 arrayvec = "0.7.1"
 bytemuck = "1.12.3"
+derive_more = "0.99.17"
 elsa = { version = "1.6.0", features = ["indexmap"] }
 indexmap = "1.7.0"
 internal-iterator = "0.2.0"

--- a/deny.toml
+++ b/deny.toml
@@ -38,6 +38,11 @@ copyleft = "deny"
 multiple-versions = "deny"
 # Lint level for when a crate version requirement is `*`
 wildcards = "deny"
+# Certain crates/versions that will be skipped when doing duplicate detection.
+skip = [
+    # FIXME(eddyb) `syn 2` has not replaced `syn 1` across the ecosystem yet.
+    { name = "syn", version = "2" },
+]
 
 # This section is considered when running `cargo deny check sources`.
 # More documentation about the 'sources' section can be found here:

--- a/src/qptr/mod.rs
+++ b/src/qptr/mod.rs
@@ -4,7 +4,7 @@
 // FIXME(eddyb) PR description of https://github.com/EmbarkStudios/spirt/pull/24
 // has more useful docs that could be copied here.
 
-use crate::{AddrSpace, Attr, DataInstKind, OrdAssertEq, Type};
+use crate::{AddrSpace, OrdAssertEq, Type};
 use std::collections::BTreeMap;
 use std::num::NonZeroU32;
 use std::ops::Range;
@@ -60,12 +60,6 @@ pub enum QPtrAttr {
     /// `ControlRegionInputDecl` or `ControlNodeOutputDecl`, this tracks all the
     /// ways in which the pointer may be used (see `QPtrUsage`).
     Usage(OrdAssertEq<QPtrUsage>),
-}
-
-impl From<QPtrAttr> for Attr {
-    fn from(attr: QPtrAttr) -> Self {
-        Attr::QPtr(attr)
-    }
 }
 
 #[derive(Clone, PartialEq, Eq, Hash)]
@@ -217,10 +211,4 @@ pub enum QPtrOp {
     //
     // FIXME(eddyb) implement more ops! at the very least copying!
     // (and lowering could ignore pointercasts, I guess?)
-}
-
-impl From<QPtrOp> for DataInstKind {
-    fn from(op: QPtrOp) -> Self {
-        DataInstKind::QPtr(op)
-    }
 }

--- a/src/visit.rs
+++ b/src/visit.rs
@@ -141,20 +141,6 @@ impl_visit! {
     }
 }
 
-/// Dynamic dispatch version of [`Visit`].
-///
-/// `dyn DynVisit<'a, V>` is possible, unlike `dyn Visit`, because of the
-/// `trait`-level type parameter `V`, which replaces the method parameter.
-pub trait DynVisit<'a, V> {
-    fn dyn_visit_with(&'a self, visitor: &mut V);
-}
-
-impl<'a, T: Visit, V: Visitor<'a>> DynVisit<'a, V> for T {
-    fn dyn_visit_with(&'a self, visitor: &mut V) {
-        self.visit_with(visitor);
-    }
-}
-
 /// Trait implemented on "deeply visitable" types, to further "explore" a type
 /// by visiting its "interior" (i.e. variants and/or fields).
 ///


### PR DESCRIPTION
`print::Node` used to contain both `Root` (which is user-specified and could be any `Visit+Print` type), and specific node types (such as interned `Type`s/`Const`s, and `Module`-owned `GlobalVar`s/`Func`s), which never needed dynamic dispatch but were forced to use it anyway, because `Node::Root`s needed it.

The other conflation was caused by the fact that non-root node types need to implement `Print<Output = AttrsAndDef>`, because they have *names* that have to be inserted (in between attributes and the rest of the definition), but the root has no such requirement, since it's self-contained and only its dependencies need to be named.

By treating roots separately, we can require `Print<Output = pretty::Fragment>` instead for roots, which fixes a long-term annoyance where pretty-printing something other than `Module` required changing its `Print` impl to have `type Output = AttrsAndDef;` (even when incorrect for that usage).

With the new setup, it may even be worth making `Print<Output = pretty::Fragment>` and `Print<Output = AttrsAndDef>` different traits (perhaps the latter could have a default `print` method that takes the name, and the method being implemented would have a different name than just `print`).