### PR TITLE
Set `use_small_heuristics = "Max"` in `rustfmt.toml` to disable iffy heuristics.

### DIFF
--- a/examples/spv-lower-link-lift.rs
+++ b/examples/spv-lower-link-lift.rs
@@ -15,10 +15,7 @@ fn main() -> std::io::Result<()> {
                 fs::write(in_file_path.with_extension(&ext), pretty.to_string())?;
                 fs::write(
                     in_file_path.with_extension(ext + ".html"),
-                    pretty
-                        .render_to_html()
-                        .with_dark_mode_support()
-                        .to_html_doc(),
+                    pretty.render_to_html().with_dark_mode_support().to_html_doc(),
                 )
             };
 

--- a/examples/spv-lower-link-qptr-lift.rs
+++ b/examples/spv-lower-link-qptr-lift.rs
@@ -15,10 +15,7 @@ fn main() -> std::io::Result<()> {
                 fs::write(in_file_path.with_extension(&ext), pretty.to_string())?;
                 fs::write(
                     in_file_path.with_extension(ext + ".html"),
-                    pretty
-                        .render_to_html()
-                        .with_dark_mode_support()
-                        .to_html_doc(),
+                    pretty.render_to_html().with_dark_mode_support().to_html_doc(),
                 )
             };
 

--- a/examples/spv-lower-print.rs
+++ b/examples/spv-lower-print.rs
@@ -10,20 +10,14 @@ fn main() -> std::io::Result<()> {
 
                 let save_print_plan = |suffix: &str, plan: spirt::print::Plan| {
                     let pretty = plan.pretty_print();
-                    let ext = if suffix.is_empty() {
-                        "spirt".into()
-                    } else {
-                        format!("{suffix}.spirt")
-                    };
+                    let ext =
+                        if suffix.is_empty() { "spirt".into() } else { format!("{suffix}.spirt") };
 
                     // FIXME(eddyb) don't allocate whole `String`s here.
                     fs::write(in_file_path.with_extension(&ext), pretty.to_string())?;
                     fs::write(
                         in_file_path.with_extension(ext + ".html"),
-                        pretty
-                            .render_to_html()
-                            .with_dark_mode_support()
-                            .to_html_doc(),
+                        pretty.render_to_html().with_dark_mode_support().to_html_doc(),
                     )
                 };
 

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,3 +1,6 @@
 # HACK(eddyb) needed to format array/slice patterns at all, because it was a
 # breaking change (see https://github.com/rust-lang/rustfmt/pull/4994).
 version = "Two"
+
+# HACK(eddyb) avoid random spilling of e.g. method call chains onto many lines.
+use_small_heuristics = "Max"

--- a/src/context.rs
+++ b/src/context.rs
@@ -107,9 +107,7 @@ mod sealed {
         fn default() -> Self {
             // NOTE(eddyb) always skip chunk `0`, as a sort of "null page",
             // to allow using `NonZeroU32` instead of merely `u32`.
-            Self(Cell::new(E::from_non_zero_u32(
-                NonZeroU32::new(E::CHUNK_SIZE).unwrap(),
-            )))
+            Self(Cell::new(E::from_non_zero_u32(NonZeroU32::new(E::CHUNK_SIZE).unwrap())))
         }
     }
 
@@ -248,9 +246,7 @@ impl<E: sealed::Entity> EntityDefs<E> {
             {
                 incomplete_flattened_base
             }
-            _ => *self
-                .complete_chunk_start_to_flattened_base
-                .get(&chunk_start)?,
+            _ => *self.complete_chunk_start_to_flattened_base.get(&chunk_start)?,
         };
         Some(flattened_base + intra_chunk_idx)
     }
@@ -260,17 +256,13 @@ impl<E: sealed::Entity> std::ops::Index<E> for EntityDefs<E> {
     type Output = E::Def;
 
     fn index(&self, entity: E) -> &Self::Output {
-        self.entity_to_flattened(entity)
-            .and_then(|i| self.flattened.get(i))
-            .unwrap()
+        self.entity_to_flattened(entity).and_then(|i| self.flattened.get(i)).unwrap()
     }
 }
 
 impl<E: sealed::Entity> std::ops::IndexMut<E> for EntityDefs<E> {
     fn index_mut(&mut self, entity: E) -> &mut Self::Output {
-        self.entity_to_flattened(entity)
-            .and_then(|i| self.flattened.get_mut(i))
-            .unwrap()
+        self.entity_to_flattened(entity).and_then(|i| self.flattened.get_mut(i)).unwrap()
     }
 }
 
@@ -392,9 +384,7 @@ impl<K: Copy + Eq + Hash, V: Default> SmallFxHashMap<K, V> {
 
 impl<K: EntityOrientedMapKey<V>, V> Default for EntityOrientedDenseMap<K, V> {
     fn default() -> Self {
-        Self {
-            chunk_start_to_value_slots: Default::default(),
-        }
+        Self { chunk_start_to_value_slots: Default::default() }
     }
 }
 
@@ -408,9 +398,8 @@ impl<K: EntityOrientedMapKey<V>, V> EntityOrientedDenseMap<K, V> {
     pub fn entry(&mut self, key: K) -> &mut Option<V> {
         let entity = K::to_entity(key);
         let (chunk_start, intra_chunk_idx) = entity.to_chunk_start_and_intra_chunk_idx();
-        let chunk_value_slots = self
-            .chunk_start_to_value_slots
-            .get_mut_or_insert_default(chunk_start);
+        let chunk_value_slots =
+            self.chunk_start_to_value_slots.get_mut_or_insert_default(chunk_start);
 
         // Ensure there are enough slots for the new entry.
         let needed_len = intra_chunk_idx + 1;
@@ -429,10 +418,7 @@ impl<K: EntityOrientedMapKey<V>, V> EntityOrientedDenseMap<K, V> {
     pub fn get(&self, key: K) -> Option<&V> {
         let entity = K::to_entity(key);
         let (chunk_start, intra_chunk_idx) = entity.to_chunk_start_and_intra_chunk_idx();
-        let value_slots = self
-            .chunk_start_to_value_slots
-            .get(chunk_start)?
-            .get(intra_chunk_idx)?;
+        let value_slots = self.chunk_start_to_value_slots.get(chunk_start)?.get(intra_chunk_idx)?;
         K::get_dense_value_slot(key, value_slots).as_ref()
     }
 
@@ -448,10 +434,8 @@ impl<K: EntityOrientedMapKey<V>, V> EntityOrientedDenseMap<K, V> {
     fn get_slot_mut(&mut self, key: K) -> Option<&mut Option<V>> {
         let entity = K::to_entity(key);
         let (chunk_start, intra_chunk_idx) = entity.to_chunk_start_and_intra_chunk_idx();
-        let value_slots = self
-            .chunk_start_to_value_slots
-            .get_mut(chunk_start)?
-            .get_mut(intra_chunk_idx)?;
+        let value_slots =
+            self.chunk_start_to_value_slots.get_mut(chunk_start)?.get_mut(intra_chunk_idx)?;
         Some(K::get_dense_value_slot_mut(key, value_slots))
     }
 }
@@ -501,10 +485,7 @@ impl<E: sealed::Entity<Def = EntityListNode<E, D>>, D> EntityList<E> {
     }
 
     pub fn iter(self) -> EntityListIter<E> {
-        EntityListIter {
-            first: self.0.map(|list| list.first),
-            last: self.0.map(|list| list.last),
-        }
+        EntityListIter { first: self.0.map(|list| list.first), last: self.0.map(|list| list.last) }
     }
 
     /// Insert `new_node` (defined in `defs`) at the start of `self`.
@@ -524,18 +505,13 @@ impl<E: sealed::Entity<Def = EntityListNode<E, D>>, D> EntityList<E> {
             // involves the `EntityListNode`s links, which should be unforgeable,
             // but it's still possible to keep around outdated `EntityList`s
             // (should `EntityList` not implement `Copy`/`Clone` *at all*?)
-            assert!(
-                old_first_def.prev.is_none(),
-                "invalid EntityList: `first->prev != None`"
-            );
+            assert!(old_first_def.prev.is_none(), "invalid EntityList: `first->prev != None`");
 
             old_first_def.prev = Some(new_node);
         }
 
-        self.0 = Some(FirstLast {
-            first: new_node,
-            last: self.0.map_or(new_node, |this| this.last),
-        });
+        self.0 =
+            Some(FirstLast { first: new_node, last: self.0.map_or(new_node, |this| this.last) });
     }
 
     /// Insert `new_node` (defined in `defs`) at the end of `self`.
@@ -555,18 +531,13 @@ impl<E: sealed::Entity<Def = EntityListNode<E, D>>, D> EntityList<E> {
             // involves the `EntityListNode`s links, which should be unforgeable,
             // but it's still possible to keep around outdated `EntityList`s
             // (should `EntityList` not implement `Copy`/`Clone` *at all*?)
-            assert!(
-                old_last_def.next.is_none(),
-                "invalid EntityList: `last->next != None`"
-            );
+            assert!(old_last_def.next.is_none(), "invalid EntityList: `last->next != None`");
 
             old_last_def.next = Some(new_node);
         }
 
-        self.0 = Some(FirstLast {
-            first: self.0.map_or(new_node, |this| this.first),
-            last: new_node,
-        });
+        self.0 =
+            Some(FirstLast { first: self.0.map_or(new_node, |this| this.first), last: new_node });
     }
 
     /// Insert `new_node` (defined in `defs`) into `self`, before `next`.
@@ -639,10 +610,7 @@ impl<E: sealed::Entity<Def = EntityListNode<E, D>>, D> EntityList<E> {
             // involves the `EntityListNode`s links, which should be unforgeable,
             // but it's still possible to keep around outdated `EntityList`s
             // (should `EntityList` not implement `Copy`/`Clone` *at all*?)
-            assert!(
-                a_last_def.next.is_none(),
-                "invalid EntityList: `last->next != None`"
-            );
+            assert!(a_last_def.next.is_none(), "invalid EntityList: `last->next != None`");
 
             a_last_def.next = Some(b.first);
         }
@@ -653,18 +621,12 @@ impl<E: sealed::Entity<Def = EntityListNode<E, D>>, D> EntityList<E> {
             // involves the `EntityListNode`s links, which should be unforgeable,
             // but it's still possible to keep around outdated `EntityList`s
             // (should `EntityList` not implement `Copy`/`Clone` *at all*?)
-            assert!(
-                b_first_def.prev.is_none(),
-                "invalid EntityList: `first->prev != None`"
-            );
+            assert!(b_first_def.prev.is_none(), "invalid EntityList: `first->prev != None`");
 
             b_first_def.prev = Some(a.last);
         }
 
-        Self(Some(FirstLast {
-            first: a.first,
-            last: b.last,
-        }))
+        Self(Some(FirstLast { first: a.first, last: b.last }))
     }
 
     /// Remove `node` (defined in `defs`) from `self`.
@@ -805,11 +767,7 @@ pub struct EntityListNode<E: sealed::Entity<Def = Self>, D> {
 
 impl<E: sealed::Entity<Def = Self>, D> From<D> for EntityListNode<E, D> {
     fn from(inner_def: D) -> Self {
-        Self {
-            prev: None,
-            next: None,
-            inner_def,
-        }
+        Self { prev: None, next: None, inner_def }
     }
 }
 

--- a/src/func_at.rs
+++ b/src/func_at.rs
@@ -113,10 +113,9 @@ impl FuncAt<'_, Value> {
             Value::ControlRegionInput { region, input_idx } => {
                 self.at(region).def().inputs[input_idx as usize].ty
             }
-            Value::ControlNodeOutput {
-                control_node,
-                output_idx,
-            } => self.at(control_node).def().outputs[output_idx as usize].ty,
+            Value::ControlNodeOutput { control_node, output_idx } => {
+                self.at(control_node).def().outputs[output_idx as usize].ty
+            }
             Value::DataInstOutput(inst) => cx[self.at(inst).def().form].output_type.unwrap(),
         }
     }
@@ -159,18 +158,8 @@ impl<'a, P: Copy> FuncAtMut<'a, P> {
     //
     // FIXME(eddyb) maybe find a better name for this?
     pub fn freeze(self) -> FuncAt<'a, P> {
-        let FuncAtMut {
-            control_regions,
-            control_nodes,
-            data_insts,
-            position,
-        } = self;
-        FuncAt {
-            control_regions,
-            control_nodes,
-            data_insts,
-            position,
-        }
+        let FuncAtMut { control_regions, control_nodes, data_insts, position } = self;
+        FuncAt { control_regions, control_nodes, data_insts, position }
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -311,9 +311,7 @@ impl AttrSetDef {
 
     // FIXME(eddyb) should this be hidden in favor of `AttrSet::append_diag`?
     pub fn append_diag(&self, diag: Diag) -> Self {
-        let mut new_attrs = Self {
-            attrs: self.attrs.clone(),
-        };
+        let mut new_attrs = Self { attrs: self.attrs.clone() };
         new_attrs.push_diag(diag);
         new_attrs
     }
@@ -376,10 +374,7 @@ pub struct Diag {
 
 impl Diag {
     pub fn new(level: DiagLevel, message: impl IntoIterator<Item = DiagMsgPart>) -> Self {
-        Self {
-            level,
-            message: message.into_iter().collect(),
-        }
+        Self { level, message: message.into_iter().collect() }
     }
 
     // FIMXE(eddyb) make macros more ergonomic than this, for interpolation.
@@ -792,12 +787,7 @@ pub enum ControlNodeKind {
     ///
     /// This corresponds to "gamma" (`γ`) nodes in (R)VSDG, though those are
     /// sometimes limited only to a two-way selection on a boolean condition.
-    Select {
-        kind: SelectionKind,
-        scrutinee: Value,
-
-        cases: SmallVec<[ControlRegion; 2]>,
-    },
+    Select { kind: SelectionKind, scrutinee: Value, cases: SmallVec<[ControlRegion; 2]> },
 
     /// Execute `body` repeatedly, until `repeat_condition` evaluates to `false`.
     ///

--- a/src/passes/link.rs
+++ b/src/passes/link.rs
@@ -153,9 +153,7 @@ pub fn resolve_imports(module: &mut Module) {
 
     // Seed the queues starting from the module exports.
     for exportee in module.exports.values_mut() {
-        exportee
-            .inner_transform_with(&mut resolver)
-            .apply_to(exportee);
+        exportee.inner_transform_with(&mut resolver).apply_to(exportee);
     }
 
     // Process the queues until they're all empty.
@@ -265,9 +263,8 @@ impl Transformer for ImportResolver<'_> {
         if let Some(&cached) = self.transformed_types.get(&ty) {
             return cached;
         }
-        let transformed = self
-            .transform_type_def(&self.cx[ty])
-            .map(|ty_def| self.cx.intern(ty_def));
+        let transformed =
+            self.transform_type_def(&self.cx[ty]).map(|ty_def| self.cx.intern(ty_def));
         self.transformed_types.insert(ty, transformed);
         transformed
     }
@@ -275,9 +272,8 @@ impl Transformer for ImportResolver<'_> {
         if let Some(&cached) = self.transformed_consts.get(&ct) {
             return cached;
         }
-        let transformed = self
-            .transform_const_def(&self.cx[ct])
-            .map(|ct_def| self.cx.intern(ct_def));
+        let transformed =
+            self.transform_const_def(&self.cx[ct]).map(|ct_def| self.cx.intern(ct_def));
         self.transformed_consts.insert(ct, transformed);
         transformed
     }
@@ -291,8 +287,7 @@ impl Transformer for ImportResolver<'_> {
         let transformed = self
             .transform_data_inst_form_def(&self.cx[data_inst_form])
             .map(|data_inst_form_def| self.cx.intern(data_inst_form_def));
-        self.transformed_data_inst_forms
-            .insert(data_inst_form, transformed);
+        self.transformed_data_inst_forms.insert(data_inst_form, transformed);
         transformed
     }
 

--- a/src/print/pretty.rs
+++ b/src/print/pretty.rs
@@ -92,10 +92,7 @@ pub struct Styles {
 
 impl Styles {
     pub fn color(color: [u8; 3]) -> Self {
-        Self {
-            color: Some(color),
-            ..Self::default()
-        }
+        Self { color: Some(color), ..Self::default() }
     }
 
     pub fn apply(self, text: impl Into<Cow<'static, str>>) -> Node {
@@ -105,11 +102,7 @@ impl Styles {
     // HACK(eddyb) this allows us to control `<sub>`/`<sup>` `font-size` exactly,
     // and use the same information for both layout and the CSS we emit.
     fn effective_size(&self) -> Option<i8> {
-        self.size.or(if self.subscript || self.superscript {
-            Some(-2)
-        } else {
-            None
-        })
+        self.size.or(if self.subscript || self.superscript { Some(-2) } else { None })
     }
 }
 
@@ -146,34 +139,23 @@ impl From<String> for Node {
 
 impl<T: Into<Node>> From<T> for Fragment {
     fn from(x: T) -> Self {
-        Self {
-            nodes: [x.into()].into_iter().collect(),
-        }
+        Self { nodes: [x.into()].into_iter().collect() }
     }
 }
 
 impl Fragment {
     pub fn new(fragments: impl IntoIterator<Item = impl Into<Self>>) -> Self {
-        Self {
-            nodes: fragments
-                .into_iter()
-                .flat_map(|fragment| fragment.into().nodes)
-                .collect(),
-        }
+        Self { nodes: fragments.into_iter().flat_map(|fragment| fragment.into().nodes).collect() }
     }
 
     /// Perform layout on the [`Fragment`], limiting lines to `max_line_width`
     /// columns where possible.
     pub fn layout_with_max_line_width(mut self, max_line_width: usize) -> FragmentPostLayout {
         // FIXME(eddyb) maybe make this a method on `Columns`?
-        let max_line_width = Columns {
-            char_width_tenths: max_line_width.try_into().unwrap_or(u16::MAX) * 10,
-        };
+        let max_line_width =
+            Columns { char_width_tenths: max_line_width.try_into().unwrap_or(u16::MAX) * 10 };
 
-        self.approx_layout(MaxWidths {
-            inline: max_line_width,
-            block: max_line_width,
-        });
+        self.approx_layout(MaxWidths { inline: max_line_width, block: max_line_width });
         FragmentPostLayout(self)
     }
 }
@@ -190,8 +172,7 @@ impl fmt::Display for FragmentPostLayout {
                 _ => None,
             })
             .try_for_each(|text| {
-                f.write_str(text)
-                    .map_or_else(ControlFlow::Break, ControlFlow::Continue)
+                f.write_str(text).map_or_else(ControlFlow::Break, ControlFlow::Continue)
             });
         match result {
             ControlFlow::Continue(()) => Ok(()),
@@ -441,10 +422,7 @@ impl<'a> FromInternalIterator<TextOp<'a>> for HtmlSnippet {
         });
         body += "</pre>";
 
-        HtmlSnippet {
-            head_deduplicatable_elements: [style_elem].into_iter().collect(),
-            body,
-        }
+        HtmlSnippet { head_deduplicatable_elements: [style_elem].into_iter().collect(), body }
     }
 }
 
@@ -464,9 +442,7 @@ struct Columns {
 }
 
 impl Columns {
-    const ZERO: Self = Self {
-        char_width_tenths: 0,
-    };
+    const ZERO: Self = Self { char_width_tenths: 0 };
 
     fn text_width(text: &str) -> Self {
         Self::maybe_styled_text_width(text, None)
@@ -481,28 +457,16 @@ impl Columns {
 
         // FIXME(eddyb) use `unicode-width` crate for accurate column count.
         Self {
-            char_width_tenths: text
-                .len()
-                .try_into()
-                .unwrap_or(u16::MAX)
-                .saturating_mul(font_size),
+            char_width_tenths: text.len().try_into().unwrap_or(u16::MAX).saturating_mul(font_size),
         }
     }
 
     fn saturating_add(self, other: Self) -> Self {
-        Self {
-            char_width_tenths: self
-                .char_width_tenths
-                .saturating_add(other.char_width_tenths),
-        }
+        Self { char_width_tenths: self.char_width_tenths.saturating_add(other.char_width_tenths) }
     }
 
     fn saturating_sub(self, other: Self) -> Self {
-        Self {
-            char_width_tenths: self
-                .char_width_tenths
-                .saturating_sub(other.char_width_tenths),
-        }
+        Self { char_width_tenths: self.char_width_tenths.saturating_sub(other.char_width_tenths) }
     }
 }
 
@@ -528,61 +492,33 @@ enum ApproxLayout {
     /// an `Inline` before (`pre_`) and after (`post_`) the multi-line block.
     //
     // FIXME(eddyb) maybe turn `ApproxLayout` into a `struct` instead?
-    BlockOrMixed {
-        pre_worst_width: Columns,
-        post_worst_width: Columns,
-    },
+    BlockOrMixed { pre_worst_width: Columns, post_worst_width: Columns },
 }
 
 impl ApproxLayout {
     fn append(self, other: Self) -> Self {
         match (self, other) {
             (
-                Self::Inline {
-                    worst_width: a,
-                    excess_width_from_only_if_block: a_excess_foib,
-                },
-                Self::Inline {
-                    worst_width: b,
-                    excess_width_from_only_if_block: b_excess_foib,
-                },
+                Self::Inline { worst_width: a, excess_width_from_only_if_block: a_excess_foib },
+                Self::Inline { worst_width: b, excess_width_from_only_if_block: b_excess_foib },
             ) => Self::Inline {
                 worst_width: a.saturating_add(b),
                 excess_width_from_only_if_block: a_excess_foib.saturating_add(b_excess_foib),
             },
             (
-                Self::BlockOrMixed {
-                    pre_worst_width, ..
-                },
-                Self::BlockOrMixed {
-                    post_worst_width, ..
-                },
-            ) => Self::BlockOrMixed {
-                pre_worst_width,
-                post_worst_width,
-            },
+                Self::BlockOrMixed { pre_worst_width, .. },
+                Self::BlockOrMixed { post_worst_width, .. },
+            ) => Self::BlockOrMixed { pre_worst_width, post_worst_width },
             (
-                Self::BlockOrMixed {
-                    pre_worst_width,
-                    post_worst_width: post_a,
-                },
-                Self::Inline {
-                    worst_width: post_b,
-                    excess_width_from_only_if_block: _,
-                },
+                Self::BlockOrMixed { pre_worst_width, post_worst_width: post_a },
+                Self::Inline { worst_width: post_b, excess_width_from_only_if_block: _ },
             ) => Self::BlockOrMixed {
                 pre_worst_width,
                 post_worst_width: post_a.saturating_add(post_b),
             },
             (
-                Self::Inline {
-                    worst_width: pre_a,
-                    excess_width_from_only_if_block: _,
-                },
-                Self::BlockOrMixed {
-                    pre_worst_width: pre_b,
-                    post_worst_width,
-                },
+                Self::Inline { worst_width: pre_a, excess_width_from_only_if_block: _ },
+                Self::BlockOrMixed { pre_worst_width: pre_b, post_worst_width },
             ) => Self::BlockOrMixed {
                 pre_worst_width: pre_a.saturating_add(pre_b),
                 post_worst_width,
@@ -635,11 +571,7 @@ impl Node {
         match self {
             Self::Text(styles, text) => text_approx_rigid_layout(styles, text),
 
-            Self::Anchor {
-                is_def: _,
-                anchor: _,
-                text,
-            } => text
+            Self::Anchor { is_def: _, anchor: _, text } => text
                 .iter()
                 .map(|(styles, text)| text_approx_rigid_layout(styles, text))
                 .reduce(ApproxLayout::append)
@@ -668,16 +600,12 @@ impl Node {
                 // comma added by `join_comma_sep`.
                 let text_layout = Self::Text(None, text.into()).approx_rigid_layout();
                 let worst_width = match text_layout {
-                    ApproxLayout::Inline {
-                        worst_width,
-                        excess_width_from_only_if_block: _,
-                    } => worst_width,
+                    ApproxLayout::Inline { worst_width, excess_width_from_only_if_block: _ } => {
+                        worst_width
+                    }
                     ApproxLayout::BlockOrMixed { .. } => Columns::ZERO,
                 };
-                ApproxLayout::Inline {
-                    worst_width,
-                    excess_width_from_only_if_block: worst_width,
-                }
+                ApproxLayout::Inline { worst_width, excess_width_from_only_if_block: worst_width }
             }
 
             // Layout computed only in `approx_flex_layout`.
@@ -745,10 +673,9 @@ impl Node {
                 // `Node::OnlyIfBlock`s, so `excess_width_from_only_if_block` can
                 // be safely subtracted from the "candidate" inline `worst_width`.
                 let candidate_inline_worst_width = match layout {
-                    ApproxLayout::Inline {
-                        worst_width,
-                        excess_width_from_only_if_block,
-                    } => Some(worst_width.saturating_sub(excess_width_from_only_if_block)),
+                    ApproxLayout::Inline { worst_width, excess_width_from_only_if_block } => {
+                        Some(worst_width.saturating_sub(excess_width_from_only_if_block))
+                    }
 
                     ApproxLayout::BlockOrMixed { .. } => None,
                 };
@@ -806,13 +733,12 @@ impl Fragment {
 
         let child_max_widths = |layout| MaxWidths {
             inline: match layout {
-                ApproxLayout::Inline {
-                    worst_width,
-                    excess_width_from_only_if_block: _,
-                } => max_widths.inline.saturating_sub(worst_width),
-                ApproxLayout::BlockOrMixed {
-                    post_worst_width, ..
-                } => max_widths.block.saturating_sub(post_worst_width),
+                ApproxLayout::Inline { worst_width, excess_width_from_only_if_block: _ } => {
+                    max_widths.inline.saturating_sub(worst_width)
+                }
+                ApproxLayout::BlockOrMixed { post_worst_width, .. } => {
+                    max_widths.block.saturating_sub(post_worst_width)
+                }
             },
             block: max_widths.block,
         };
@@ -826,10 +752,7 @@ impl Fragment {
                 rigid_layout @ ApproxLayout::Inline { .. } => {
                     layout = layout.append(rigid_layout);
                 }
-                ApproxLayout::BlockOrMixed {
-                    pre_worst_width,
-                    post_worst_width,
-                } => {
+                ApproxLayout::BlockOrMixed { pre_worst_width, post_worst_width } => {
                     // Split the `BlockOrMixed` just before the block, and
                     // process "recent" flexible nodes in between the halves.
                     layout = layout.append(ApproxLayout::Inline {
@@ -943,11 +866,7 @@ impl Node {
                 text_render_to_line_ops(styles, text).try_for_each(each_line_op)?;
             }
 
-            &Self::Anchor {
-                is_def,
-                ref anchor,
-                ref text,
-            } => {
+            &Self::Anchor { is_def, ref anchor, ref text } => {
                 if text.is_empty() {
                     each_line_op(LineOp::EmptyAnchor { is_def, anchor })?;
                 } else {
@@ -963,18 +882,15 @@ impl Node {
             }
 
             Self::IndentedBlock(fragments) => {
-                [
-                    LineOp::PushIndent,
-                    LineOp::BreakIfWithinLine(Break::NewLine),
-                ]
-                .into_internal_iter()
-                .chain(fragments.into_internal_iter().flat_map(|fragment| {
-                    fragment
-                        .render_to_line_ops(true)
-                        .chain([LineOp::BreakIfWithinLine(Break::NewLine)])
-                }))
-                .chain([LineOp::PopIndent])
-                .try_for_each(each_line_op)?;
+                [LineOp::PushIndent, LineOp::BreakIfWithinLine(Break::NewLine)]
+                    .into_internal_iter()
+                    .chain(fragments.into_internal_iter().flat_map(|fragment| {
+                        fragment
+                            .render_to_line_ops(true)
+                            .chain([LineOp::BreakIfWithinLine(Break::NewLine)])
+                    }))
+                    .chain([LineOp::PopIndent])
+                    .try_for_each(each_line_op)?;
             }
             // Post-layout, this is only used for the inline layout.
             Self::InlineOrIndentedBlock(fragments) => {
@@ -1145,9 +1061,7 @@ impl<'a> LineOp<'a> {
                     for _ in indent_so_far..target_indent {
                         each_text_op(TextOp::Text(INDENT))?;
                     }
-                    line_state = LineState::OnlyIndentedOrAnchored {
-                        indent_so_far: target_indent,
-                    };
+                    line_state = LineState::OnlyIndentedOrAnchored { indent_so_far: target_indent };
                 }
             }
 
@@ -1250,18 +1164,12 @@ pub fn join_comma_sep(
 
     if let Some((last_child, non_last_children)) = children.split_last_mut() {
         for non_last_child in non_last_children {
-            non_last_child
-                .nodes
-                .extend([",".into(), Node::BreakingOnlySpace]);
+            non_last_child.nodes.extend([",".into(), Node::BreakingOnlySpace]);
         }
 
         // Trailing comma is only needed after the very last element.
         last_child.nodes.push(Node::IfBlockLayout(","));
     }
 
-    Fragment::new([
-        prefix.into(),
-        Node::InlineOrIndentedBlock(children),
-        suffix.into(),
-    ])
+    Fragment::new([prefix.into(), Node::InlineOrIndentedBlock(children), suffix.into()])
 }

--- a/src/qptr/mod.rs
+++ b/src/qptr/mod.rs
@@ -33,10 +33,7 @@ pub enum QPtrAttr {
     /// (i.e. logical pointer semantics, unsuited for e.g. `OpPtrAccessChain`).
     //
     // FIXME(eddyb) reduce usage by modeling more of SPIR-V inside SPIR-T.
-    ToSpvPtrInput {
-        input_idx: u32,
-        pointee: OrdAssertEq<Type>,
-    },
+    ToSpvPtrInput { input_idx: u32, pointee: OrdAssertEq<Type> },
 
     /// When applied to a `DataInst` with a `QPtr`-typed output value,
     /// this describes the original `OpTypePointer` produced by an unknown
@@ -95,10 +92,7 @@ pub struct QPtrMemUsage {
 }
 
 impl QPtrMemUsage {
-    pub const UNUSED: Self = Self {
-        max_size: Some(0),
-        kind: QPtrMemUsageKind::Unused,
-    };
+    pub const UNUSED: Self = Self { max_size: Some(0), kind: QPtrMemUsageKind::Unused };
 }
 
 #[derive(Clone, PartialEq, Eq, Hash)]

--- a/src/spv/mod.rs
+++ b/src/spv/mod.rs
@@ -65,10 +65,7 @@ pub struct Inst {
 
 impl From<spec::Opcode> for Inst {
     fn from(opcode: spec::Opcode) -> Self {
-        Self {
-            opcode,
-            imms: SmallVec::new(),
-        }
+        Self { opcode, imms: SmallVec::new() }
     }
 }
 
@@ -154,9 +151,7 @@ pub fn encode_literal_string(s: &str) -> impl Iterator<Item = Imm> + '_ {
     let bytes = s.as_bytes();
 
     // FIXME(eddyb) replace with `array_chunks` once that is stabilized.
-    let full_words = bytes
-        .chunks_exact(4)
-        .map(|w| <[u8; 4]>::try_from(w).unwrap());
+    let full_words = bytes.chunks_exact(4).map(|w| <[u8; 4]>::try_from(w).unwrap());
 
     let leftover_bytes = &bytes[full_words.len() * 4..];
     let mut last_word = [0; 4];
@@ -164,16 +159,14 @@ pub fn encode_literal_string(s: &str) -> impl Iterator<Item = Imm> + '_ {
 
     let total_words = full_words.len() + 1;
 
-    full_words
-        .chain(iter::once(last_word))
-        .map(u32::from_le_bytes)
-        .enumerate()
-        .map(move |(i, word)| {
+    full_words.chain(iter::once(last_word)).map(u32::from_le_bytes).enumerate().map(
+        move |(i, word)| {
             let kind = wk.LiteralString;
             match (i, total_words) {
                 (0, 1) => Imm::Short(kind, word),
                 (0, _) => Imm::LongStart(kind, word),
                 (_, _) => Imm::LongCont(kind, word),
             }
-        })
+        },
+    )
 }

--- a/src/spv/print.rs
+++ b/src/spv/print.rs
@@ -49,9 +49,7 @@ pub struct TokensForOperand<ID> {
 
 impl<ID> Default for TokensForOperand<ID> {
     fn default() -> Self {
-        Self {
-            tokens: SmallVec::new(),
-        }
+        Self { tokens: SmallVec::new() }
     }
 }
 
@@ -101,9 +99,7 @@ impl<IMMS: Iterator<Item = spv::Imm>, ID, IDS: Iterator<Item = ID>> OperandPrint
                 break;
             }
 
-            self.out
-                .tokens
-                .push(Token::Punctuation(if first { "(" } else { ", " }));
+            self.out.tokens.push(Token::Punctuation(if first { "(" } else { ", " }));
             first = false;
 
             let (name, kind) = name_and_kind.name_and_kind();
@@ -139,11 +135,8 @@ impl<IMMS: Iterator<Item = spv::Imm>, ID, IDS: Iterator<Item = ID>> OperandPrint
                 Err(e) => Token::Error(format!("/* {e} in {bytes:?} */")),
             }
         } else {
-            let mut words_msb_to_lsb = words
-                .into_iter()
-                .rev()
-                .skip_while(|&word| word == 0)
-                .peekable();
+            let mut words_msb_to_lsb =
+                words.into_iter().rev().skip_while(|&word| word == 0).peekable();
             let most_significant_word = words_msb_to_lsb.next().unwrap_or(0);
 
             // FIXME(eddyb) use a more advanced decision procedure for picking
@@ -172,9 +165,7 @@ impl<IMMS: Iterator<Item = spv::Imm>, ID, IDS: Iterator<Item = ID>> OperandPrint
 
         // FIXME(eddyb) should this be a hard error?
         let emit_missing_error = |this: &mut Self| {
-            this.out
-                .tokens
-                .push(Token::Error(format!("/* missing {name} */")));
+            this.out.tokens.push(Token::Error(format!("/* missing {name} */")));
         };
 
         let mut maybe_get_enum_word = || match self.imms.next() {
@@ -193,9 +184,7 @@ impl<IMMS: Iterator<Item = spv::Imm>, ID, IDS: Iterator<Item = ID>> OperandPrint
                     None => return emit_missing_error(self),
                 };
 
-                self.out
-                    .tokens
-                    .push(Token::OperandKindNamespacePrefix(name));
+                self.out.tokens.push(Token::OperandKindNamespacePrefix(name));
                 if word == 0 {
                     self.out.tokens.push(Token::EnumerandName(empty_name));
                 } else if let Some(bit_idx) = spec::BitIdx::of_single_set_bit(word) {
@@ -256,17 +245,14 @@ impl<IMMS: Iterator<Item = spv::Imm>, ID, IDS: Iterator<Item = ID>> OperandPrint
     }
 
     fn inst_operands(mut self, opcode: spec::Opcode) -> impl Iterator<Item = TokensForOperand<ID>> {
-        opcode
-            .def()
-            .all_operands_with_names()
-            .map_while(move |(mode, name_and_kind)| {
-                if mode == spec::OperandMode::Optional && self.is_exhausted() {
-                    return None;
-                }
-                let (name, kind) = name_and_kind.name_and_kind();
-                self.operand(name, kind);
-                Some(mem::take(&mut self.out))
-            })
+        opcode.def().all_operands_with_names().map_while(move |(mode, name_and_kind)| {
+            if mode == spec::OperandMode::Optional && self.is_exhausted() {
+                return None;
+            }
+            let (name, kind) = name_and_kind.name_and_kind();
+            self.operand(name, kind);
+            Some(mem::take(&mut self.out))
+        })
     }
 }
 

--- a/src/spv/spec.rs
+++ b/src/spv/spec.rs
@@ -269,8 +269,7 @@ impl InstructionDef {
     /// or that an operand's absence signals the end of operands (`Optional`),
     /// which is also the exit signal for the "rest operands" infinite iterators.
     pub fn all_operands(&self) -> impl Iterator<Item = (OperandMode, OperandKind)> + '_ {
-        self.all_operands_with_names()
-            .map(|(mode, name_and_kind)| (mode, name_and_kind.kind()))
+        self.all_operands_with_names().map(|(mode, name_and_kind)| (mode, name_and_kind.kind()))
     }
 
     /// Like `all_operands`, but providing access to the operand names as well.
@@ -296,16 +295,10 @@ impl InstructionDef {
                     RestOperandsUnit::Two([a_kind, b_kind]) => (a_kind, Some(b_kind)),
                 };
                 iter::repeat(
-                    iter::once((
-                        OperandMode::Optional,
-                        PackedOperandNameAndKind::unnamed(opt_a),
-                    ))
-                    .chain(req_b.map(|kind| {
-                        (
-                            OperandMode::Required,
-                            PackedOperandNameAndKind::unnamed(kind),
-                        )
-                    })),
+                    iter::once((OperandMode::Optional, PackedOperandNameAndKind::unnamed(opt_a)))
+                        .chain(req_b.map(|kind| {
+                            (OperandMode::Required, PackedOperandNameAndKind::unnamed(kind))
+                        })),
                 )
                 .flatten()
             }))
@@ -376,10 +369,7 @@ impl PackedOperandNameAndKind {
 
     #[inline]
     fn unpack(self) -> (usize, OperandKind) {
-        (
-            (self.0 >> 6) as usize,
-            OperandKind((self.0 & ((1 << 6) - 1)) as u8),
-        )
+        ((self.0 >> 6) as usize, OperandKind((self.0 & ((1 << 6) - 1)) as u8))
     }
 
     /// Unpack this `PackedOperandNameAndKind` into just its `OperandKind`.
@@ -418,11 +408,7 @@ pub struct BitIdx(pub u8);
 impl BitIdx {
     /// Returns `Some(BitIdx(i))` if and only if `x == (1 << i)`.
     pub fn of_single_set_bit(x: u32) -> Option<Self> {
-        if x.is_power_of_two() {
-            Some(Self(x.trailing_zeros() as u8))
-        } else {
-            None
-        }
+        if x.is_power_of_two() { Some(Self(x.trailing_zeros() as u8)) } else { None }
     }
 
     /// Returns an iterator of [`BitIdx`]s, from which `x` can be reconstructed
@@ -467,24 +453,18 @@ impl Enumerant {
     /// or that an operand's absence signals the end of operands (`Optional`),
     /// which is also the exit signal for the "rest operands" infinite iterators.
     pub fn all_params(&self) -> impl Iterator<Item = (OperandMode, OperandKind)> + '_ {
-        self.all_params_with_names()
-            .map(|(mode, name_and_kind)| (mode, name_and_kind.kind()))
+        self.all_params_with_names().map(|(mode, name_and_kind)| (mode, name_and_kind.kind()))
     }
 
     /// Like `all_params`, but providing access to the operand names as well.
     pub fn all_params_with_names(
         &self,
     ) -> impl Iterator<Item = (OperandMode, PackedOperandNameAndKind)> + '_ {
-        self.req_params
-            .iter()
-            .copied()
-            .map(|kind| (OperandMode::Required, kind))
-            .chain(self.rest_params.into_iter().flat_map(|kind| {
-                iter::repeat((
-                    OperandMode::Optional,
-                    PackedOperandNameAndKind::unnamed(kind),
-                ))
-            }))
+        self.req_params.iter().copied().map(|kind| (OperandMode::Required, kind)).chain(
+            self.rest_params.into_iter().flat_map(|kind| {
+                iter::repeat((OperandMode::Optional, PackedOperandNameAndKind::unnamed(kind)))
+            }),
+        )
     }
 }
 
@@ -548,10 +528,7 @@ impl Spec {
         // HACK(eddyb) ad-hoc interning, to reduce the cost of tracking operand names
         // down to a single extra byte per operand (see `PackedOperandNameAndKind`).
         let mut operand_names = FxIndexSet::default();
-        assert_eq!(
-            operand_names.insert_full("").0,
-            PackedOperandNameAndKind::EMPTY_NAME_IDX
-        );
+        assert_eq!(operand_names.insert_full("").0, PackedOperandNameAndKind::EMPTY_NAME_IDX);
         let mut pack_operand_name_and_kind = |name: &Option<raw::CowStr<'static>>, kind| {
             let name = name
                 .as_ref()
@@ -759,10 +736,8 @@ impl Spec {
 
         // FIXME(eddyb) automate this in `indexed::NamedIdxMap`.
         assert_eq!(operand_kind_by_name.len(), operand_kinds.len());
-        let operand_kinds = indexed::NamedIdxMap {
-            idx_by_name: operand_kind_by_name,
-            storage: operand_kinds,
-        };
+        let operand_kinds =
+            indexed::NamedIdxMap { idx_by_name: operand_kind_by_name, storage: operand_kinds };
 
         let operand_kind_pairs_by_name: FxHashMap<_, _> = raw_core_grammar
             .operand_kinds
@@ -1246,9 +1221,8 @@ pub mod indexed {
             };
             let next_block = block.map_or(0, |b| b + 1);
 
-            let seg_start = block.map_or(Some(0), |b| {
-                self.block_starts.get(b).copied().map(usize::from)
-            })?;
+            let seg_start =
+                block.map_or(Some(0), |b| self.block_starts.get(b).copied().map(usize::from))?;
             let seg_end = self
                 .block_starts
                 .get(next_block)
@@ -1340,11 +1314,7 @@ pub mod indexed {
             let (seg_range, intra_seg_idx) =
                 storage.idx_to_segmented(idx.to_usize().try_into().ok()?)?;
 
-            storage
-                .flattened
-                .get(seg_range)?
-                .get(intra_seg_idx)?
-                .as_ref()
+            storage.flattened.get(seg_range)?.get(intra_seg_idx)?.as_ref()
         }
     }
 

--- a/src/spv/write.rs
+++ b/src/spv/write.rs
@@ -100,9 +100,8 @@ impl OperandEmitter<'_> {
                 self.out.push(word);
 
                 for bit_idx in spec::BitIdx::of_all_set_bits(word) {
-                    let bit_def = bits
-                        .get(bit_idx)
-                        .ok_or(Error::UnsupportedEnumerand(kind, word))?;
+                    let bit_def =
+                        bits.get(bit_idx).ok_or(Error::UnsupportedEnumerand(kind, word))?;
                     self.enumerant_params(bit_def)?;
                 }
             }
@@ -117,8 +116,7 @@ impl OperandEmitter<'_> {
                 self.enumerant_params(variant_def)?;
             }
             spec::OperandKindDef::Id => {
-                self.out
-                    .push(self.ids.next().ok_or(Error::NotEnoughIds)?.get());
+                self.out.push(self.ids.next().ok_or(Error::NotEnoughIds)?.get());
             }
             spec::OperandKindDef::Literal { .. } => {
                 match self.imms.next().ok_or(Error::NotEnoughImms)? {
@@ -181,18 +179,13 @@ pub struct ModuleEmitter {
 
 // FIXME(eddyb) stop abusing `io::Error` for error reporting.
 fn invalid(reason: &str) -> io::Error {
-    io::Error::new(
-        io::ErrorKind::InvalidData,
-        format!("malformed SPIR-V ({reason})"),
-    )
+    io::Error::new(io::ErrorKind::InvalidData, format!("malformed SPIR-V ({reason})"))
 }
 
 impl ModuleEmitter {
     pub fn with_header(header: [u32; spec::HEADER_LEN]) -> Self {
         // FIXME(eddyb) sanity-check the provided header words.
-        Self {
-            words: header.into(),
-        }
+        Self { words: header.into() }
     }
 
     // FIXME(eddyb) sanity-check the operands against the definition of `inst.opcode`.


### PR DESCRIPTION
This removes just over 1000 lines that only existed because `rustfmt`'s default decided to use multiple lines for e.g. method call chains that could just as well fit on one line.

Will require some gymnastics to handle rebasing on top but this feels big enough that I'm pushing it through.