### PR TITLE
print: shorten names like `type2`/`func3`/etc. to `T2`/`F3`/etc.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased] - ReleaseDate
 
 ### Changed 🛠
+- [PR#39](https://github.com/EmbarkStudios/spirt/pull/39) shortened pretty-printed names
+  like `type2`/`func3`/etc. to `T2`/`F3`/etc. (with e.g. `type T2 = ...` style definitions)
 - [PR#38](https://github.com/EmbarkStudios/spirt/pull/38) split off `print::Node::Root`,
   allowing "roots" and "non-root nodes" to have different APIs, and dynamic dispatch
   to be limited to "roots" (as "non-root nodes" are a small finite set of types)

--- a/README.md
+++ b/README.md
@@ -135,9 +135,9 @@ fn main() -> @location(0) i32 {
 ```cxx
 #[spv.Decoration.Flat]
 #[spv.Decoration.Location(Location: 0)]
-global_var0 in spv.StorageClass.Output: s32
+global_var GV0 in spv.StorageClass.Output: s32
 
-func0() -> spv.OpTypeVoid {
+func F0() -> spv.OpTypeVoid {
   loop(v0: s32 <- 1s32, v1: s32 <- 1s32) {
     v2 = spv.OpSLessThan(v1, 10s32): bool
     (v3: bool, v4: s32, v5: s32) = if v2 {
@@ -145,7 +145,7 @@ func0() -> spv.OpTypeVoid {
       v7 = spv.OpIAdd(v1, 1s32): s32
       (true, v6, v7)
     } else {
-      spv.OpStore(Pointer: &global_var0, Object: v0)
+      spv.OpStore(Pointer: &GV0, Object: v0)
       (false, spv.OpUndef: s32, spv.OpUndef: s32)
     }
     (v4, v5) -> (v0, v1)


### PR DESCRIPTION
This is something I realized while looking at the output of #36, where keywords like `type` or `const` were overly verbose.

I've kept the keywords but only on definitions, so e.g. `type T5 = ...` is referred to as `T5`.

Comparison (using Kajiya's `assets/shaders/ircache/raster_origins_vs.hlsl`, compiled by DXC):
|[**Before**](https://htmlpreview.github.io/?https://gist.github.com/eddyb/809b734460afeaa5c72c31992c9d0bbb/raw/0-before-spirt%252339-raster_origins_vs.hlsl.structured.spirt.html)<br><sub>(click for complete pretty HTML example)</sub>|[**After**](https://htmlpreview.github.io/?https://gist.github.com/eddyb/809b734460afeaa5c72c31992c9d0bbb/raw/1-after-spirt%252339-raster_origins_vs.hlsl.structured.spirt.html)<br><sub>(click for complete pretty HTML example)</sub>|
|-|-|
|![image](https://github.com/EmbarkStudios/spirt/assets/77424/51526d40-f404-47f9-a54b-535367658ee6)|![image](https://github.com/EmbarkStudios/spirt/assets/77424/5bd320ad-f559-4ace-9180-1aa707973973)|
|![image](https://github.com/EmbarkStudios/spirt/assets/77424/c3f75dc3-fdad-487e-866c-c9c35d770275)|![image](https://github.com/EmbarkStudios/spirt/assets/77424/96c8eb55-a14e-48f8-886d-a10b8f8c8550)|