### PR TITLE
Pretty-print `OpExtInst` using official `extinst.*.grammar.json` and/or custom `Context`-registered ones.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased] - ReleaseDate
 
+### Added ⭐
+- [PR#45](https://github.com/EmbarkStudios/spirt/pull/45) added the abilit to
+  pretty-print `OpExtInst`s (SPIR-V "extended instructions") using official
+  `extinst.*.grammar.json` descriptions and/or custom ones (registered via `Context`)
+
 ### Changed 🛠
 - [PR#43](https://github.com/EmbarkStudios/spirt/pull/43) tweaked several pretty-printing
   details to improve visual cohesion ("named arguments" in `module.{dialect,debuginfo}`)

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,52 @@
+fn main() {
+    // HACK(eddyb) disable the default of re-running the build script on *any*
+    // change to *the entire source tree* (i.e. the default is roughly `./`).
+    println!("cargo:rerun-if-changed=build.rs");
+
+    let khr_spv_include_dir =
+        std::env::current_dir().unwrap().join("khronos-spec/SPIRV-Headers/include/spirv/unified1");
+    println!("cargo:rerun-if-changed={}", khr_spv_include_dir.display());
+
+    if !std::fs::metadata(&khr_spv_include_dir).map_or(false, |m| m.is_dir()) {
+        eprintln!(" error: {} is not a directory", khr_spv_include_dir.display());
+        eprintln!("  help: git submodules are required to build from a git checkout");
+        eprintln!("  help: run `git submodule update --init`");
+        eprintln!("  note: if the error persists, please open an issue");
+        std::process::exit(1);
+    }
+
+    let core_grammar = "spirv.core.grammar.json";
+    let mut extinsts_names_and_grammars: Vec<_> = std::fs::read_dir(&khr_spv_include_dir)
+        .unwrap()
+        .filter_map(|e| {
+            let file_name = e.unwrap().file_name();
+            Some((
+                file_name
+                    .to_str()?
+                    .strip_prefix("extinst.")?
+                    .strip_suffix(".grammar.json")?
+                    .to_string(),
+                file_name,
+            ))
+        })
+        .collect();
+    extinsts_names_and_grammars.sort();
+
+    let all_jsons = format!(
+        "pub(super) const SPIRV_CORE_GRAMMAR: &str = include_str!({:?});\n\
+         pub(super) const EXTINST_NAMES_AND_GRAMMARS: &[(&str, &str)] = &[\n{}];",
+        khr_spv_include_dir.join(core_grammar),
+        extinsts_names_and_grammars
+            .into_iter()
+            .map(|(name, grammar)| {
+                format!("({:?}, include_str!({:?})),\n", name, khr_spv_include_dir.join(grammar),)
+            })
+            .collect::<String>()
+    );
+    std::fs::write(
+        std::path::PathBuf::from(std::env::var_os("OUT_DIR").unwrap())
+            .join("khr_spv_grammar_jsons.rs"),
+        all_jsons,
+    )
+    .unwrap();
+}

--- a/src/print/mod.rs
+++ b/src/print/mod.rs
@@ -3249,6 +3249,9 @@ impl Print for FuncAt<'_, DataInst> {
                 let lowercase_ext_set_name = ext_set_name.to_ascii_lowercase();
                 let (ext_set_alias, known_inst_desc) = (spv_spec
                     .get_ext_inst_set_by_lowercase_name(&lowercase_ext_set_name))
+                .or_else(|| {
+                    printer.cx.get_custom_ext_inst_set_by_lowercase_name(&lowercase_ext_set_name)
+                })
                 .map_or((&None, None), |ext_inst_set| {
                     // FIXME(eddyb) check that these aliases are unique
                     // across the entire output before using them!


### PR DESCRIPTION
Rust-GPU benefits the most from this, with its new custom `OpExtInst`s for debuginfo:
|Before|After|
|-|-|
|<img src="https://github.com/EmbarkStudios/spirt/assets/77424/83a8c9cf-6c31-4b92-a0fe-e668a8a21d0b" height="500">|![image](https://github.com/EmbarkStudios/spirt/assets/77424/b8dec870-3e5d-4936-bdbc-b932a656d2fe)|

It also works great for seeing how Rust-GPU's new custom `Abort` converts to a `debugPrintf`:
|Before|![image](https://github.com/EmbarkStudios/spirt/assets/77424/a829b4a1-32cc-413f-90fd-aebf8148ece0)|
|-|-|
|**After**|![image](https://github.com/EmbarkStudios/spirt/assets/77424/ace358bd-e244-4229-8929-579e040f7c75)|
