### PR TITLE
module-merge pass

### DIFF
--- a/examples/spv-lower-merge-link-lift.rs
+++ b/examples/spv-lower-merge-link-lift.rs
@@ -72,10 +72,12 @@ fn main() -> std::io::Result<()> {
             after_pass("merge file", &merged)?;
 
             eprint_duration(|| spirt::passes::merge::merge(&mut module, merged)).unwrap();
-
+            eprintln!("merge");
             after_pass("merged", &module)?;
 
-            /*
+            /* NOTE: If you add that, it'll probably delete the just merged exports
+             * to prevent that, use an module that declares an `import` for one of the merged
+             * `export`s.
             let original_export_count = module.exports.len();
             eprint_duration(|| {
                 spirt::passes::link::minimize_exports(&mut module, |export_key| {
@@ -91,8 +93,6 @@ fn main() -> std::io::Result<()> {
 
             after_pass("minimize_exports", &module)?;
             */
-            // HACK(eddyb) do this late enough to avoid spending time on unused
-            // functions, which `link::minimize_exports` makes unreachable.
             eprint_duration(|| spirt::passes::legalize::structurize_func_cfgs(&mut module));
             eprintln!("legalize::structurize_func_cfgs");
             after_pass("structurize_func_cfgs", &module)?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -165,6 +165,7 @@ pub mod passes {
 
     pub mod legalize;
     pub mod link;
+    pub mod merge;
     pub mod qptr;
 }
 pub mod qptr;

--- a/src/print/mod.rs
+++ b/src/print/mod.rs
@@ -1034,7 +1034,9 @@ impl<'a> Printer<'a> {
                     _ => unreachable!(),
                 };
                 if let Some(use_style) = use_style_slot {
-                    assert!(matches!(use_style, UseStyle::Inline));
+                    //NOTE(siebencorgie) Assert breaks if we leave a _dangling_ export function
+                    // that is no entrypoint.
+                    //assert!(matches!(use_style, UseStyle::Inline));
 
                     let parent_func = Some(func);
                     let named_style = try_claim_name_from_attrs_across_versions(


### PR DESCRIPTION
Small pass that allows merging all exports of one module into another module.

The whole pass is basically a slightly changed version of the Linker pass + the dialect check. 

One thing I'm not completely sure about is [this](https://github.com/EmbarkStudios/spirt/compare/main...SiebenCorgie:spirt:merge-pass?expand=1#diff-7dc3feaa3deb4fbe4caf034e57de74ba163af09f6d44fcad5a42a6b30e0e159dR1039) assert. It fails if you introduce a _dangling_ export that is not resolved before printing. Until now all non `EntryPoint` exports are resolved, which is why this works. 