### PR TITLE
[WIP] spirti: SPIR-T interpreter (on the CPU, optionally via rayon).

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,3 +1,6 @@
+[workspace]
+members = ["spirti"]
+
 [package]
 name = "spirt"
 description = "Shader-focused IR to target, transform and translate from."

--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ func F0() -> spv.OpTypeVoid {
       v6 = spv.OpIAdd(v1, 1s32): s32
       (v5, v6)
     } else {
-      (spv.OpUndef: s32, spv.OpUndef: s32)
+      (undef: s32, undef: s32)
     }
     (v3, v4) -> (v0, v1)
   } while v2

--- a/README.md
+++ b/README.md
@@ -139,10 +139,10 @@ global_var GV0 in spv.StorageClass.Output: s32
 
 func F0() -> spv.OpTypeVoid {
   loop(v0: s32 <- 1s32, v1: s32 <- 1s32) {
-    v2 = spv.OpSLessThan(v1, 10s32): bool
+    v2 = s.lt(v1, 10s32): bool
     (v3: s32, v4: s32) = if v2 {
-      v5 = spv.OpIMul(v0, v1): s32
-      v6 = spv.OpIAdd(v1, 1s32): s32
+      v5 = i.mul(v0, v1): s32
+      v6 = i.add(v1, 1s32): s32
       (v5, v6)
     } else {
       (undef: s32, undef: s32)

--- a/spirti/Cargo.toml
+++ b/spirti/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "spirti"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+spirt = { path = ".." }
+
+# FIXME(eddyb) deduplicate these by the workspace inheritance feature.
+arrayvec = "0.7.1"
+derive_more = "0.99.17"
+itertools = "0.10.3"
+lazy_static = "1.4.0"
+rustc-hash = "1.1.0"
+smallvec = { version = "1.7.0", features = ["serde", "union"] }
+
+image = "0.24.6"
+rayon = { version = "1.7.0", optional = true }
+
+[features]
+default = ["rayon"]

--- a/spirti/src/main.rs
+++ b/spirti/src/main.rs
@@ -1,0 +1,1423 @@
+use arrayvec::ArrayVec;
+use itertools::Itertools;
+use lazy_static::lazy_static;
+#[cfg(feature = "rayon")]
+use rayon::prelude::*;
+use rustc_hash::FxHashMap;
+use smallvec::SmallVec;
+use spirt::func_at::FuncAt;
+use spirt::{
+    scalar, spv, vector, AddrSpace, Attr, Const, ConstKind, Context, ControlNode, ControlNodeDef,
+    ControlNodeKind, ControlRegion, ControlRegionDef, DataInst, DataInstDef, DataInstFormDef,
+    DataInstKind, DeclDef, EntityOrientedDenseMap, ExportKey, Exportee, Func, GlobalVar,
+    InternedStr, Module, SelectionKind, Type, TypeKind, Value,
+};
+use std::ops::Range;
+use std::path::Path;
+use std::rc::Rc;
+
+// HACK(eddyb) `spv::spec::Spec` with extra `WellKnown`s.
+macro_rules! def_spv_spec_with_extra_well_known {
+    ($($group:ident: $ty:ty = [$($entry:ident),+ $(,)?]),+ $(,)?) => {
+        struct SpvSpecWithExtras {
+            __base_spec: &'static spv::spec::Spec,
+
+            well_known: SpvWellKnownWithExtras,
+        }
+
+        #[allow(non_snake_case)]
+        pub struct SpvWellKnownWithExtras {
+            __base_well_known: &'static spv::spec::WellKnown,
+
+            $($(pub $entry: $ty,)+)+
+        }
+
+        impl std::ops::Deref for SpvSpecWithExtras {
+            type Target = spv::spec::Spec;
+            fn deref(&self) -> &Self::Target {
+                self.__base_spec
+            }
+        }
+
+        impl std::ops::Deref for SpvWellKnownWithExtras {
+            type Target = spv::spec::WellKnown;
+            fn deref(&self) -> &Self::Target {
+                self.__base_well_known
+            }
+        }
+
+        impl SpvSpecWithExtras {
+            #[inline(always)]
+            #[must_use]
+            pub fn get() -> &'static SpvSpecWithExtras {
+                lazy_static! {
+                    static ref SPEC: SpvSpecWithExtras = {
+                        #[allow(non_camel_case_types)]
+                        struct PerWellKnownGroup<$($group),+> {
+                            $($group: $group),+
+                        }
+
+                        let spv_spec = spv::spec::Spec::get();
+                        let wk = &spv_spec.well_known;
+
+                        let storage_classes = match &spv_spec.operand_kinds[wk.StorageClass] {
+                            spv::spec::OperandKindDef::ValueEnum { variants } => variants,
+                            _ => unreachable!(),
+                        };
+                        let decorations = match &spv_spec.operand_kinds[wk.Decoration] {
+                            spv::spec::OperandKindDef::ValueEnum { variants } => variants,
+                            _ => unreachable!(),
+                        };
+
+                        let execution_models = match &spv_spec.operand_kinds[spv_spec.operand_kinds.lookup("ExecutionModel").unwrap()] {
+                            spv::spec::OperandKindDef::ValueEnum { variants } => variants,
+                            _ => unreachable!(),
+                        };
+                        let builtins = match &spv_spec.operand_kinds[spv_spec.operand_kinds.lookup("BuiltIn").unwrap()] {
+                            spv::spec::OperandKindDef::ValueEnum { variants } => variants,
+                            _ => unreachable!(),
+                        };
+
+                        let glsl_std_450_ops = spv_spec
+                            .get_ext_inst_set_by_lowercase_name("glsl.std.450")
+                            .unwrap()
+                            .instructions
+                            .iter()
+                            .map(|(&op, inst_desc)| (&inst_desc.name[..], op))
+                            .collect::<FxHashMap<_, _>>();
+
+                        let lookup_fns = PerWellKnownGroup {
+                            opcode: |name| spv_spec.instructions.lookup(name).unwrap(),
+                            operand_kind: |name| spv_spec.operand_kinds.lookup(name).unwrap(),
+                            storage_class: |name| storage_classes.lookup(name).unwrap().into(),
+                            decoration: |name| decorations.lookup(name).unwrap().into(),
+                            execution_model: |name| execution_models.lookup(name).unwrap().into(),
+                            builtin: |name| builtins.lookup(name).unwrap().into(),
+                            glsl_std_450_op: |name| glsl_std_450_ops.get(name).copied().unwrap(),
+                        };
+
+                        SpvSpecWithExtras {
+                            __base_spec: spv_spec,
+
+                            well_known: SpvWellKnownWithExtras {
+                                __base_well_known: &spv_spec.well_known,
+
+                                $($($entry: (lookup_fns.$group)(stringify!($entry)),)+)+
+                            },
+                        }
+                    };
+                }
+                &SPEC
+            }
+        }
+    };
+}
+def_spv_spec_with_extra_well_known! {
+    opcode: spv::spec::Opcode = [
+        OpConstantComposite,
+
+        // FIXME(eddyb) maybe make a macro for most of these to be mentioned
+        // only once, at their use site in `eval_data_inst`.
+        OpSelect,
+        OpCompositeConstruct,
+        OpCompositeExtract,
+        OpCompositeInsert,
+    ],
+    operand_kind: spv::spec::OperandKind = [
+        ExecutionModel,
+    ],
+    storage_class: u32 = [
+        PushConstant,
+    ],
+    decoration: u32 = [
+        BuiltIn,
+    ],
+    execution_model: u32 = [
+        Vertex,
+        Fragment,
+    ],
+    builtin: u32 = [
+        FragCoord
+    ],
+    glsl_std_450_op: u32 = [
+        FAbs,
+        Exp,
+        Sqrt,
+        Sin,
+        Cos,
+
+        FMin,
+        FMax,
+        Pow,
+
+        Fma,
+    ],
+}
+
+fn main() {
+    let (in_file_path, out_file_path) = match &std::env::args().collect::<Vec<_>>()[..] {
+        [_, in_file, out_file] => {
+            (Path::new(in_file).to_path_buf(), Path::new(out_file).to_path_buf())
+        }
+        args => {
+            eprintln!("Usage: {} IN_FILE OUT_FILE", args[0]);
+            std::process::exit(1);
+        }
+    };
+
+    let wk = &SpvSpecWithExtras::get().well_known;
+
+    let mut module = Module::lower_from_spv_file(Rc::new(Context::new()), in_file_path).unwrap();
+    spirt::passes::legalize::structurize_func_cfgs(&mut module);
+
+    let h = 1080;
+    let w = h * 16 / 9;
+
+    // FIXME(eddyb) allow customizing this in-depth (via CLI).
+    // FIXME(eddyb) some kind of interpolation could allow generating an animation,
+    // by feeding time & mouse coords etc. for e.g. the mouse shader example.
+    let push_constants = &{
+        let u = |x| DynScalar::U32(DynLeaf::Uniform(x));
+        let f = |x| DynScalar::F32(DynLeaf::Uniform(x));
+        [
+            u(w).into(),
+            u(h).into(),
+            f(0.0).into(),
+            f(0.0).into(),
+            f(0.0).into(),
+            f(0.0).into(),
+            f(0.0).into(),
+            f(0.0).into(),
+            f(0.0).into(),
+            u(0).into(),
+            DynVal::Vector([f(0.0), f(0.0), f(0.0)].into_iter().collect()),
+        ]
+    };
+
+    let cx = module.cx();
+    let mut interpreter = Interpreter {
+        wk,
+        glsl_std_450: cx.intern("GLSL.std.450"),
+        ty_u32: cx.intern(scalar::Type::U32),
+        ty_s32: cx.intern(scalar::Type::S32),
+
+        module: &module,
+        push_constants,
+        launch: Launch::FragRect { width: w.try_into().unwrap(), height: h.try_into().unwrap() },
+        invocations: u32::checked_mul(w, h).unwrap().try_into().unwrap(),
+
+        inst_counter: 0,
+
+        global_vars: Default::default(),
+        call_stack: Default::default(),
+    };
+    let (fragment_entry, fragment_interface_global_vars) = module
+        .exports
+        .iter()
+        .find_map(|(export_key, exportee)| match (export_key, exportee) {
+            (ExportKey::SpvEntryPoint { imms, interface_global_vars }, &Exportee::Func(func))
+                if imms.starts_with(&[spv::Imm::Short(wk.ExecutionModel, wk.Fragment)]) =>
+            {
+                Some((func, interface_global_vars))
+            }
+            _ => None,
+        })
+        .expect("no fragment entry-point");
+
+    let start = std::time::Instant::now();
+    interpreter.eval_call(fragment_entry, SmallVec::new());
+    let elapsed = start.elapsed();
+    eprintln!(
+        "{:8.3}ms for {} instructions ({w}px × {h}px = {} invocations each)",
+        elapsed.as_secs_f64() * 1e3,
+        interpreter.inst_counter,
+        interpreter.invocations,
+    );
+    eprintln!(
+        "={:7.3}ms per instruction",
+        elapsed.as_secs_f64() * 1e3 / (interpreter.inst_counter as f64),
+    );
+    eprintln!(
+        "={:7.1}ns per invocation",
+        elapsed.as_secs_f64() * 1e9 / (interpreter.invocations as f64),
+    );
+    eprintln!(
+        "={:7.1}ns per instruction per invocation",
+        elapsed.as_secs_f64() * 1e9
+            / (interpreter.inst_counter as f64)
+            / (interpreter.invocations as f64),
+    );
+
+    for &gv in fragment_interface_global_vars {
+        let gv_decl = &module.global_vars[gv];
+        if gv_decl.addr_space == AddrSpace::SpvStorageClass(wk.Output) {
+            if let Some(DynVal::Vector(elems)) = interpreter.global_vars.get(gv) {
+                if let [
+                    DynScalar::F32(r),
+                    DynScalar::F32(g),
+                    DynScalar::F32(b),
+                    DynScalar::F32(a),
+                ] = &elems[..]
+                {
+                    // FIXME(eddyb) use `rayon` to build a `Vec<u8>` here.
+                    image::RgbaImage::from_fn(w, h, |x, y| {
+                        let i = usize::try_from(y.checked_mul(w).unwrap().checked_add(x).unwrap())
+                            .unwrap();
+                        let get = |x: &DynLeaf<f32>| {
+                            let x = match x {
+                                &DynLeaf::Uniform(x) => x,
+                                DynLeaf::PerInvocation(xs) => xs[i],
+                            }
+                            .clamp(0.0, 1.0);
+
+                            // apply the srgb OETF (i.e. do "linear to sRGB")
+                            fn srgb_oetf(x: f32) -> f32 {
+                                if x <= 0.0031308 {
+                                    x * 12.92
+                                } else {
+                                    1.055 * x.powf(1.0 / 2.4) - 0.055
+                                }
+                            }
+
+                            // FIXME(eddyb) do not convert alpha.
+                            (srgb_oetf(x).clamp(0.0, 1.0) * 255.0) as u8
+                        };
+                        image::Rgba([get(r), get(g), get(b), get(a)])
+                    })
+                    .save(out_file_path)
+                    .unwrap();
+                    return;
+                }
+            }
+        }
+    }
+    unreachable!("`f32x4` output global var not found");
+}
+
+#[derive(Clone)]
+enum DynLeaf<T> {
+    Uniform(T),
+    // FIXME(eddyb) make this hierarchical to allow "subgroup-uniform" etc.
+    PerInvocation(Rc<Vec<T>>),
+    // HACK(eddyb) consider some "linear interpolation" for that doesn't store
+    // the values, or some "min"/"max" tracking, to potentially uniformize conditions.
+}
+
+// FIXME(eddyb) test perf vs rayon (also, consider batching that LLVM may vectorize).
+impl<T: Copy + Send + Sync> DynLeaf<T> {
+    fn map<U: Send>(self, f: impl Fn(T) -> U + Send + Sync) -> DynLeaf<U> {
+        match self {
+            DynLeaf::Uniform(x) => DynLeaf::Uniform(f(x)),
+            // FIXME(eddyb) also consider making uniform if all the results are
+            // all equal, but that may be too expensive to check? (maybe it'd
+            // make more sense if it were hierarchical, since it would already
+            // be trying to group invocations, and have more impact on average)
+            //
+            // FIXME(eddyb) take advantage of by-value `self` to re-use the `Rc`
+            // allocation in-place, whenever possible (would require knowing that
+            // `T == U`, or some kind of "scalars all made of `u32` chunks" repr).
+            #[cfg(feature = "rayon")]
+            DynLeaf::PerInvocation(xs) => {
+                DynLeaf::PerInvocation(Rc::new(xs.par_iter().copied().map(f).collect()))
+            }
+            #[cfg(not(feature = "rayon"))]
+            DynLeaf::PerInvocation(xs) => {
+                DynLeaf::PerInvocation(Rc::new(xs.iter().copied().map(f).collect()))
+            }
+        }
+    }
+    fn map2<U: Copy + Send + Sync, V: Send>(
+        self,
+        other: DynLeaf<U>,
+        f: impl Fn(T, U) -> V + Send + Sync,
+    ) -> DynLeaf<V> {
+        match (self, other) {
+            (x, DynLeaf::Uniform(y)) => x.map(move |x| f(x, y)),
+            (DynLeaf::Uniform(x), y) => y.map(move |y| f(x, y)),
+            (DynLeaf::PerInvocation(xs), DynLeaf::PerInvocation(ys)) => {
+                DynLeaf::PerInvocation(Rc::new(
+                    {
+                        #[cfg(feature = "rayon")]
+                        {
+                            xs.par_iter().zip_eq(&ys[..])
+                        }
+                        #[cfg(not(feature = "rayon"))]
+                        {
+                            xs.iter().zip_eq(&ys[..])
+                        }
+                    }
+                    .map(|(&x, &y)| f(x, y))
+                    .collect(),
+                ))
+            }
+        }
+    }
+    fn map3<U: Copy + Send + Sync, V: Copy + Send + Sync, W: Send>(
+        self,
+        other: DynLeaf<U>,
+        other2: DynLeaf<V>,
+        f: impl Fn(T, U, V) -> W + Send + Sync,
+    ) -> DynLeaf<W> {
+        match (self, other, other2) {
+            (x, y, DynLeaf::Uniform(z)) => x.map2(y, move |x, y| f(x, y, z)),
+            (x, DynLeaf::Uniform(y), z) => x.map2(z, move |x, z| f(x, y, z)),
+            (DynLeaf::Uniform(x), y, z) => y.map2(z, move |y, z| f(x, y, z)),
+            (
+                DynLeaf::PerInvocation(xs),
+                DynLeaf::PerInvocation(ys),
+                DynLeaf::PerInvocation(zs),
+            ) => DynLeaf::PerInvocation(Rc::new(
+                {
+                    #[cfg(feature = "rayon")]
+                    {
+                        xs.par_iter().zip_eq(&ys[..]).zip_eq(&zs[..])
+                    }
+                    #[cfg(not(feature = "rayon"))]
+                    {
+                        xs.iter().zip_eq(&ys[..]).zip_eq(&zs[..])
+                    }
+                }
+                .map(|((&x, &y), &z)| f(x, y, z))
+                .collect(),
+            )),
+        }
+    }
+}
+
+// HACK(eddyb) traits to call the `map2`/`map3` methods, but as `map`, on tuples.
+trait LeafMap2<A: Copy + Send + Sync, B: Copy + Send + Sync> {
+    fn map<R: Send>(self, f: impl Fn(A, B) -> R + Send + Sync) -> DynLeaf<R>;
+}
+trait LeafMap3<A: Copy + Send + Sync, B: Copy + Send + Sync, C: Copy + Send + Sync> {
+    fn map<R: Send>(self, f: impl Fn(A, B, C) -> R + Send + Sync) -> DynLeaf<R>;
+}
+
+impl<A: Copy + Send + Sync, B: Copy + Send + Sync> LeafMap2<A, B> for (DynLeaf<A>, DynLeaf<B>) {
+    fn map<R: Send>(self, f: impl Fn(A, B) -> R + Send + Sync) -> DynLeaf<R> {
+        let (xs, ys) = self;
+        xs.map2(ys, f)
+    }
+}
+impl<A: Copy + Send + Sync, B: Copy + Send + Sync, C: Copy + Send + Sync> LeafMap3<A, B, C>
+    for (DynLeaf<A>, DynLeaf<B>, DynLeaf<C>)
+{
+    fn map<R: Send>(self, f: impl Fn(A, B, C) -> R + Send + Sync) -> DynLeaf<R> {
+        let (xs, ys, zs) = self;
+        xs.map3(ys, zs, f)
+    }
+}
+
+#[derive(Clone, derive_more::From, derive_more::TryInto)]
+enum DynScalar {
+    Undef,
+
+    // FIXME(eddyb) this should really use a bitset!
+    #[from]
+    #[try_into]
+    Bool(DynLeaf<bool>),
+
+    // FIXME(eddyb) have a single repr that does whole `u32` chunks?
+    #[from]
+    #[try_into]
+    U32(DynLeaf<u32>),
+    #[from]
+    #[try_into]
+    S32(DynLeaf<i32>),
+    #[from]
+    #[try_into]
+    F32(DynLeaf<f32>),
+}
+
+macro_rules! op_closure {
+    // HACK(eddyb) notation shorthand, allowing e.g. `(+)` instead of `|x, y| x + y`.
+    (! $op:tt) => { |x, y| !(x $op y) };
+    ($op:tt) => { |x, y| x $op y };
+
+    // HACK(eddyb) adapter shorthand (used with specialized `U`/`S` for integers).
+    ($ctor:ident($($closure:tt)+)) => { $ctor(op_closure!($($closure)+)) };
+
+    ($closure:expr) => { $closure };
+}
+
+// FIXME(eddyb) come up with a better syntax, and ideally unify the cases.
+macro_rules! dispatch_scalar {
+    ($inputs:ident.match $op:ident => ($T:ty) -> _: $($pat:pat => ($($closure:tt)+)),+ $(,)?) => {{
+        let (x,) = $inputs.into_iter().collect_tuple().unwrap();
+        match $op {
+            $($pat => {
+                // HACK(eddyb) closure somewhat used as `try` block.
+                None.or_else(|| {
+                    let x: DynLeaf<$T> = x.try_into().ok()?;
+                    Some(DynScalar::from(x.map(op_closure!($($closure)+))))
+                }).unwrap()
+            })+
+        }
+    }};
+    // FIXME(eddyb) use for int binops too.
+    ($inputs:ident.match $op:ident => ($T:ty, $U:ty) -> _: $($pat:pat => ($($closure:tt)+)),+ $(,)?) => {{
+        let (x, y) = $inputs.into_iter().collect_tuple().unwrap();
+        match $op {
+            $($pat => {
+                // HACK(eddyb) closure somewhat used as `try` block.
+                None.or_else(|| {
+                    let x: DynLeaf<$T> = x.try_into().ok()?;
+                    let y: DynLeaf<$U> = y.try_into().ok()?;
+                    Some(DynScalar::from((x, y).map(op_closure!($($closure)+))))
+                }).unwrap()
+            }),+
+        }
+    }};
+    ($inputs:ident.match $op:ident => ($T:ty, $U:ty, $V:ty) -> _: $($pat:pat => ($($closure:tt)+)),+ $(,)?) => {{
+        let (x, y, z) = $inputs.into_iter().collect_tuple().unwrap();
+        match $op {
+            $($pat => {
+                // HACK(eddyb) closure somewhat used as `try` block.
+                None.or_else(|| {
+                    let x: DynLeaf<$T> = x.try_into().ok()?;
+                    let y: DynLeaf<$U> = y.try_into().ok()?;
+                    let z: DynLeaf<$U> = z.try_into().ok()?;
+                    Some(DynScalar::from((x, y, z).map(op_closure!($($closure)+))))
+                }).unwrap()
+            }),+
+        }
+    }};
+}
+
+#[derive(Clone)]
+enum DynPtrBase {
+    GlobalVar(GlobalVar),
+}
+
+#[derive(Clone, derive_more::From, derive_more::TryInto)]
+enum DynVal {
+    #[from]
+    #[try_into]
+    Scalar(DynScalar),
+
+    Vector(ArrayVec<DynScalar, 4>),
+
+    // FIXME(eddyb) make this cheap by disaggregation.
+    Ptr {
+        base: DynPtrBase,
+        access_chain: SmallVec<[u32; 4]>,
+    },
+
+    LazyUninitAggregate,
+    Aggregate(Rc<[DynVal]>),
+
+    SpvStringLiteralForExtInst(InternedStr),
+}
+
+// FIXME(eddyb) this is all over the place, reorganize!
+fn vec_distribute<VDS: FromIterator<DynScalar>, VDV: IntoIterator<Item = DynVal>>(
+    per_elem: impl Fn(VDS) -> DynScalar,
+) -> impl Fn(VDV) -> DynVal {
+    move |inputs| {
+        let mut inputs: SmallVec<[_; 4]> = inputs
+            .into_iter()
+            .map(|v| match v {
+                DynVal::Vector(xs) => xs.into_iter(),
+                _ => unreachable!(),
+            })
+            .collect();
+        let elem_count = inputs[0].len();
+        inputs.iter().for_each(|xs| assert_eq!(xs.len(), elem_count));
+
+        DynVal::Vector(
+            (0..elem_count)
+                .map(|_| per_elem(inputs.iter_mut().map(|xs| xs.next().unwrap()).collect()))
+                .collect(),
+        )
+    }
+}
+fn scalar_or_vec_distribute<VDS: FromIterator<DynScalar>, VDV: IntoIterator<Item = DynVal>>(
+    per_scalar: impl Fn(VDS) -> DynScalar,
+) -> impl Fn(VDV) -> DynVal {
+    move |inputs| {
+        let mut inputs = inputs.into_iter().peekable();
+        match inputs.peek().unwrap() {
+            DynVal::Scalar(_) => {
+                DynVal::Scalar(per_scalar(inputs.map(|x| x.try_into().unwrap()).collect()))
+            }
+            DynVal::Vector(_) => vec_distribute(&per_scalar)(inputs),
+            _ => unreachable!(),
+        }
+    }
+}
+
+struct Interpreter<'a> {
+    wk: &'static SpvWellKnownWithExtras,
+    // FIXME(eddyb) group this into something like an `interned` field.
+    glsl_std_450: InternedStr,
+    ty_u32: Type,
+    ty_s32: Type,
+
+    module: &'a Module,
+    // FIXME(eddyb) this feels weird here now that it's not `[u32]` anymore.
+    push_constants: &'a [DynVal],
+    launch: Launch,
+    // FIXME(eddyb) compute this from `launch` more automatedly.
+    // FIXME(eddyb) use this.
+    #[allow(dead_code)]
+    invocations: usize,
+
+    inst_counter: usize,
+
+    global_vars: EntityOrientedDenseMap<GlobalVar, DynVal>,
+    call_stack: Vec<CallFrame>,
+}
+
+enum Launch {
+    // FIXME(eddyb) use this.
+    #[allow(dead_code)]
+    VertIndices(Range<u32>),
+    FragRect {
+        width: u16,
+        height: u16,
+    },
+}
+
+#[derive(Default)]
+struct CallFrame {
+    region_inputs: EntityOrientedDenseMap<ControlRegion, SmallVec<[DynVal; 4]>>,
+    control_node_outputs: EntityOrientedDenseMap<ControlNode, SmallVec<[DynVal; 4]>>,
+    data_inst_outputs: EntityOrientedDenseMap<DataInst, DynVal>,
+}
+
+impl<'a> Interpreter<'a> {
+    fn cx(&self) -> &'a Context {
+        self.module.cx_ref()
+    }
+    fn eval_call(&mut self, f: Func, args: SmallVec<[DynVal; 4]>) -> SmallVec<[DynVal; 4]> {
+        let func_def_body = match &self.module.funcs[f].def {
+            DeclDef::Imported(import) => unreachable!(
+                "calling import {:?}",
+                match import {
+                    &spirt::Import::LinkName(name) => &self.cx()[name],
+                }
+            ),
+            DeclDef::Present(def) => def,
+        };
+
+        self.call_stack.push(CallFrame::default());
+        let ret_vals = self.eval_region(func_def_body.at_body(), args);
+        self.call_stack.pop().unwrap();
+        ret_vals
+    }
+    fn eval_region(
+        &mut self,
+        func_at_region: FuncAt<ControlRegion>,
+        input_vals: SmallVec<[DynVal; 4]>,
+    ) -> SmallVec<[DynVal; 4]> {
+        let ControlRegionDef { inputs, children: _, outputs } = func_at_region.def();
+
+        assert_eq!(input_vals.len(), inputs.len());
+        if !input_vals.is_empty() {
+            self.call_stack
+                .last_mut()
+                .unwrap()
+                .region_inputs
+                .insert(func_at_region.position, input_vals);
+        }
+
+        for func_at_node in func_at_region.at_children() {
+            self.eval_control_node(func_at_node);
+        }
+
+        outputs.iter().map(|&v| self.eval_value(v)).collect()
+    }
+    fn eval_control_node(&mut self, func_at_control_node: FuncAt<ControlNode>) {
+        let ControlNodeDef { kind, outputs } = func_at_control_node.def();
+        match kind {
+            &ControlNodeKind::Block { insts } => {
+                assert_eq!(outputs.len(), 0);
+                for func_at_inst in func_at_control_node.at(insts) {
+                    self.eval_data_inst(func_at_inst);
+                }
+            }
+            ControlNodeKind::Select { kind, scrutinee, cases } => match kind {
+                SelectionKind::BoolCond => {
+                    self.inst_counter += 1;
+
+                    let cond = match self.eval_value(*scrutinee) {
+                        DynVal::Scalar(DynScalar::Bool(cond)) => cond,
+                        _ => unreachable!(),
+                    };
+
+                    // HACK(eddyb) try really hard to avoid per-invocation decisions.
+                    let cond = match cond {
+                        DynLeaf::Uniform(cond) => cond,
+                        DynLeaf::PerInvocation(conds)
+                            if {
+                                let first = conds[0];
+                                #[cfg(feature = "rayon")]
+                                {
+                                    conds[1..].par_iter().all(|&c| c == first)
+                                }
+                                #[cfg(not(feature = "rayon"))]
+                                {
+                                    conds[1..].iter().all(|&c| c == first)
+                                }
+                            } =>
+                        {
+                            conds[0]
+                        }
+                        DynLeaf::PerInvocation(_) => todo!("per-invocation `if`-`else` decision"),
+                    };
+                    let case = cases[if cond { 0 } else { 1 }];
+
+                    let output_vals =
+                        self.eval_region(func_at_control_node.at(case), SmallVec::new());
+
+                    assert_eq!(output_vals.len(), outputs.len());
+                    if !output_vals.is_empty() {
+                        self.call_stack
+                            .last_mut()
+                            .unwrap()
+                            .control_node_outputs
+                            .insert(func_at_control_node.position, output_vals);
+                    }
+                }
+                SelectionKind::Switch { .. } => todo!(),
+            },
+            ControlNodeKind::Loop { initial_inputs, body, repeat_condition } => {
+                let mut loop_state = initial_inputs.iter().map(|&v| self.eval_value(v)).collect();
+
+                loop {
+                    loop_state = self.eval_region(func_at_control_node.at(*body), loop_state);
+
+                    self.inst_counter += 1;
+
+                    let rep_cond = match self.eval_value(*repeat_condition) {
+                        DynVal::Scalar(DynScalar::Bool(cond)) => cond,
+                        _ => unreachable!(),
+                    };
+
+                    // HACK(eddyb) try really hard to avoid per-invocation decisions.
+                    let rep_cond = match rep_cond {
+                        DynLeaf::Uniform(cond) => cond,
+                        DynLeaf::PerInvocation(conds)
+                            if {
+                                let first = conds[0];
+                                #[cfg(feature = "rayon")]
+                                {
+                                    conds[1..].par_iter().all(|&c| c == first)
+                                }
+                                #[cfg(not(feature = "rayon"))]
+                                {
+                                    conds[1..].iter().all(|&c| c == first)
+                                }
+                            } =>
+                        {
+                            conds[0]
+                        }
+                        DynLeaf::PerInvocation(_) => todo!("per-invocation `loop` repeat decision"),
+                    };
+                    if !rep_cond {
+                        break;
+                    }
+                }
+            }
+        }
+    }
+    fn eval_data_inst(&mut self, func_at_inst: FuncAt<DataInst>) {
+        self.inst_counter += 1;
+
+        let start = std::time::Instant::now();
+
+        let DataInstDef { attrs: _, form, inputs } = func_at_inst.def();
+        let DataInstFormDef { kind, output_type } = &self.cx()[*form];
+
+        let inputs: SmallVec<[_; 4]> = inputs.iter().map(|&v| self.eval_value(v)).collect();
+
+        macro_rules! float_unop {
+            ($($f:tt)+) => {
+                scalar_or_vec_distribute(|inputs: ArrayVec<_, 1>| {
+                    let op = ();
+                    dispatch_scalar! { inputs.match op => (f32) -> _:
+                        () => ($($f)+)
+                    }
+                })(inputs)
+            };
+        }
+        macro_rules! float_binop {
+            ($($f:tt)+) => {
+                scalar_or_vec_distribute(|inputs: ArrayVec<_, 2>| {
+                    let op = ();
+                    dispatch_scalar! { inputs.match op => (f32, f32) -> _:
+                        () => ($($f)+)
+                    }
+                })(inputs)
+            };
+        }
+        // FIXME(eddyb) this is a silly name, find a better one (`op3`? overload macro?).
+        macro_rules! float_triop {
+            ($($f:tt)+) => {
+                scalar_or_vec_distribute(|inputs: ArrayVec<_, 3>| {
+                    let op = ();
+                    dispatch_scalar! { inputs.match op => (f32, f32, f32) -> _:
+                        () => ($($f)+)
+                    }
+                })(inputs)
+            };
+        }
+
+        let output = match kind {
+            &DataInstKind::Scalar(op) => Some(
+                self.eval_scalar_op(
+                    op,
+                    inputs.into_iter().map(|x| x.try_into().unwrap()).collect(),
+                )
+                .into(),
+            ),
+            &DataInstKind::Vector(op) => Some({
+                match op {
+                    vector::Op::Distribute(op) => {
+                        vec_distribute(|inputs| self.eval_scalar_op(op, inputs))(inputs)
+                    }
+                    vector::Op::Reduce(op) => match op {
+                        vector::ReduceOp::Dot => todo!(),
+                        vector::ReduceOp::Any => todo!(),
+                        vector::ReduceOp::All => todo!(),
+                    },
+                    vector::Op::Whole(op) => match op {
+                        vector::WholeOp::New => DynVal::Vector(
+                            inputs.into_iter().map(|x| x.try_into().unwrap()).collect(),
+                        ),
+                        vector::WholeOp::Extract { elem_idx } => {
+                            match inputs.into_iter().collect_tuple().unwrap() {
+                                (DynVal::Vector(elems),) => DynVal::Scalar(
+                                    elems.into_iter().nth(usize::from(elem_idx)).unwrap(),
+                                ),
+                                _ => unreachable!(),
+                            }
+                        }
+                        vector::WholeOp::Insert { elem_idx } => {
+                            let (new_elem, val) = inputs.into_iter().collect_tuple().unwrap();
+                            match val {
+                                DynVal::Vector(mut elems) => {
+                                    elems[usize::from(elem_idx)] = new_elem.try_into().unwrap();
+                                    DynVal::Vector(elems)
+                                }
+                                _ => unreachable!(),
+                            }
+                        }
+                        vector::WholeOp::DynExtract => todo!(),
+                        vector::WholeOp::DynInsert => todo!(),
+                        vector::WholeOp::Mul => todo!(),
+                    },
+                }
+            }),
+            &DataInstKind::FuncCall(callee) => {
+                let mut ret_vals = self.eval_call(callee, inputs);
+                assert!(ret_vals.len() <= 1);
+                ret_vals.pop()
+            }
+            DataInstKind::QPtr(_) => todo!(),
+            DataInstKind::SpvInst(spv_inst) => {
+                if spv_inst.opcode == self.wk.OpStore {
+                    // FIXME(eddyb) deduplicate between `OpStore` and `OpLoad`.
+                    let (ptr, val) = inputs.into_iter().collect_tuple().unwrap();
+                    let (ptr_base, ptr_access_chain) = match ptr {
+                        DynVal::Ptr { base, access_chain } => (base, access_chain),
+                        _ => unreachable!(),
+                    };
+                    let mut slot = match ptr_base {
+                        DynPtrBase::GlobalVar(gv) => {
+                            // FIXME(eddyb) get the pointee type to generate a `ConstKind::Undef`.
+                            self.global_vars.entry(gv).get_or_insert(DynVal::LazyUninitAggregate)
+                        }
+                    };
+                    // FIXME(eddyb) lazily initialize structure based on type.
+                    for i in ptr_access_chain {
+                        let components = match slot {
+                            DynVal::LazyUninitAggregate => {
+                                todo!("OpStore wants typed lazy uninit init")
+                            }
+                            // HACK(eddyb) this reimplements `Rc::make_mut` for `Rc<[T]>`.
+                            DynVal::Aggregate(components) => {
+                                // FIXME(eddyb) this works around pre-polonius borrowck.
+                                if Rc::get_mut(components).is_none() {
+                                    let cloned = components.iter().cloned().collect();
+                                    *components = cloned;
+                                }
+                                Rc::get_mut(components).unwrap()
+                            }
+                            _ => unreachable!(),
+                        };
+                        slot = &mut components[usize::try_from(i).unwrap()];
+                    }
+
+                    *slot = val;
+                    None
+                } else if spv_inst.opcode == self.wk.OpLoad {
+                    // FIXME(eddyb) deduplicate between `OpStore` and `OpLoad`.
+                    let (ptr,) = inputs.into_iter().collect_tuple().unwrap();
+                    let (ptr_base, ptr_access_chain) = match ptr {
+                        DynVal::Ptr { base, access_chain } => (base, access_chain),
+                        _ => unreachable!(),
+                    };
+                    let mut val = match ptr_base {
+                        DynPtrBase::GlobalVar(gv) => {
+                            // FIXME(eddyb) get the pointee type to generate a `ConstKind::Undef`.
+                            self.global_vars.get(gv).cloned().unwrap_or(DynVal::LazyUninitAggregate)
+                        }
+                    };
+                    for i in ptr_access_chain {
+                        val = match val {
+                            DynVal::Vector(elems) => {
+                                DynVal::Scalar(elems[usize::try_from(i).unwrap()].clone())
+                            }
+                            DynVal::Aggregate(components) => {
+                                components[usize::try_from(i).unwrap()].clone()
+                            }
+                            DynVal::LazyUninitAggregate => DynVal::LazyUninitAggregate,
+                            _ => unreachable!(),
+                        };
+                    }
+                    Some(val)
+                } else if spv_inst.opcode == self.wk.OpAccessChain {
+                    let mut inputs = inputs.into_iter();
+                    let mut ptr = inputs.next().unwrap();
+                    let ptr_access_chain = match &mut ptr {
+                        DynVal::Ptr { base: _, access_chain } => access_chain,
+                        _ => unreachable!(),
+                    };
+                    for i in inputs {
+                        let i = match i {
+                            DynVal::Scalar(DynScalar::U32(i)) => match i {
+                                DynLeaf::Uniform(i) => i,
+                                _ => todo!("non-uniform OpAccessChain"),
+                            },
+                            _ => unreachable!(),
+                        };
+                        ptr_access_chain.push(i);
+                    }
+                    Some(ptr)
+                } else if spv_inst.opcode == self.wk.OpSelect {
+                    let (cond, t, e) = inputs.into_iter().collect_tuple().unwrap();
+                    let cond = match cond {
+                        DynVal::Scalar(DynScalar::Bool(cond)) => cond,
+                        _ => unreachable!(),
+                    };
+                    // FIXME(eddyb) support composites (or, wait for deaggregate).
+                    fn select<T>(cond: bool, t: T, e: T) -> T {
+                        if cond { t } else { e }
+                    }
+                    Some(match (t, e) {
+                        (DynVal::Scalar(t), DynVal::Scalar(e)) => DynVal::Scalar(match (t, e) {
+                            (DynScalar::Bool(t), DynScalar::Bool(e)) => {
+                                DynScalar::Bool((cond, t, e).map(select))
+                            }
+                            (DynScalar::F32(t), DynScalar::F32(e)) => {
+                                DynScalar::F32((cond, t, e).map(select))
+                            }
+                            _ => unreachable!(),
+                        }),
+                        _ => unreachable!(),
+                    })
+                } else if spv_inst.opcode == self.wk.OpCompositeConstruct {
+                    // FIXME(eddyb) update for `disaggregate`.
+                    Some(DynVal::Aggregate(inputs.into_iter().collect()))
+                } else if spv_inst.opcode == self.wk.OpCompositeExtract {
+                    // FIXME(eddyb) update for `disaggregate`.
+                    let (mut val,) = inputs.into_iter().collect_tuple().unwrap();
+                    for &imm in &spv_inst.imms {
+                        val = match (imm, val) {
+                            (spv::Imm::Short(_, i), DynVal::Aggregate(components)) => {
+                                components[usize::try_from(i).unwrap()].clone()
+                            }
+                            _ => unreachable!(),
+                        };
+                    }
+                    Some(val)
+                } else if spv_inst.opcode == self.wk.OpCompositeInsert {
+                    // FIXME(eddyb) update for `disaggregate`.
+                    let (new_leaf, mut val) = inputs.into_iter().collect_tuple().unwrap();
+                    let mut slot = &mut val;
+                    for &imm in &spv_inst.imms {
+                        let i = match imm {
+                            spv::Imm::Short(_, i) => i,
+                            _ => unreachable!(),
+                        };
+                        let components = match slot {
+                            DynVal::LazyUninitAggregate => {
+                                todo!("OpCompositeInsert wants typed lazy uninit init")
+                            }
+                            // HACK(eddyb) this reimplements `Rc::make_mut` for `Rc<[T]>`.
+                            DynVal::Aggregate(components) => {
+                                // FIXME(eddyb) this works around pre-polonius borrowck.
+                                if Rc::get_mut(components).is_none() {
+                                    let cloned = components.iter().cloned().collect();
+                                    *components = cloned;
+                                }
+                                Rc::get_mut(components).unwrap()
+                            }
+                            _ => unreachable!(),
+                        };
+                        slot = &mut components[usize::try_from(i).unwrap()];
+                    }
+                    *slot = new_leaf;
+                    Some(val)
+                } else if spv_inst.opcode == self.wk.OpBitcast {
+                    Some(match inputs.into_iter().collect_tuple().unwrap() {
+                        (DynVal::Scalar(DynScalar::U32(x)),)
+                            if *output_type == Some(self.ty_s32) =>
+                        {
+                            DynVal::Scalar(DynScalar::S32(x.map(|x| x as i32)))
+                        }
+                        (DynVal::Scalar(DynScalar::S32(x)),)
+                            if *output_type == Some(self.ty_u32) =>
+                        {
+                            DynVal::Scalar(DynScalar::U32(x.map(|x| x as u32)))
+                        }
+                        _ => unreachable!(),
+                    })
+                } else {
+                    todo!(
+                        "unsupported instruction {} {}",
+                        spv_inst.opcode.name(),
+                        spv::print::inst_operands(
+                            spv_inst.opcode,
+                            spv_inst.imms.iter().copied(),
+                            inputs.iter().enumerate().map(|(i, _)| format!("<input #{i}>"))
+                        )
+                        .map(|operand| operand.concat_to_plain_text())
+                        .collect::<Vec<_>>()
+                        .join(" ")
+                    )
+                }
+            }
+
+            &DataInstKind::SpvExtInst { ext_set, inst }
+                if ext_set == self.glsl_std_450 && inst == self.wk.FAbs =>
+            {
+                Some(float_unop!(|x| x.abs()))
+            }
+            &DataInstKind::SpvExtInst { ext_set, inst }
+                if ext_set == self.glsl_std_450 && inst == self.wk.Exp =>
+            {
+                Some(float_unop!(|x| x.exp()))
+            }
+            &DataInstKind::SpvExtInst { ext_set, inst }
+                if ext_set == self.glsl_std_450 && inst == self.wk.Sqrt =>
+            {
+                Some(float_unop!(|x| x.sqrt()))
+            }
+            &DataInstKind::SpvExtInst { ext_set, inst }
+                if ext_set == self.glsl_std_450 && inst == self.wk.Sin =>
+            {
+                Some(float_unop!(|x| x.sin()))
+            }
+            &DataInstKind::SpvExtInst { ext_set, inst }
+                if ext_set == self.glsl_std_450 && inst == self.wk.Cos =>
+            {
+                Some(float_unop!(|x| x.cos()))
+            }
+
+            &DataInstKind::SpvExtInst { ext_set, inst }
+                if ext_set == self.glsl_std_450 && inst == self.wk.FMin =>
+            {
+                Some(float_binop!(|x, y| x.min(y)))
+            }
+            &DataInstKind::SpvExtInst { ext_set, inst }
+                if ext_set == self.glsl_std_450 && inst == self.wk.FMax =>
+            {
+                Some(float_binop!(|x, y| x.max(y)))
+            }
+            &DataInstKind::SpvExtInst { ext_set, inst }
+                if ext_set == self.glsl_std_450 && inst == self.wk.Pow =>
+            {
+                Some(float_binop!(|x, y| x.powf(y)))
+            }
+
+            &DataInstKind::SpvExtInst { ext_set, inst }
+                if ext_set == self.glsl_std_450 && inst == self.wk.Fma =>
+            {
+                Some(float_triop!(|x, y, z| x.mul_add(y, z)))
+            }
+
+            &DataInstKind::SpvExtInst { ext_set, inst } => {
+                let ext_set = &self.cx()[ext_set];
+                todo!(
+                    "unsupported extended instruction {ext_set} {inst} ({:?})",
+                    spv::spec::Spec::get()
+                        .get_ext_inst_set_by_lowercase_name(&ext_set.to_ascii_lowercase())
+                        .and_then(|ext_inst_set_desc| Some(
+                            &ext_inst_set_desc.instructions.get(&inst)?.name
+                        )),
+                )
+            }
+        };
+        if let Some(output) = output {
+            self.call_stack
+                .last_mut()
+                .unwrap()
+                .data_inst_outputs
+                .insert(func_at_inst.position, output);
+        }
+        let elapsed = start.elapsed();
+        let ns_per_invocation = elapsed.as_secs_f64() * 1e9 / (self.invocations as f64);
+        #[allow(clippy::overly_complex_bool_expr)]
+        if ns_per_invocation >= 0.01 && false {
+            let name = match kind {
+                DataInstKind::Scalar(op) => op.name(),
+                DataInstKind::Vector(op) => match op {
+                    vector::Op::Distribute(op) => op.name(),
+                    vector::Op::Reduce(op) => op.name(),
+                    vector::Op::Whole(op) => op.name(),
+                },
+                DataInstKind::FuncCall(_) => "call",
+                DataInstKind::QPtr(_) => unreachable!(),
+                DataInstKind::SpvInst(spv_inst) => spv_inst.opcode.name(),
+                &DataInstKind::SpvExtInst { ext_set, inst } => {
+                    &spv::spec::Spec::get()
+                        .get_ext_inst_set_by_lowercase_name(
+                            &self.cx()[ext_set].to_ascii_lowercase(),
+                        )
+                        .unwrap()
+                        .instructions[&inst]
+                        .name
+                }
+            };
+            eprint!("{ns_per_invocation:8.1}ns × {}: {name}", self.invocations);
+            if let &Some(ty) = output_type {
+                // HACK(eddyb) hope the type is self-contained.
+                let ty = spirt::print::Plan::for_root(self.cx(), &ty).pretty_print().to_string();
+                let ty = if !ty.contains('\n') && ty.len() < 8 { &ty } else { "⋯" };
+                eprint!(" → {ty}");
+            }
+            eprintln!();
+        }
+    }
+    fn eval_scalar_op(&self, op: scalar::Op, inputs: SmallVec<[DynScalar; 4]>) -> DynScalar {
+        // HACK(eddyb) see `scalar::Op::FloatBinary` (needed for `CmpOrUnord`).
+        #[allow(clippy::neg_cmp_op_on_partial_ord)]
+        match op {
+            scalar::Op::BoolUnary(op) => {
+                // FIXME(eddyb) move import into macro.
+                use scalar::BoolUnOp::*;
+                dispatch_scalar! { inputs.match op => (bool) -> _:
+                    Not => (|x| !x)
+                }
+            }
+            scalar::Op::BoolBinary(op) => {
+                // FIXME(eddyb) move import into macro.
+                use scalar::BoolBinOp::*;
+                dispatch_scalar! { inputs.match op => (bool, bool) -> _:
+                    Eq => (==),
+                    Ne => (!=),
+                    Or => (|),
+                    And => (&),
+                }
+            }
+            scalar::Op::IntUnary(op) => match op {
+                scalar::IntUnOp::Neg => todo!(),
+                scalar::IntUnOp::Not => todo!(),
+                scalar::IntUnOp::CountOnes => todo!(),
+                scalar::IntUnOp::TruncOrZeroExtend => todo!(),
+                scalar::IntUnOp::TruncOrSignExtend => todo!(),
+            },
+            // FIXME(eddyb) wrap everything in `Wrapping`.
+            scalar::Op::IntBinary(op) => {
+                // FIXME(eddyb) maybe use `num-traits` to automate away a lot of this?
+                trait Int {}
+                trait CastTo<T: Int>: Int {
+                    fn cast_to(self) -> T;
+                }
+                impl<T: Int> CastTo<T> for T {
+                    fn cast_to(self) -> T {
+                        self
+                    }
+                }
+
+                macro_rules! int_cast_impls {
+                    ($($U:ident <=> $S:ident),+ $(,)?) => {$(
+                        impl Int for $U {}
+                        impl Int for $S {}
+                        impl CastTo<$U> for $S { fn cast_to(self) -> $U { self as $U } }
+                        impl CastTo<$S> for $U { fn cast_to(self) -> $S { self as $S } }
+                    )+}
+                }
+                int_cast_impls! {
+                    u32 <=> i32,
+                }
+
+                // HACK(eddyb) comparison ops make this necessary at all.
+                trait MaybeReverseCastOutput<I: CastTo<T>, T: Int> {
+                    type Output;
+                    fn maybe_reverse_cast_output(self) -> Self::Output;
+                }
+                impl<I: CastTo<T>, T: Int> MaybeReverseCastOutput<I, T> for bool {
+                    type Output = Self;
+                    fn maybe_reverse_cast_output(self) -> Self {
+                        self
+                    }
+                }
+                impl<I: CastTo<T>, T: CastTo<I>> MaybeReverseCastOutput<I, T> for T {
+                    type Output = I;
+                    fn maybe_reverse_cast_output(self) -> I {
+                        self.cast_to()
+                    }
+                }
+
+                // HACK(eddyb) allow forcing a signedness.
+                #[allow(non_snake_case)]
+                fn U<I: CastTo<u32>, R: MaybeReverseCastOutput<I, u32>>(
+                    f: impl Fn(u32, u32) -> R,
+                ) -> impl Fn(I, I) -> <R as MaybeReverseCastOutput<I, u32>>::Output
+                {
+                    move |x, y| f(x.cast_to(), y.cast_to()).maybe_reverse_cast_output()
+                }
+                #[allow(non_snake_case)]
+                fn S<I: CastTo<i32>, R: MaybeReverseCastOutput<I, i32>>(
+                    f: impl Fn(i32, i32) -> R,
+                ) -> impl Fn(I, I) -> <R as MaybeReverseCastOutput<I, i32>>::Output
+                {
+                    move |x, y| f(x.cast_to(), y.cast_to()).maybe_reverse_cast_output()
+                }
+
+                macro_rules! dispatch_int_binop {
+                    ($inputs:ident.match $op:ident: $($pat:pat => ($($f:tt)+)),+ $(,)?) => {{
+                        let (x, y) = $inputs.into_iter().collect_tuple().unwrap();
+                        match $op {
+                            $($pat => {
+                                // HACK(eddyb) closures somewhat used as `try` blocks.
+                                None.or_else(|| {
+                                    // FIXME(eddyb) remove the clones by using
+                                    // something better than `TryInto` here.
+                                    let x: DynLeaf<u32> = x.clone().try_into().ok()?;
+                                    let y: DynLeaf<u32> = y.clone().try_into().ok()?;
+                                    Some(DynScalar::from((x, y).map(op_closure!($($f)+))))
+                                }).or_else(|| {
+                                    let x: DynLeaf<i32> = x.clone().try_into().ok()?;
+                                    let y: DynLeaf<i32> = y.clone().try_into().ok()?;
+                                    Some(DynScalar::from((x, y).map(op_closure!($($f)+))))
+                                }).unwrap()
+                            }),+
+                        }
+                    }};
+                }
+
+                use scalar::IntBinOp::*;
+                dispatch_int_binop! { inputs.match op:
+                    Add => (+),
+                    Sub => (-),
+                    Mul => (*),
+                    DivU => (U(/)),
+                    DivS => (S(/)),
+                    ModU => (U(|_, _| -> u32 { todo!() })),
+                    RemS => (S(%)),
+                    ModS => (S(|_, _| -> i32 { todo!() })),
+                    ShrU => (U(>>)),
+                    ShrS => (S(>>)),
+                    Shl => (<<),
+                    Or => (|),
+                    Xor => (^),
+                    And => (&),
+                    CarryingAdd => (|_, _| -> u32 { todo!() }),
+                    BorrowingSub => (|_, _| -> u32 { todo!() }),
+                    WideningMulU => (U(|_, _| -> u32 { todo!() })),
+                    WideningMulS => (S(|_, _| -> i32 { todo!() })),
+                    Eq => (==),
+                    Ne => (!=),
+                    GtU => (U(>)),
+                    GtS => (S(>)),
+                    GeU => (U(>=)),
+                    GeS => (S(>=)),
+                    LtU => (U(<)),
+                    LtS => (S(<)),
+                    LeU => (U(<=)),
+                    LeS => (S(<=)),
+                }
+            }
+            scalar::Op::FloatUnary(op) => {
+                use scalar::FloatUnOp::*;
+                dispatch_scalar! { inputs.match op => (_) -> _:
+                    Neg => (|x: f32| -x),
+                    IsNan => (|x: f32| x.is_nan()),
+                    IsInf => (|x: f32| x.is_infinite()),
+                    // FIXME(eddyb) handle both signed and unsigned here.
+                    FromUInt => (|x: u32| x as f32),
+                    FromSInt => (|x: i32| x as f32),
+                    ToUInt => (|x: f32| x as u32),
+                    ToSInt => (|x: f32| x as i32),
+                    Convert => (|_: f32| -> f32 { todo!() }),
+                    QuantizeAsF16 => (|_: f32| -> f32 { todo!() }),
+                }
+            }
+            scalar::Op::FloatBinary(op) => {
+                // FIXME(eddyb) move import into macro.
+                use scalar::{FloatBinOp::*, FloatCmp::*};
+                dispatch_scalar! { inputs.match op => (f32, f32) -> _:
+                    Add => (+),
+                    Sub => (-),
+                    Mul => (*),
+                    Div => (/),
+                    Rem => (%),
+                    Mod => (|_, _| -> f32 { todo!() }),
+                    Cmp(Eq) => (==),
+                    Cmp(Ne) => (!=),
+                    Cmp(Lt) => (<),
+                    Cmp(Gt) => (>),
+                    Cmp(Le) => (<=),
+                    Cmp(Ge) => (>=),
+                    // HACK(eddyb) all of these negate the opposite comparison,
+                    // which flips unordered from always `false` to always `true`.
+                    CmpOrUnord(Eq) => (! ==),
+                    CmpOrUnord(Ne) => (! !=),
+                    CmpOrUnord(Lt) => (! <),
+                    CmpOrUnord(Gt) => (! >),
+                    CmpOrUnord(Le) => (! <=),
+                    CmpOrUnord(Ge) => (! >=),
+                }
+            }
+        }
+    }
+    fn eval_scalar_const(&self, ct: scalar::Const) -> DynScalar {
+        match ct {
+            scalar::Const::FALSE => DynScalar::Bool(DynLeaf::Uniform(false)),
+            scalar::Const::TRUE => DynScalar::Bool(DynLeaf::Uniform(true)),
+            _ => match ct.ty() {
+                scalar::Type::U32 => DynScalar::U32(DynLeaf::Uniform(ct.int_as_u32().unwrap())),
+                scalar::Type::S32 => DynScalar::S32(DynLeaf::Uniform(ct.int_as_i32().unwrap())),
+                scalar::Type::F32 => DynScalar::F32(DynLeaf::Uniform(f32::from_bits(
+                    u32::try_from(ct.bits()).unwrap(),
+                ))),
+                _ => {
+                    let ct: Const = self.cx().intern(ct);
+                    todo!(
+                        "unsupported const `{}`",
+                        spirt::print::Plan::for_root(self.cx(), &ct).pretty_print()
+                    )
+                }
+            },
+        }
+    }
+    fn eval_value(&mut self, value: Value) -> DynVal {
+        match value {
+            Value::Const(ct) => {
+                let ct_def = &self.cx()[ct];
+                match &ct_def.kind {
+                    ConstKind::Undef => match self.cx()[ct_def.ty].kind {
+                        TypeKind::Scalar(_) => DynVal::Scalar(DynScalar::Undef),
+                        TypeKind::Vector(ty) => DynVal::Vector(
+                            (0..ty.elem_count.get()).map(|_| DynScalar::Undef).collect(),
+                        ),
+                        _ => DynVal::LazyUninitAggregate,
+                    },
+                    &ConstKind::Scalar(ct) => DynVal::Scalar(self.eval_scalar_const(ct)),
+                    ConstKind::Vector(ct) => {
+                        DynVal::Vector(ct.elems().map(|ct| self.eval_scalar_const(ct)).collect())
+                    }
+                    &ConstKind::PtrToGlobalVar(gv) => {
+                        self.lazy_init_global_var(gv);
+                        DynVal::Ptr {
+                            base: DynPtrBase::GlobalVar(gv),
+                            access_chain: SmallVec::new(),
+                        }
+                    }
+                    // FIXME(eddyb) update for `disaggregate`.
+                    ConstKind::SpvInst { spv_inst_and_const_inputs } => {
+                        let (spv_inst, const_inputs) = &**spv_inst_and_const_inputs;
+                        if spv_inst.opcode == self.wk.OpConstantComposite {
+                            DynVal::Aggregate(
+                                const_inputs
+                                    .iter()
+                                    .map(|&ct| self.eval_value(Value::Const(ct)))
+                                    .collect(),
+                            )
+                        } else {
+                            todo!("unsupported {}", spv_inst.opcode.name())
+                        }
+                    }
+                    &ConstKind::SpvStringLiteralForExtInst(s) => {
+                        DynVal::SpvStringLiteralForExtInst(s)
+                    }
+                }
+            }
+            Value::ControlRegionInput { region, input_idx } => {
+                self.call_stack.last().unwrap().region_inputs[region][input_idx as usize].clone()
+            }
+            Value::ControlNodeOutput { control_node, output_idx } => {
+                self.call_stack.last().unwrap().control_node_outputs[control_node]
+                    [output_idx as usize]
+                    .clone()
+            }
+            Value::DataInstOutput(inst) => {
+                self.call_stack.last().unwrap().data_inst_outputs[inst].clone()
+            }
+        }
+    }
+    fn lazy_init_global_var(&mut self, gv: GlobalVar) {
+        let cx = self.cx();
+
+        let entry = self.global_vars.entry(gv);
+        if entry.is_some() {
+            return;
+        }
+
+        let gv_decl = &self.module.global_vars[gv];
+
+        // FIXME(eddyb) use the actual type for this (or force qptr?).
+        if gv_decl.addr_space == AddrSpace::SpvStorageClass(self.wk.PushConstant) {
+            *entry = Some(DynVal::Aggregate(
+                [DynVal::Aggregate(self.push_constants.iter().cloned().collect())]
+                    .into_iter()
+                    .collect(),
+            ));
+            return;
+        }
+
+        let builtin = if gv_decl.addr_space == AddrSpace::SpvStorageClass(self.wk.Input) {
+            cx[gv_decl.attrs].attrs.iter().find_map(|attr| match attr {
+                Attr::SpvAnnotation(spv_inst) if spv_inst.opcode == self.wk.OpDecorate => {
+                    match spv_inst
+                        .imms
+                        .strip_prefix(&[spv::Imm::Short(self.wk.Decoration, self.wk.BuiltIn)])?
+                    {
+                        &[spv::Imm::Short(builtin_kind, builtin)] => Some((builtin_kind, builtin)),
+                        _ => None,
+                    }
+                }
+                _ => None,
+            })
+        } else {
+            None
+        };
+
+        if let Some((builtin_kind, builtin)) = builtin {
+            let print_builtin = || {
+                spv::print::operand_from_imms([spv::Imm::Short(builtin_kind, builtin)])
+                    .concat_to_plain_text()
+            };
+            let init = if builtin == self.wk.FragCoord {
+                match self.launch {
+                    Launch::FragRect { width, height } => DynVal::Vector(
+                        [
+                            DynScalar::F32(DynLeaf::PerInvocation(Rc::new(
+                                (0..height)
+                                    .flat_map(|_| 0..width)
+                                    .map(|x| (x as f32) + 0.5)
+                                    .collect(),
+                            ))),
+                            DynScalar::F32(DynLeaf::PerInvocation(Rc::new(
+                                (0..height)
+                                    .map(|y| (y as f32) + 0.5)
+                                    .flat_map(|y| (0..width).map(move |_| y))
+                                    .collect(),
+                            ))),
+                            DynScalar::F32(DynLeaf::Uniform(0.0)),
+                            DynScalar::F32(DynLeaf::Uniform(1.0)),
+                        ]
+                        .into(),
+                    ),
+                    _ => unreachable!("{} used outside Fragment shader", print_builtin()),
+                }
+            } else {
+                todo!("unknown {}", print_builtin());
+            };
+            *entry = Some(init);
+        }
+    }
+}

--- a/src/cfg.rs
+++ b/src/cfg.rs
@@ -1568,14 +1568,6 @@ impl<'a> Structurizer<'a> {
     /// Create an undefined constant (as a placeholder where a value needs to be
     /// present, but won't actually be used), of type `ty`.
     fn const_undef(&self, ty: Type) -> Const {
-        // FIXME(eddyb) SPIR-T should have native undef itself.
-        let wk = &spv::spec::Spec::get().well_known;
-        self.cx.intern(ConstDef {
-            attrs: AttrSet::default(),
-            ty,
-            kind: ConstKind::SpvInst {
-                spv_inst_and_const_inputs: Rc::new((wk.OpUndef.into(), [].into_iter().collect())),
-            },
-        })
+        self.cx.intern(ConstDef { attrs: AttrSet::default(), ty, kind: ConstKind::Undef })
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -987,6 +987,12 @@ pub enum DataInstKind {
     #[from]
     Scalar(scalar::Op),
 
+    /// Vector (small array of [`scalar`]s) pure operations.
+    ///
+    /// See also the [`vector`] module for more documentation and definitions.
+    #[from]
+    Vector(vector::Op),
+
     // FIXME(eddyb) try to split this into recursive and non-recursive calls,
     // to avoid needing special handling for recursion where it's impossible.
     FuncCall(Func),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -938,6 +938,12 @@ pub struct DataInstFormDef {
 
 #[derive(Clone, PartialEq, Eq, Hash, derive_more::From)]
 pub enum DataInstKind {
+    /// Scalar (`bool`, integer, and floating-point) pure operations.
+    ///
+    /// See also the [`scalar`] module for more documentation and definitions.
+    #[from]
+    Scalar(scalar::Op),
+
     // FIXME(eddyb) try to split this into recursive and non-recursive calls,
     // to avoid needing special handling for recursion where it's impossible.
     FuncCall(Func),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -168,6 +168,7 @@ pub mod passes {
     pub mod qptr;
 }
 pub mod qptr;
+pub mod scalar;
 pub mod spv;
 
 use smallvec::SmallVec;
@@ -453,16 +454,23 @@ impl<T: Eq> Ord for OrdAssertEq<T> {
 pub use context::Type;
 
 /// Definition for a [`Type`].
-//
-// FIXME(eddyb) maybe special-case some basic types like integers.
 #[derive(PartialEq, Eq, Hash)]
 pub struct TypeDef {
     pub attrs: AttrSet,
     pub kind: TypeKind,
 }
 
-#[derive(Clone, PartialEq, Eq, Hash)]
+#[derive(Clone, PartialEq, Eq, Hash, derive_more::From)]
 pub enum TypeKind {
+    /// Scalar (`bool`, integer, and floating-point) type, with limitations
+    /// on the supported bit-widths (power-of-two multiples of a byte).
+    ///
+    /// **Note**: pointers are never scalars (like SPIR-V, but unlike other IRs).
+    ///
+    /// See also the [`scalar`] module for more documentation and definitions.
+    #[from]
+    Scalar(scalar::Type),
+
     /// "Quasi-pointer", an untyped pointer-like abstract scalar that can represent
     /// both memory locations (in any address space) and other kinds of locations
     /// (e.g. SPIR-V `OpVariable`s in non-memory "storage classes").
@@ -490,12 +498,18 @@ pub enum TypeKind {
     SpvStringLiteralForExtInst,
 }
 
-// HACK(eddyb) this behaves like an implicit conversion for `cx.intern(...)`.
-impl context::InternInCx<Type> for TypeKind {
-    fn intern_in_cx(self, cx: &Context) -> Type {
-        cx.intern(TypeDef { attrs: Default::default(), kind: self })
+// HACK(eddyb) this behaves like an implicit conversion for `cx.intern(...)`,
+// and the macro is only used because coherence bans `impl<T: Into<TypeKind>>`.
+macro_rules! impl_intern_type_kind {
+    ($($kind:ty),+ $(,)?) => {
+        $(impl context::InternInCx<Type> for $kind {
+            fn intern_in_cx(self, cx: &Context) -> Type {
+                cx.intern(TypeDef { attrs: Default::default(), kind: self.into() })
+            }
+        })+
     }
 }
+impl_intern_type_kind!(TypeKind, scalar::Type);
 
 // HACK(eddyb) this is like `Either<Type, Const>`, only used in `TypeKind::SpvInst`,
 // and only because SPIR-V type definitions can references both types and consts.
@@ -503,6 +517,16 @@ impl context::InternInCx<Type> for TypeKind {
 pub enum TypeOrConst {
     Type(Type),
     Const(Const),
+}
+
+// HACK(eddyb) on `Type` instead of `TypeDef` for ergonomics reasons.
+impl Type {
+    pub fn as_scalar(self, cx: &Context) -> Option<scalar::Type> {
+        match cx[self].kind {
+            TypeKind::Scalar(ty) => Some(ty),
+            _ => None,
+        }
+    }
 }
 
 /// Interned handle for a [`ConstDef`](crate::ConstDef) (a constant value).
@@ -518,13 +542,25 @@ pub struct ConstDef {
     pub kind: ConstKind,
 }
 
-#[derive(Clone, PartialEq, Eq, Hash)]
+#[derive(Clone, PartialEq, Eq, Hash, derive_more::From)]
 pub enum ConstKind {
     /// Undeterminate value (i.e. SPIR-V `OpUndef`, LLVM `undef`).
     //
     // FIXME(eddyb) could it be possible to adopt LLVM's newer `poison`+`freeze`
     // model, without being forced to never lift back to `OpUndef`?
     Undef,
+
+    /// Scalar (`bool`, integer, and floating-point) constant, which must have
+    /// a type of [`TypeKind::Scalar`] (of the same [`scalar::Type`]).
+    ///
+    /// See also the [`scalar`] module for more documentation and definitions.
+    //
+    // FIXME(eddyb) maybe document the 128-bit limitation?.
+    // FIXME(eddyb) this technically makes the `scalar::Type` redundant, could
+    // it get out of sync? (perhaps "forced canonicalization" could be used to
+    // enforce that interning simply doesn't allow such scenarios?).
+    #[from]
+    Scalar(scalar::Const),
 
     PtrToGlobalVar(GlobalVar),
 
@@ -538,6 +574,34 @@ pub enum ConstKind {
     /// which can't have literals itself - for non-string literals `OpConstant*`
     /// are readily usable, but only `OpString` is supported for string literals.
     SpvStringLiteralForExtInst(InternedStr),
+}
+
+// HACK(eddyb) this behaves like an implicit conversion for `cx.intern(...)`,
+// like the `TypeKind` one, but this one is even weirder because it also interns
+// the inherent type of the constant, as a `Type` (with empty attributes).
+macro_rules! impl_intern_const_kind {
+    ($($kind:ty),+ $(,)?) => {
+        $(impl context::InternInCx<Const> for $kind {
+            fn intern_in_cx(self, cx: &Context) -> Const {
+                cx.intern(ConstDef {
+                    attrs: Default::default(),
+                    ty: cx.intern(self.ty()),
+                    kind: self.into(),
+                })
+            }
+        })+
+    }
+}
+impl_intern_const_kind!(scalar::Const);
+
+// HACK(eddyb) on `Const` instead of `ConstDef` for ergonomics reasons.
+impl Const {
+    pub fn as_scalar(self, cx: &Context) -> Option<&scalar::Const> {
+        match &cx[self].kind {
+            ConstKind::Scalar(ct) => Some(ct),
+            _ => None,
+        }
+    }
 }
 
 /// Declarations ([`GlobalVarDecl`], [`FuncDecl`]) can contain a full definition,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -520,6 +520,12 @@ pub struct ConstDef {
 
 #[derive(Clone, PartialEq, Eq, Hash)]
 pub enum ConstKind {
+    /// Undeterminate value (i.e. SPIR-V `OpUndef`, LLVM `undef`).
+    //
+    // FIXME(eddyb) could it be possible to adopt LLVM's newer `poison`+`freeze`
+    // model, without being forced to never lift back to `OpUndef`?
+    Undef,
+
     PtrToGlobalVar(GlobalVar),
 
     // HACK(eddyb) this is a fallback case that should become increasingly rare

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -895,13 +895,24 @@ pub enum ControlNodeKind {
     },
 }
 
+// FIXME(eddyb) consider interning this, perhaps in a similar vein to `DataInstForm`.
 #[derive(Clone)]
 pub enum SelectionKind {
     /// Two-case selection based on boolean condition, i.e. `if`-`else`, with
     /// the two cases being "then" and "else" (in that order).
     BoolCond,
 
-    SpvInst(spv::Inst),
+    /// `N+1`-case selection based on comparing an integer scrutinee against
+    /// `N` constants, i.e. `switch`, with the last case being the "default"
+    /// (making it the only case without a matching entry in `case_consts`).
+    Switch {
+        // FIXME(eddyb) avoid some of the `scalar::Const` overhead here, as there
+        // is only a single type and we shouldn't need to store more bits per case,
+        // than the actual width of the integer type.
+        // FIXME(eddyb) consider storing this more like sorted compressed keyset,
+        // as there can be no duplicates, and in many cases it may be contiguous.
+        case_consts: Vec<scalar::Const>,
+    },
 }
 
 /// Entity handle for a [`DataInstDef`](crate::DataInstDef) (an SSA instruction).

--- a/src/print/mod.rs
+++ b/src/print/mod.rs
@@ -24,7 +24,7 @@ use crate::print::multiversion::Versions;
 use crate::qptr::{self, QPtrAttr, QPtrMemUsage, QPtrMemUsageKind, QPtrOp, QPtrUsage};
 use crate::visit::{InnerVisit, Visit, Visitor};
 use crate::{
-    cfg, spv, AddrSpace, Attr, AttrSet, AttrSetDef, Const, ConstDef, ConstKind, Context,
+    cfg, scalar, spv, AddrSpace, Attr, AttrSet, AttrSetDef, Const, ConstDef, ConstKind, Context,
     ControlNode, ControlNodeDef, ControlNodeKind, ControlNodeOutputDecl, ControlRegion,
     ControlRegionDef, ControlRegionInputDecl, DataInst, DataInstDef, DataInstForm, DataInstFormDef,
     DataInstKind, DeclDef, Diag, DiagLevel, DiagMsgPart, EntityListIter, ExportKey, Exportee, Func,
@@ -817,19 +817,13 @@ impl<'a> Printer<'a> {
                                     // here and `TypeDef`'s `Print` impl.
                                     let has_compact_print_or_is_leaf = match &ty_def.kind {
                                         TypeKind::SpvInst { spv_inst, type_and_const_inputs } => {
-                                            [
-                                                wk.OpTypeBool,
-                                                wk.OpTypeInt,
-                                                wk.OpTypeFloat,
-                                                wk.OpTypeVector,
-                                            ]
-                                            .contains(&spv_inst.opcode)
+                                            spv_inst.opcode == wk.OpTypeVector
                                                 || type_and_const_inputs.is_empty()
                                         }
 
-                                        TypeKind::QPtr | TypeKind::SpvStringLiteralForExtInst => {
-                                            true
-                                        }
+                                        TypeKind::Scalar(_)
+                                        | TypeKind::QPtr
+                                        | TypeKind::SpvStringLiteralForExtInst => true,
                                     };
 
                                     ty_def.attrs == AttrSet::default()
@@ -838,28 +832,16 @@ impl<'a> Printer<'a> {
                                 CxInterned::Const(ct) => {
                                     let ct_def = &cx[ct];
 
-                                    // FIXME(eddyb) remove the duplication between
-                                    // here and `ConstDef`'s `Print` impl.
-                                    let (has_compact_print, has_nested_consts) = match &ct_def.kind
-                                    {
+                                    let has_nested_consts = match &ct_def.kind {
                                         ConstKind::SpvInst { spv_inst_and_const_inputs } => {
-                                            let (spv_inst, const_inputs) =
+                                            let (_spv_inst, const_inputs) =
                                                 &**spv_inst_and_const_inputs;
-                                            (
-                                                [
-                                                    wk.OpConstantFalse,
-                                                    wk.OpConstantTrue,
-                                                    wk.OpConstant,
-                                                ]
-                                                .contains(&spv_inst.opcode),
-                                                !const_inputs.is_empty(),
-                                            )
+                                            !const_inputs.is_empty()
                                         }
-                                        _ => (false, false),
+                                        _ => false,
                                     };
 
-                                    ct_def.attrs == AttrSet::default()
-                                        && (has_compact_print || !has_nested_consts)
+                                    ct_def.attrs == AttrSet::default() && !has_nested_consts
                                 }
                             }
                     }
@@ -2380,30 +2362,13 @@ impl Print for TypeDef {
 
         // FIXME(eddyb) should this be done by lowering SPIR-V types to SPIR-T?
         let kw = |kw| printer.declarative_keyword_style().apply(kw).into();
+        #[allow(irrefutable_let_patterns)]
         let compact_def = if let &TypeKind::SpvInst {
             spv_inst: spv::Inst { opcode, ref imms },
             ref type_and_const_inputs,
         } = kind
         {
-            if opcode == wk.OpTypeBool {
-                Some(kw("bool".into()))
-            } else if opcode == wk.OpTypeInt {
-                let (width, signed) = match imms[..] {
-                    [spv::Imm::Short(_, width), spv::Imm::Short(_, signedness)] => {
-                        (width, signedness != 0)
-                    }
-                    _ => unreachable!(),
-                };
-
-                Some(if signed { kw(format!("s{width}")) } else { kw(format!("u{width}")) })
-            } else if opcode == wk.OpTypeFloat {
-                let width = match imms[..] {
-                    [spv::Imm::Short(_, width)] => width,
-                    _ => unreachable!(),
-                };
-
-                Some(kw(format!("f{width}")))
-            } else if opcode == wk.OpTypeVector {
+            if opcode == wk.OpTypeVector {
                 let (elem_ty, elem_count) = match (&imms[..], &type_and_const_inputs[..]) {
                     (&[spv::Imm::Short(_, elem_count)], &[TypeOrConst::Type(elem_ty)]) => {
                         (elem_ty, elem_count)
@@ -2429,6 +2394,16 @@ impl Print for TypeDef {
                 def
             } else {
                 match kind {
+                    TypeKind::Scalar(ty) => {
+                        let width = ty.bit_width();
+                        kw(match ty {
+                            scalar::Type::Bool => "bool".into(),
+                            scalar::Type::SInt(_) => format!("s{width}"),
+                            scalar::Type::UInt(_) => format!("u{width}"),
+                            scalar::Type::Float(_) => format!("f{width}"),
+                        })
+                    }
+
                     // FIXME(eddyb) should this be shortened to `qtr`?
                     TypeKind::QPtr => printer.declarative_keyword_style().apply("qptr").into(),
 
@@ -2462,71 +2437,22 @@ impl Print for ConstDef {
         let wk = &spv::spec::Spec::get().well_known;
 
         let kw = |kw| printer.declarative_keyword_style().apply(kw).into();
-        let literal_ty_suffix = |ty| {
-            pretty::Styles {
-                // HACK(eddyb) the exact type detracts from the value.
-                color_opacity: Some(0.4),
-                subscript: true,
-                ..printer.declarative_keyword_style()
-            }
-            .apply(ty)
-        };
-        let compact_def = if let ConstKind::SpvInst { spv_inst_and_const_inputs } = kind {
-            let (spv_inst, _const_inputs) = &**spv_inst_and_const_inputs;
-            let &spv::Inst { opcode, ref imms } = spv_inst;
 
-            if opcode == wk.OpConstantFalse {
-                Some(kw("false"))
-            } else if opcode == wk.OpConstantTrue {
-                Some(kw("true"))
-            } else if opcode == wk.OpConstant {
-                // HACK(eddyb) it's simpler to only handle a limited subset of
-                // integer/float bit-widths, for now.
-                let raw_bits = match imms[..] {
-                    [spv::Imm::Short(_, x)] => Some(u64::from(x)),
-                    [spv::Imm::LongStart(_, lo), spv::Imm::LongCont(_, hi)] => {
-                        Some(u64::from(lo) | (u64::from(hi) << 32))
-                    }
-                    _ => None,
-                };
-
-                if let (
-                    Some(raw_bits),
-                    &TypeKind::SpvInst {
-                        spv_inst: spv::Inst { opcode: ty_opcode, imms: ref ty_imms },
-                        ..
-                    },
-                ) = (raw_bits, &printer.cx[*ty].kind)
-                {
-                    if ty_opcode == wk.OpTypeInt {
-                        let (width, signed) = match ty_imms[..] {
-                            [spv::Imm::Short(_, width), spv::Imm::Short(_, signedness)] => {
-                                (width, signedness != 0)
-                            }
-                            _ => unreachable!(),
-                        };
-
-                        if width <= 64 {
-                            let (printed_value, ty) = if signed {
-                                let sext_raw_bits =
-                                    (raw_bits as u128 as i128) << (128 - width) >> (128 - width);
-                                (format!("{sext_raw_bits}"), format!("s{width}"))
-                            } else {
-                                (format!("{raw_bits}"), format!("u{width}"))
-                            };
-                            Some(pretty::Fragment::new([
-                                printer.numeric_literal_style().apply(printed_value),
-                                literal_ty_suffix(ty),
-                            ]))
-                        } else {
-                            None
-                        }
-                    } else if ty_opcode == wk.OpTypeFloat {
-                        let width = match ty_imms[..] {
-                            [spv::Imm::Short(_, width)] => width,
-                            _ => unreachable!(),
-                        };
-
+        let def_without_name = match kind {
+            ConstKind::Undef => pretty::Fragment::new([
+                printer.imperative_keyword_style().apply("undef").into(),
+                printer.pretty_type_ascription_suffix(*ty),
+            ]),
+            ConstKind::Scalar(scalar::Const::FALSE) => kw("false"),
+            ConstKind::Scalar(scalar::Const::TRUE) => kw("true"),
+            ConstKind::Scalar(ct) => {
+                let ty = ct.ty();
+                let width = ty.bit_width();
+                let (maybe_printed_value, ty_prefix) = match ty {
+                    scalar::Type::Bool => unreachable!(),
+                    scalar::Type::SInt(_) => (ct.int_as_i128().map(|x| x.to_string()), 's'),
+                    scalar::Type::UInt(_) => (ct.int_as_u128().map(|x| x.to_string()), 'u'),
+                    scalar::Type::Float(_) => {
                         /// Check that parsing the result of printing produces
                         /// the original bits of the floating-point value, and
                         /// only return `Some` if that is the case.
@@ -2546,69 +2472,81 @@ impl Print for ConstDef {
                             })
                         }
 
-                        let printed_value = match width {
-                            32 => bitwise_roundtrip_float_print(
-                                raw_bits as u32,
-                                f32::from_bits,
-                                f32::to_bits,
-                            ),
-                            64 => bitwise_roundtrip_float_print(
-                                raw_bits,
-                                f64::from_bits,
-                                f64::to_bits,
-                            ),
-                            _ => None,
-                        };
-                        printed_value.map(|s| {
-                            pretty::Fragment::new([
-                                printer.numeric_literal_style().apply(s),
-                                literal_ty_suffix(format!("f{width}")),
-                            ])
-                        })
-                    } else {
-                        None
+                        (
+                            match width {
+                                32 => bitwise_roundtrip_float_print(
+                                    ct.bits() as u32,
+                                    f32::from_bits,
+                                    f32::to_bits,
+                                ),
+                                64 => bitwise_roundtrip_float_print(
+                                    ct.bits() as u64,
+                                    f64::from_bits,
+                                    f64::to_bits,
+                                ),
+                                _ => None,
+                            },
+                            'f',
+                        )
                     }
-                } else {
-                    None
-                }
-            } else {
-                None
-            }
-        } else {
-            None
-        };
-
-        AttrsAndDef {
-            attrs: attrs.print(printer),
-            def_without_name: compact_def.unwrap_or_else(|| match kind {
-                ConstKind::Undef => pretty::Fragment::new([
-                    printer.imperative_keyword_style().apply("undef").into(),
-                    printer.pretty_type_ascription_suffix(*ty),
-                ]),
-                &ConstKind::PtrToGlobalVar(gv) => {
-                    pretty::Fragment::new(["&".into(), gv.print(printer)])
-                }
-
-                ConstKind::SpvInst { spv_inst_and_const_inputs } => {
-                    let (spv_inst, const_inputs) = &**spv_inst_and_const_inputs;
-                    pretty::Fragment::new([
-                        printer.pretty_spv_inst(
-                            printer.spv_op_style(),
-                            spv_inst.opcode,
-                            &spv_inst.imms,
-                            const_inputs.iter().map(|ct| ct.print(printer)),
+                };
+                match maybe_printed_value {
+                    Some(printed_value) => {
+                        let literal_ty_suffix = pretty::Styles {
+                            // HACK(eddyb) the exact type detracts from the value.
+                            color_opacity: Some(0.4),
+                            subscript: true,
+                            ..printer.declarative_keyword_style()
+                        }
+                        .apply(format!("{ty_prefix}{width}"));
+                        pretty::Fragment::new([
+                            printer.numeric_literal_style().apply(printed_value),
+                            literal_ty_suffix,
+                        ])
+                    }
+                    // HACK(eddyb) fallback using the bitwise representation.
+                    None => pretty::Fragment::new([
+                        printer
+                            .demote_style_for_namespace_prefix(printer.declarative_keyword_style())
+                            .apply(format!("{ty_prefix}{width}."))
+                            .into(),
+                        printer.declarative_keyword_style().apply("from_bits").into(),
+                        pretty::join_comma_sep(
+                            "(",
+                            [
+                                // FIXME(eddyb) consider padding this with enough
+                                // leading zeroes for its respective width.
+                                printer.numeric_literal_style().apply(format!("0x{:x}", ct.bits())),
+                            ],
+                            ")",
                         ),
-                        printer.pretty_type_ascription_suffix(*ty),
-                    ])
+                    ]),
                 }
-                &ConstKind::SpvStringLiteralForExtInst(s) => pretty::Fragment::new([
-                    printer.pretty_spv_opcode(printer.spv_op_style(), wk.OpString),
-                    "(".into(),
-                    printer.pretty_string_literal(&printer.cx[s]),
-                    ")".into(),
-                ]),
-            }),
-        }
+            }
+            &ConstKind::PtrToGlobalVar(gv) => {
+                pretty::Fragment::new(["&".into(), gv.print(printer)])
+            }
+
+            ConstKind::SpvInst { spv_inst_and_const_inputs } => {
+                let (spv_inst, const_inputs) = &**spv_inst_and_const_inputs;
+                pretty::Fragment::new([
+                    printer.pretty_spv_inst(
+                        printer.spv_op_style(),
+                        spv_inst.opcode,
+                        &spv_inst.imms,
+                        const_inputs.iter().map(|ct| ct.print(printer)),
+                    ),
+                    printer.pretty_type_ascription_suffix(*ty),
+                ])
+            }
+            &ConstKind::SpvStringLiteralForExtInst(s) => pretty::Fragment::new([
+                printer.pretty_spv_opcode(printer.spv_op_style(), wk.OpString),
+                "(".into(),
+                printer.pretty_string_literal(&printer.cx[s]),
+                ")".into(),
+            ]),
+        };
+        AttrsAndDef { attrs: attrs.print(printer), def_without_name }
     }
 }
 
@@ -3299,21 +3237,17 @@ impl Print for FuncAt<'_, DataInst> {
                 let pseudo_imm_from_value = |v: Value| {
                     if let Value::Const(ct) = v {
                         match &printer.cx[ct].kind {
-                            ConstKind::Undef | ConstKind::PtrToGlobalVar(_) => {}
+                            ConstKind::Undef
+                            | ConstKind::PtrToGlobalVar(_)
+                            | ConstKind::SpvInst { .. } => {}
 
                             &ConstKind::SpvStringLiteralForExtInst(s) => {
                                 return Some(PseudoImm::Str(&printer.cx[s]));
                             }
-                            ConstKind::SpvInst { spv_inst_and_const_inputs } => {
-                                let (spv_inst, _const_inputs) = &**spv_inst_and_const_inputs;
-                                if spv_inst.opcode == wk.OpConstant {
-                                    if let [spv::Imm::Short(_, x)] = spv_inst.imms[..] {
-                                        // HACK(eddyb) only allow unambiguously positive values.
-                                        if i32::try_from(x).and_then(u32::try_from) == Ok(x) {
-                                            return Some(PseudoImm::U32(x));
-                                        }
-                                    }
-                                }
+                            // HACK(eddyb) lossless roundtrip through `i32` is most conservative
+                            // option (only `0..=i32::MAX`, i.e. `0 <= x < 2**32, is allowed).
+                            ConstKind::Scalar(ct) => {
+                                return Some(PseudoImm::U32(u32::try_from(ct.int_as_i32()?).ok()?));
                             }
                         }
                     }

--- a/src/print/mod.rs
+++ b/src/print/mod.rs
@@ -2581,9 +2581,14 @@ impl Print for ConstDef {
         AttrsAndDef {
             attrs: attrs.print(printer),
             def_without_name: compact_def.unwrap_or_else(|| match kind {
+                ConstKind::Undef => pretty::Fragment::new([
+                    printer.imperative_keyword_style().apply("undef").into(),
+                    printer.pretty_type_ascription_suffix(*ty),
+                ]),
                 &ConstKind::PtrToGlobalVar(gv) => {
                     pretty::Fragment::new(["&".into(), gv.print(printer)])
                 }
+
                 ConstKind::SpvInst { spv_inst_and_const_inputs } => {
                     let (spv_inst, const_inputs) = &**spv_inst_and_const_inputs;
                     pretty::Fragment::new([
@@ -3294,6 +3299,8 @@ impl Print for FuncAt<'_, DataInst> {
                 let pseudo_imm_from_value = |v: Value| {
                     if let Value::Const(ct) = v {
                         match &printer.cx[ct].kind {
+                            ConstKind::Undef | ConstKind::PtrToGlobalVar(_) => {}
+
                             &ConstKind::SpvStringLiteralForExtInst(s) => {
                                 return Some(PseudoImm::Str(&printer.cx[s]));
                             }
@@ -3308,7 +3315,6 @@ impl Print for FuncAt<'_, DataInst> {
                                     }
                                 }
                             }
-                            ConstKind::PtrToGlobalVar(_) => {}
                         }
                     }
                     None

--- a/src/print/mod.rs
+++ b/src/print/mod.rs
@@ -24,8 +24,8 @@ use crate::print::multiversion::Versions;
 use crate::qptr::{self, QPtrAttr, QPtrMemUsage, QPtrMemUsageKind, QPtrOp, QPtrUsage};
 use crate::visit::{InnerVisit, Visit, Visitor};
 use crate::{
-    cfg, scalar, spv, AddrSpace, Attr, AttrSet, AttrSetDef, Const, ConstDef, ConstKind, Context,
-    ControlNode, ControlNodeDef, ControlNodeKind, ControlNodeOutputDecl, ControlRegion,
+    cfg, scalar, spv, vector, AddrSpace, Attr, AttrSet, AttrSetDef, Const, ConstDef, ConstKind,
+    Context, ControlNode, ControlNodeDef, ControlNodeKind, ControlNodeOutputDecl, ControlRegion,
     ControlRegionDef, ControlRegionInputDecl, DataInst, DataInstDef, DataInstForm, DataInstFormDef,
     DataInstKind, DeclDef, Diag, DiagLevel, DiagMsgPart, EntityListIter, ExportKey, Exportee, Func,
     FuncDecl, FuncParam, FxIndexMap, FxIndexSet, GlobalVar, GlobalVarDecl, GlobalVarDefBody,
@@ -2407,7 +2407,7 @@ impl Print for ConstDef {
 
         let kw = |kw| printer.declarative_keyword_style().apply(kw).into();
 
-        // FIXME(eddyb) should this just a method on `scalar::Const` instead?
+        // FIXME(eddyb) should this be a method on `scalar::Const` instead?
         let print_scalar = |ct: scalar::Const, include_type_suffix: bool| match ct {
             scalar::Const::FALSE => kw("false"),
             scalar::Const::TRUE => kw("true"),
@@ -3023,17 +3023,62 @@ impl Print for FuncAt<'_, DataInst> {
 
         let mut output_type_to_print = *output_type;
 
+        // FIXME(eddyb) should this be a method on `scalar::Op` instead?
+        let print_scalar = |op: scalar::Op| {
+            let name = op.name();
+            let (namespace_prefix, name) = name.split_at(name.find('.').unwrap() + 1);
+            pretty::Fragment::new([
+                printer
+                    .demote_style_for_namespace_prefix(printer.declarative_keyword_style())
+                    .apply(namespace_prefix),
+                printer.declarative_keyword_style().apply(name),
+            ])
+        };
+
         let def_without_type = match kind {
-            &DataInstKind::Scalar(op) => {
-                let name = op.name();
+            &DataInstKind::Scalar(op) => pretty::Fragment::new([
+                print_scalar(op),
+                pretty::join_comma_sep("(", inputs.iter().map(|v| v.print(printer)), ")"),
+            ]),
+
+            &DataInstKind::Vector(op) => {
+                let (name, extra_last_input) = match op {
+                    vector::Op::Distribute(_) => ("vec.distribute", None),
+                    vector::Op::Reduce(op) => (op.name(), None),
+                    vector::Op::Whole(op) => (
+                        op.name(),
+                        match op {
+                            vector::WholeOp::Extract { elem_idx }
+                            | vector::WholeOp::Insert { elem_idx } => Some(
+                                printer.numeric_literal_style().apply(elem_idx.to_string()).into(),
+                            ),
+                            vector::WholeOp::New
+                            | vector::WholeOp::DynExtract
+                            | vector::WholeOp::DynInsert
+                            | vector::WholeOp::Mul => None,
+                        },
+                    ),
+                };
                 let (namespace_prefix, name) = name.split_at(name.find('.').unwrap() + 1);
-                pretty::Fragment::new([
+                let mut pretty_name = pretty::Fragment::new([
                     printer
                         .demote_style_for_namespace_prefix(printer.declarative_keyword_style())
-                        .apply(namespace_prefix)
-                        .into(),
-                    printer.declarative_keyword_style().apply(name).into(),
-                    pretty::join_comma_sep("(", inputs.iter().map(|v| v.print(printer)), ")"),
+                        .apply(namespace_prefix),
+                    printer.declarative_keyword_style().apply(name),
+                ]);
+                if let vector::Op::Distribute(op) = op {
+                    pretty_name = pretty::Fragment::new([
+                        pretty_name,
+                        pretty::join_comma_sep("(", [print_scalar(op)], ")"),
+                    ]);
+                }
+                pretty::Fragment::new([
+                    pretty_name,
+                    pretty::join_comma_sep(
+                        "(",
+                        inputs.iter().map(|v| v.print(printer)).chain(extra_last_input),
+                        ")",
+                    ),
                 ])
             }
 

--- a/src/print/mod.rs
+++ b/src/print/mod.rs
@@ -3044,6 +3044,19 @@ impl Print for FuncAt<'_, DataInst> {
         let mut output_type_to_print = *output_type;
 
         let def_without_type = match kind {
+            &DataInstKind::Scalar(op) => {
+                let name = op.name();
+                let (namespace_prefix, name) = name.split_at(name.find('.').unwrap() + 1);
+                pretty::Fragment::new([
+                    printer
+                        .demote_style_for_namespace_prefix(printer.declarative_keyword_style())
+                        .apply(namespace_prefix)
+                        .into(),
+                    printer.declarative_keyword_style().apply(name).into(),
+                    pretty::join_comma_sep("(", inputs.iter().map(|v| v.print(printer)), ")"),
+                ])
+            }
+
             &DataInstKind::FuncCall(func) => pretty::Fragment::new([
                 printer.declarative_keyword_style().apply("call").into(),
                 " ".into(),

--- a/src/qptr/analyze.rs
+++ b/src/qptr/analyze.rs
@@ -906,6 +906,8 @@ impl<'a> InferUsage<'a> {
                     });
                 };
                 match &data_inst_form_def.kind {
+                    DataInstKind::Scalar(_) => {}
+
                     &DataInstKind::FuncCall(callee) => {
                         match self.infer_usage_in_func(module, callee) {
                             FuncInferUsageState::Complete(callee_results) => {

--- a/src/qptr/analyze.rs
+++ b/src/qptr/analyze.rs
@@ -906,7 +906,7 @@ impl<'a> InferUsage<'a> {
                     });
                 };
                 match &data_inst_form_def.kind {
-                    DataInstKind::Scalar(_) => {}
+                    DataInstKind::Scalar(_) | DataInstKind::Vector(_) => {}
 
                     &DataInstKind::FuncCall(callee) => {
                         match self.infer_usage_in_func(module, callee) {

--- a/src/qptr/layout.rs
+++ b/src/qptr/layout.rs
@@ -2,7 +2,7 @@
 
 use crate::qptr::shapes;
 use crate::{
-    spv, AddrSpace, Attr, Const, ConstKind, Context, Diag, FxIndexMap, Type, TypeKind, TypeOrConst,
+    scalar, spv, AddrSpace, Attr, Const, Context, Diag, FxIndexMap, Type, TypeKind, TypeOrConst,
 };
 use itertools::Either;
 use smallvec::SmallVec;
@@ -182,18 +182,10 @@ impl<'a> LayoutCache<'a> {
         Self { cx, wk: &spv::spec::Spec::get().well_known, config, cache: Default::default() }
     }
 
-    // FIXME(eddyb) properly distinguish between zero-extension and sign-extension.
     fn const_as_u32(&self, ct: Const) -> Option<u32> {
-        if let ConstKind::SpvInst { spv_inst_and_const_inputs } = &self.cx[ct].kind {
-            let (spv_inst, _const_inputs) = &**spv_inst_and_const_inputs;
-            if spv_inst.opcode == self.wk.OpConstant && spv_inst.imms.len() == 1 {
-                match spv_inst.imms[..] {
-                    [spv::Imm::Short(_, x)] => return Some(x),
-                    _ => unreachable!(),
-                }
-            }
-        }
-        None
+        // HACK(eddyb) lossless roundtrip through `i32` is most conservative
+        // option (only `0..=i32::MAX`, i.e. `0 <= x < 2**32, is allowed).
+        u32::try_from(ct.as_scalar(&self.cx)?.int_as_i32()?).ok()
     }
 
     /// Attempt to compute a `TypeLayout` for a given (SPIR-V) `Type`.
@@ -202,26 +194,16 @@ impl<'a> LayoutCache<'a> {
             return Ok(cached);
         }
 
+        let layout = self.layout_of_uncached(ty)?;
+        self.cache.borrow_mut().insert(ty, layout.clone());
+        Ok(layout)
+    }
+
+    fn layout_of_uncached(&self, ty: Type) -> Result<TypeLayout, LayoutError> {
         let cx = &self.cx;
         let wk = self.wk;
 
         let ty_def = &cx[ty];
-        let (spv_inst, type_and_const_inputs) = match &ty_def.kind {
-            // FIXME(eddyb) treat `QPtr`s as scalars.
-            TypeKind::QPtr => {
-                return Err(LayoutError(Diag::bug(
-                    ["`layout_of(qptr)` (already lowered?)".into()],
-                )));
-            }
-            TypeKind::SpvInst { spv_inst, type_and_const_inputs } => {
-                (spv_inst, type_and_const_inputs)
-            }
-            TypeKind::SpvStringLiteralForExtInst => {
-                return Err(LayoutError(Diag::bug([
-                    "`layout_of(type_of(OpString<\"...\">))`".into()
-                ])));
-            }
-        };
 
         let scalar_with_size_and_align = |(size, align)| {
             TypeLayout::Concrete(Rc::new(MemTypeLayout {
@@ -340,25 +322,43 @@ impl<'a> LayoutCache<'a> {
                 }
             }
         };
-        let short_imm_at = |i| match spv_inst.imms[i] {
-            spv::Imm::Short(_, x) => x,
-            _ => unreachable!(),
-        };
 
         // FIXME(eddyb) !!! what if... types had a min/max size and then...
         // that would allow surrounding offsets to limit their size... but... ugh...
         // ugh this doesn't make any sense. maybe if the front-end specifies
         // offsets with "abstract types", it must configure `qptr::layout`?
-        let layout = if spv_inst.opcode == wk.OpTypeBool {
-            // FIXME(eddyb) make this properly abstract instead of only configurable.
-            scalar_with_size_and_align(self.config.abstract_bool_size_align)
-        } else if spv_inst.opcode == wk.OpTypePointer {
+
+        let (spv_inst, type_and_const_inputs) = match &ty_def.kind {
+            TypeKind::Scalar(scalar::Type::Bool) => {
+                // FIXME(eddyb) make this properly abstract instead of only configurable.
+                return Ok(scalar_with_size_and_align(self.config.abstract_bool_size_align));
+            }
+            TypeKind::Scalar(ty) => return Ok(scalar(ty.bit_width())),
+
+            // FIXME(eddyb) treat `QPtr`s as scalars.
+            TypeKind::QPtr => {
+                return Err(LayoutError(Diag::bug(
+                    ["`layout_of(qptr)` (already lowered?)".into()],
+                )));
+            }
+            TypeKind::SpvInst { spv_inst, type_and_const_inputs } => {
+                (spv_inst, type_and_const_inputs)
+            }
+            TypeKind::SpvStringLiteralForExtInst => {
+                return Err(LayoutError(Diag::bug([
+                    "`layout_of(type_of(OpString<\"...\">))`".into()
+                ])));
+            }
+        };
+        let short_imm_at = |i| match spv_inst.imms[i] {
+            spv::Imm::Short(_, x) => x,
+            _ => unreachable!(),
+        };
+        Ok(if spv_inst.opcode == wk.OpTypePointer {
             // FIXME(eddyb) make this properly abstract instead of only configurable.
             // FIXME(eddyb) categorize `OpTypePointer` by storage class and split on
             // logical vs physical here.
             scalar_with_size_and_align(self.config.logical_ptr_size_align)
-        } else if [wk.OpTypeInt, wk.OpTypeFloat].contains(&spv_inst.opcode) {
-            scalar(short_imm_at(0))
         } else if [wk.OpTypeVector, wk.OpTypeMatrix].contains(&spv_inst.opcode) {
             let len = short_imm_at(0);
             let (min_legacy_align, legacy_align_multiplier) = if spv_inst.opcode == wk.OpTypeVector
@@ -642,8 +642,6 @@ impl<'a> LayoutCache<'a> {
                 spv_inst.opcode.name()
             )
             .into()])));
-        };
-        self.cache.borrow_mut().insert(ty, layout.clone());
-        Ok(layout)
+        })
     }
 }

--- a/src/qptr/lift.rs
+++ b/src/qptr/lift.rs
@@ -7,13 +7,12 @@ use crate::func_at::FuncAtMut;
 use crate::qptr::{shapes, QPtrAttr, QPtrMemUsage, QPtrMemUsageKind, QPtrOp, QPtrUsage};
 use crate::transform::{InnerInPlaceTransform, InnerTransform, Transformed, Transformer};
 use crate::{
-    spv, AddrSpace, Attr, AttrSet, AttrSetDef, Const, ConstDef, ConstKind, Context, ControlNode,
-    ControlNodeKind, DataInst, DataInstDef, DataInstFormDef, DataInstKind, DeclDef, Diag,
-    DiagLevel, EntityDefs, EntityOrientedDenseMap, Func, FuncDecl, FxIndexMap, GlobalVar,
+    scalar, spv, AddrSpace, Attr, AttrSet, AttrSetDef, Const, ConstDef, ConstKind, Context,
+    ControlNode, ControlNodeKind, DataInst, DataInstDef, DataInstFormDef, DataInstKind, DeclDef,
+    Diag, DiagLevel, EntityDefs, EntityOrientedDenseMap, Func, FuncDecl, FxIndexMap, GlobalVar,
     GlobalVarDecl, Module, Type, TypeDef, TypeKind, TypeOrConst, Value,
 };
 use smallvec::SmallVec;
-use std::cell::Cell;
 use std::mem;
 use std::num::NonZeroU32;
 use std::rc::Rc;
@@ -27,8 +26,6 @@ pub struct LiftToSpvPtrs<'a> {
     cx: Rc<Context>,
     wk: &'static spv::spec::WellKnown,
     layout_cache: LayoutCache<'a>,
-
-    cached_u32_type: Cell<Option<Type>>,
 }
 
 impl<'a> LiftToSpvPtrs<'a> {
@@ -37,7 +34,6 @@ impl<'a> LiftToSpvPtrs<'a> {
             cx: cx.clone(),
             wk: &spv::spec::Spec::get().well_known,
             layout_cache: LayoutCache::new(cx, layout_config),
-            cached_u32_type: Default::default(),
         }
     }
 
@@ -291,7 +287,9 @@ impl<'a> LiftToSpvPtrs<'a> {
                 spv_inst: spv_opcode.into(),
                 type_and_const_inputs: [TypeOrConst::Type(element_type)]
                     .into_iter()
-                    .chain(fixed_len.map(|len| TypeOrConst::Const(self.const_u32(len))))
+                    .chain(fixed_len.map(|len| {
+                        TypeOrConst::Const(self.cx.intern(scalar::Const::from_u32(len)))
+                    }))
                     .collect(),
             },
         }))
@@ -327,48 +325,6 @@ impl<'a> LiftToSpvPtrs<'a> {
             attrs: self.cx.intern(attrs),
             kind: TypeKind::SpvInst { spv_inst: wk.OpTypeStruct.into(), type_and_const_inputs },
         }))
-    }
-
-    /// Get the (likely cached) `u32` type.
-    fn u32_type(&self) -> Type {
-        if let Some(cached) = self.cached_u32_type.get() {
-            return cached;
-        }
-        let wk = self.wk;
-        let ty = self.cx.intern(TypeKind::SpvInst {
-            spv_inst: spv::Inst {
-                opcode: wk.OpTypeInt,
-                imms: [
-                    spv::Imm::Short(wk.LiteralInteger, 32),
-                    spv::Imm::Short(wk.LiteralInteger, 0),
-                ]
-                .into_iter()
-                .collect(),
-            },
-            type_and_const_inputs: [].into_iter().collect(),
-        });
-        self.cached_u32_type.set(Some(ty));
-        ty
-    }
-
-    fn const_u32(&self, x: u32) -> Const {
-        let wk = self.wk;
-
-        self.cx.intern(ConstDef {
-            attrs: AttrSet::default(),
-            ty: self.u32_type(),
-            kind: ConstKind::SpvInst {
-                spv_inst_and_const_inputs: Rc::new((
-                    spv::Inst {
-                        opcode: wk.OpConstant,
-                        imms: [spv::Imm::Short(wk.LiteralContextDependentNumber, x)]
-                            .into_iter()
-                            .collect(),
-                    },
-                    [].into_iter().collect(),
-                )),
-            },
-        })
     }
 
     /// Attempt to compute a `TypeLayout` for a given (SPIR-V) `Type`.
@@ -644,7 +600,7 @@ impl LiftToSpvPtrInstsInFunc<'_> {
                         ]))
                     })?;
                     access_chain_inputs
-                        .push(Value::Const(self.lifter.const_u32(idx_as_i32 as u32)));
+                        .push(Value::Const(cx.intern(scalar::Const::from_u32(idx_as_i32 as u32))));
 
                     match &layout.components {
                         Components::Scalar => unreachable!(),
@@ -757,7 +713,7 @@ impl LiftToSpvPtrInstsInFunc<'_> {
                         ]))
                     })?;
                     access_chain_inputs
-                        .push(Value::Const(self.lifter.const_u32(idx_as_i32 as u32)));
+                        .push(Value::Const(cx.intern(scalar::Const::from_u32(idx_as_i32 as u32))));
 
                     layout = match &layout.components {
                         Components::Scalar => unreachable!(),
@@ -945,7 +901,8 @@ impl LiftToSpvPtrInstsInFunc<'_> {
         let mut access_chain_inputs: SmallVec<_> = [ptr].into_iter().collect();
 
         if let TypeLayout::HandleArray(handle, _) = pointee_layout {
-            access_chain_inputs.push(Value::Const(self.lifter.const_u32(0)));
+            access_chain_inputs
+                .push(Value::Const(self.lifter.cx.intern(scalar::Const::from_u32(0))));
             pointee_layout = TypeLayout::Handle(handle);
         }
         match (pointee_layout, access_layout) {
@@ -1014,8 +971,9 @@ impl LiftToSpvPtrInstsInFunc<'_> {
                             format!("{idx} not representable as a positive s32").into()
                         ]))
                     })?;
-                    access_chain_inputs
-                        .push(Value::Const(self.lifter.const_u32(idx_as_i32 as u32)));
+                    access_chain_inputs.push(Value::Const(
+                        self.lifter.cx.intern(scalar::Const::from_u32(idx_as_i32 as u32)),
+                    ));
 
                     pointee_layout = match &pointee_layout.components {
                         Components::Scalar => unreachable!(),

--- a/src/qptr/lift.rs
+++ b/src/qptr/lift.rs
@@ -404,6 +404,8 @@ impl LiftToSpvPtrInstsInFunc<'_> {
             Ok((addr_space, self.lifter.layout_of(pointee_type)?))
         };
         let replacement_data_inst_def = match &data_inst_form_def.kind {
+            DataInstKind::Scalar(_) => return Ok(Transformed::Unchanged),
+
             &DataInstKind::FuncCall(_callee) => {
                 for &v in &data_inst_def.inputs {
                     if self.lifter.as_spv_ptr_type(type_of_val(v)).is_some() {

--- a/src/qptr/lift.rs
+++ b/src/qptr/lift.rs
@@ -404,7 +404,7 @@ impl LiftToSpvPtrInstsInFunc<'_> {
             Ok((addr_space, self.lifter.layout_of(pointee_type)?))
         };
         let replacement_data_inst_def = match &data_inst_form_def.kind {
-            DataInstKind::Scalar(_) => return Ok(Transformed::Unchanged),
+            DataInstKind::Scalar(_) | DataInstKind::Vector(_) => return Ok(Transformed::Unchanged),
 
             &DataInstKind::FuncCall(_callee) => {
                 for &v in &data_inst_def.inputs {

--- a/src/qptr/lower.rs
+++ b/src/qptr/lower.rs
@@ -616,7 +616,7 @@ impl LowerFromSpvPtrInstsInFunc<'_> {
 
         match data_inst_form_def.kind {
             // Known semantics, no need to preserve SPIR-V pointer information.
-            DataInstKind::FuncCall(_) | DataInstKind::QPtr(_) => return,
+            DataInstKind::Scalar(_) | DataInstKind::FuncCall(_) | DataInstKind::QPtr(_) => return,
 
             DataInstKind::SpvInst(_) | DataInstKind::SpvExtInst { .. } => {}
         }

--- a/src/qptr/lower.rs
+++ b/src/qptr/lower.rs
@@ -616,7 +616,10 @@ impl LowerFromSpvPtrInstsInFunc<'_> {
 
         match data_inst_form_def.kind {
             // Known semantics, no need to preserve SPIR-V pointer information.
-            DataInstKind::Scalar(_) | DataInstKind::FuncCall(_) | DataInstKind::QPtr(_) => return,
+            DataInstKind::Scalar(_)
+            | DataInstKind::Vector(_)
+            | DataInstKind::FuncCall(_)
+            | DataInstKind::QPtr(_) => return,
 
             DataInstKind::SpvInst(_) | DataInstKind::SpvExtInst { .. } => {}
         }

--- a/src/scalar.rs
+++ b/src/scalar.rs
@@ -1,0 +1,198 @@
+//! Scalar (`bool`, integer, and floating-point) types and associated functionality.
+//!
+//! **Note**: pointers are never scalars (like SPIR-V, but unlike other IRs).
+
+// HACK(eddyb) this could be some `struct` with private fields, but this `enum`
+// is only 2 bytes in size, and has better ergonomics overall.
+#[derive(Copy, Clone, PartialEq, Eq, Hash)]
+pub enum Type {
+    Bool,
+    SInt(IntWidth),
+    UInt(IntWidth),
+    Float(FloatWidth),
+}
+
+impl Type {
+    // HACK(eddyb) only common widths, as a convenience, expand as-needed.
+    pub const S32: Type = Type::SInt(IntWidth::I32);
+    pub const U32: Type = Type::UInt(IntWidth::I32);
+    pub const F32: Type = Type::Float(FloatWidth::F32);
+    pub const F64: Type = Type::Float(FloatWidth::F64);
+
+    pub const fn bit_width(self) -> u32 {
+        match self {
+            Type::Bool => 1,
+            Type::SInt(w) | Type::UInt(w) => w.bits(),
+            Type::Float(w) => w.bits(),
+        }
+    }
+}
+
+/// Bit-width of a supported integer type (only power-of-two multiples of a byte).
+#[derive(Copy, Clone, PartialEq, Eq, Hash)]
+pub struct IntWidth {
+    // HACK(eddyb) this is so compact that only 3 bits of this byte are used
+    // to encode integer types from `i8` to `i128`, and so `Type` could all fit
+    // in one byte, but that'd need a new `enum` for `Bool`/`{S,U}Int`/`Float`.
+    log2_bytes: u8,
+}
+
+impl IntWidth {
+    pub const I8: Self = Self::try_from_bits_unwrap(8);
+    pub const I16: Self = Self::try_from_bits_unwrap(16);
+    pub const I32: Self = Self::try_from_bits_unwrap(32);
+    pub const I64: Self = Self::try_from_bits_unwrap(64);
+    pub const I128: Self = Self::try_from_bits_unwrap(128);
+
+    // FIXME(eddyb) remove when `Option::unwrap` is stabilized.
+    const fn try_from_bits_unwrap(bits: u32) -> Self {
+        match Self::try_from_bits(bits) {
+            Some(w) => w,
+            None => unreachable!(),
+        }
+    }
+
+    pub const fn try_from_bits(bits: u32) -> Option<Self> {
+        if bits % 8 != 0 {
+            return None;
+        }
+        let bytes = bits / 8;
+        match bytes.checked_ilog2() {
+            Some(log2_bytes_u32) => {
+                let log2_bytes = log2_bytes_u32 as u8;
+                assert!(log2_bytes as u32 == log2_bytes_u32);
+                Some(Self { log2_bytes })
+            }
+            None => None,
+        }
+    }
+
+    pub const fn bits(self) -> u32 {
+        8 * (1 << self.log2_bytes)
+    }
+}
+
+/// Bit-width of a supported floating-point type (only power-of-two multiples of a byte).
+#[derive(Copy, Clone, PartialEq, Eq, Hash)]
+pub struct FloatWidth(IntWidth);
+
+impl FloatWidth {
+    pub const F32: Self = Self::try_from_bits_unwrap(32);
+    pub const F64: Self = Self::try_from_bits_unwrap(64);
+
+    // FIXME(eddyb) remove when `Option::unwrap` is stabilized.
+    const fn try_from_bits_unwrap(bits: u32) -> Self {
+        match Self::try_from_bits(bits) {
+            Some(w) => w,
+            None => unreachable!(),
+        }
+    }
+
+    pub const fn try_from_bits(bits: u32) -> Option<Self> {
+        match IntWidth::try_from_bits(bits) {
+            Some(w) => Some(Self(w)),
+            None => None,
+        }
+    }
+
+    pub const fn bits(self) -> u32 {
+        self.0.bits()
+    }
+}
+
+// FIXME(eddyb) document the 128-bit limitations.
+// HACK(eddyb) `(Type, u128)` would waste almost half its size on padding, and
+// packing will only impact accessing the `bits`, while allowing e.g. being
+// wrapped in an outer `enum`, before reaching the same size as `(u128, u128)`.
+#[repr(packed)]
+#[derive(Copy, Clone, PartialEq, Eq, Hash)]
+pub struct Const {
+    ty: Type,
+    bits: u128,
+}
+
+impl Const {
+    pub const FALSE: Const = Const::from_bool(false);
+    pub const TRUE: Const = Const::from_bool(true);
+
+    // FIXME(eddyb) document the panic conditions.
+    // FIXME(eddyb) make this public?
+    const fn from_bits_trunc(ty: Type, bits: u128) -> Const {
+        // FIXME(eddyb) this ensures `Const`s cannot be created when that could
+        // potentially need more than 128 bits for e.g. constant-folding.
+        let width = ty.bit_width();
+        assert!(width <= 128);
+
+        Const { ty, bits: bits & (!0u128 >> (128 - width)) }
+    }
+
+    // FIXME(eddyb) document the panic conditions.
+    pub const fn from_bits(ty: Type, bits: u128) -> Const {
+        let ct_trunc = Const::from_bits_trunc(ty, bits);
+        assert!(ct_trunc.bits == bits);
+        ct_trunc
+    }
+
+    pub const fn try_from_bits(ty: Type, bits: u128) -> Option<Const> {
+        let ct_trunc = Const::from_bits_trunc(ty, bits);
+        if ct_trunc.bits == bits { Some(ct_trunc) } else { None }
+    }
+
+    pub const fn from_bool(v: bool) -> Const {
+        Const::from_bits(Type::Bool, v as u128)
+    }
+
+    pub const fn from_u32(v: u32) -> Const {
+        Const::from_bits(Type::U32, v as u128)
+    }
+
+    /// Returns `Some(ct)` iff `ty` is `{S,U}Int` and can represent `v: i128`
+    /// (i.e. `ct` has the same sign and absolute value as `v` does).
+    pub fn int_try_from_i128(ty: Type, v: i128) -> Option<Const> {
+        let ct_trunc = Const::from_bits_trunc(ty, v as u128);
+        (ct_trunc.int_as_i128() == Some(v)).then_some(ct_trunc)
+    }
+
+    pub const fn ty(&self) -> Type {
+        self.ty
+    }
+
+    pub const fn bits(&self) -> u128 {
+        self.bits
+    }
+
+    /// Returns `Some(v)` iff `self` is `{S,U}Int` and representable by `v: i128`
+    /// (i.e. `self` has the same sign and absolute value as `v` does).
+    pub fn int_as_i128(&self) -> Option<i128> {
+        match self.ty {
+            Type::Bool | Type::Float(_) => None,
+            Type::SInt(_) => {
+                let width = self.ty.bit_width();
+                Some((self.bits as i128) << (128 - width) >> (128 - width))
+            }
+            Type::UInt(_) => self.bits.try_into().ok(),
+        }
+    }
+
+    /// Returns `Some(v)` iff `self` is `{S,U}Int` and representable by `v: u128`
+    /// (i.e. `self` is positive and has the same absolute value as `v` does).
+    pub fn int_as_u128(&self) -> Option<u128> {
+        match self.ty {
+            Type::Bool | Type::Float(_) => None,
+            Type::SInt(_) => self.int_as_i128()?.try_into().ok(),
+            Type::UInt(_) => Some(self.bits),
+        }
+    }
+
+    /// Returns `Some(v)` iff `self` is `{S,U}Int` and representable by `v: i32`
+    /// (i.e. `self` has the same sign and absolute value as `v` does).
+    pub fn int_as_i32(&self) -> Option<i32> {
+        self.int_as_i128()?.try_into().ok()
+    }
+
+    /// Returns `Some(v)` iff `self` is `{S,U}Int` and representable by `v: u32`
+    /// (i.e. `self` is positive and has the same absolute value as `v` does).
+    pub fn int_as_u32(&self) -> Option<u32> {
+        self.int_as_u128()?.try_into().ok()
+    }
+}

--- a/src/spv/canonical.rs
+++ b/src/spv/canonical.rs
@@ -165,7 +165,11 @@ def_mappable_ops! {
 }
 
 impl scalar::Const {
-    fn try_decode_from_spv_imms(ty: scalar::Type, imms: &[spv::Imm]) -> Option<scalar::Const> {
+    // HACK(eddyb) this is not private so `spv::lower` can use it for `OpSwitch`.
+    pub(super) fn try_decode_from_spv_imms(
+        ty: scalar::Type,
+        imms: &[spv::Imm],
+    ) -> Option<scalar::Const> {
         // FIXME(eddyb) don't hardcode the 128-bit limitation,
         // but query `scalar::Const` somehow instead.
         if ty.bit_width() > 128 {
@@ -198,7 +202,8 @@ impl scalar::Const {
         }
     }
 
-    fn encode_as_spv_imms(&self) -> impl Iterator<Item = spv::Imm> {
+    // HACK(eddyb) this is not private so `spv::lift` can use it for `OpSwitch`.
+    pub(super) fn encode_as_spv_imms(&self) -> impl Iterator<Item = spv::Imm> {
         let wk = &spec::Spec::get().well_known;
 
         let ty = self.ty();

--- a/src/spv/canonical.rs
+++ b/src/spv/canonical.rs
@@ -1,0 +1,70 @@
+//! Bidirectional (SPIR-V <-> SPIR-T) "canonical mappings".
+//!
+//! Both directions are defined close together as much as possible, to:
+//! - limit code duplication, making it easy to add more mappings
+//! - limit how much they could even go out of sync over time
+//! - prevent naming e.g. SPIR-V opcodes, outside canonicalization
+//
+// FIXME(eddyb) should interning attempts check/apply these canonicalizations?
+
+use crate::spv::{self, spec};
+use crate::ConstKind;
+use lazy_static::lazy_static;
+
+// FIXME(eddyb) these ones could maybe make use of build script generation.
+macro_rules! def_mappable_ops {
+    ($($op:ident),+ $(,)?) => {
+        #[allow(non_snake_case)]
+        struct MappableOps {
+            $($op: spec::Opcode,)+
+        }
+        impl MappableOps {
+            #[inline(always)]
+            #[must_use]
+            pub fn get() -> &'static MappableOps {
+                lazy_static! {
+                    static ref MAPPABLE_OPS: MappableOps = {
+                        let spv_spec = spec::Spec::get();
+                        MappableOps {
+                            $($op: spv_spec.instructions.lookup(stringify!($op)).unwrap(),)+
+                        }
+                    };
+                }
+                &MAPPABLE_OPS
+            }
+        }
+    };
+}
+def_mappable_ops! {
+    OpUndef,
+}
+
+// FIXME(eddyb) decide on a visibility scope - `pub(super)` avoids some mistakes
+// (using these methods outside of `spv::{lower,lift}`), but may be too restrictive.
+impl spv::Inst {
+    pub(super) fn as_canonical_const(&self) -> Option<ConstKind> {
+        let Self { opcode, imms } = self;
+        let (&opcode, imms) = (opcode, &imms[..]);
+
+        let mo = MappableOps::get();
+
+        if opcode == mo.OpUndef {
+            assert_eq!(imms.len(), 0);
+            Some(ConstKind::Undef)
+        } else {
+            None
+        }
+    }
+
+    pub(super) fn from_canonical_const(const_kind: &ConstKind) -> Option<Self> {
+        let mo = MappableOps::get();
+
+        match const_kind {
+            ConstKind::Undef => Some(mo.OpUndef.into()),
+
+            ConstKind::PtrToGlobalVar(_)
+            | ConstKind::SpvInst { .. }
+            | ConstKind::SpvStringLiteralForExtInst(_) => None,
+        }
+    }
+}

--- a/src/spv/canonical.rs
+++ b/src/spv/canonical.rs
@@ -8,7 +8,7 @@
 // FIXME(eddyb) should interning attempts check/apply these canonicalizations?
 
 use crate::spv::{self, spec};
-use crate::ConstKind;
+use crate::{scalar, ConstKind, Context, Type, TypeKind};
 use lazy_static::lazy_static;
 
 // FIXME(eddyb) these ones could maybe make use of build script generation.
@@ -36,23 +36,174 @@ macro_rules! def_mappable_ops {
     };
 }
 def_mappable_ops! {
+    OpTypeBool,
+    OpTypeInt,
+    OpTypeFloat,
+
     OpUndef,
+    OpConstantFalse,
+    OpConstantTrue,
+    OpConstant,
+}
+
+impl scalar::Const {
+    fn try_decode_from_spv_imms(ty: scalar::Type, imms: &[spv::Imm]) -> Option<scalar::Const> {
+        // FIXME(eddyb) don't hardcode the 128-bit limitation,
+        // but query `scalar::Const` somehow instead.
+        if ty.bit_width() > 128 {
+            return None;
+        }
+        let imm_words = usize::try_from(ty.bit_width().div_ceil(32)).unwrap();
+        if imms.len() != imm_words {
+            return None;
+        }
+        let mut bits = 0;
+        for (i, &imm) in imms.iter().enumerate() {
+            let w = match imm {
+                spv::Imm::Short(_, w) if imm_words == 1 => w,
+                spv::Imm::LongStart(_, w) if i == 0 && imm_words > 1 => w,
+                spv::Imm::LongCont(_, w) if i > 0 => w,
+                _ => return None,
+            };
+            bits |= (w as u128) << (i * 32);
+        }
+
+        // HACK(eddyb) signed integers are encoded sign-extended into immediates.
+        if let scalar::Type::SInt(_) = ty {
+            let imm_width = imm_words * 32;
+            scalar::Const::int_try_from_i128(
+                ty,
+                (bits as i128) << (128 - imm_width) >> (128 - imm_width),
+            )
+        } else {
+            scalar::Const::try_from_bits(ty, bits)
+        }
+    }
+
+    fn encode_as_spv_imms(&self) -> impl Iterator<Item = spv::Imm> {
+        let wk = &spec::Spec::get().well_known;
+
+        let ty = self.ty();
+        let imm_words = ty.bit_width().div_ceil(32);
+
+        let bits = self.bits();
+
+        // HACK(eddyb) signed integers are encoded sign-extended into immediates.
+        let bits = if let scalar::Type::SInt(_) = ty {
+            let imm_width = imm_words * 32;
+            (self.int_as_i128().unwrap() as u128) & (!0 >> (128 - imm_width))
+        } else {
+            bits
+        };
+
+        (0..imm_words).map(move |i| {
+            let k = wk.LiteralContextDependentNumber;
+            let w = (bits >> (i * 32)) as u32;
+            if imm_words == 1 {
+                spv::Imm::Short(k, w)
+            } else if i == 0 {
+                spv::Imm::LongStart(k, w)
+            } else {
+                spv::Imm::LongCont(k, w)
+            }
+        })
+    }
 }
 
 // FIXME(eddyb) decide on a visibility scope - `pub(super)` avoids some mistakes
 // (using these methods outside of `spv::{lower,lift}`), but may be too restrictive.
 impl spv::Inst {
-    pub(super) fn as_canonical_const(&self) -> Option<ConstKind> {
+    // HACK(eddyb) exported only for `spv::read`/`LiteralContextDependentNumber`.
+    pub(super) fn int_or_float_type_bit_width(&self) -> Option<u32> {
+        let mo = MappableOps::get();
+
+        match self.imms[..] {
+            [spv::Imm::Short(_, bit_width), _] if self.opcode == mo.OpTypeInt => Some(bit_width),
+            [spv::Imm::Short(_, bit_width)] if self.opcode == mo.OpTypeFloat => Some(bit_width),
+            _ => None,
+        }
+    }
+
+    // FIXME(eddyb) automate bidirectional mappings more (although the need
+    // for conditional, i.e. "partial", mappings, adds a lot of complexity).
+    pub(super) fn as_canonical_type(&self) -> Option<TypeKind> {
         let Self { opcode, imms } = self;
         let (&opcode, imms) = (opcode, &imms[..]);
 
         let mo = MappableOps::get();
 
-        if opcode == mo.OpUndef {
-            assert_eq!(imms.len(), 0);
-            Some(ConstKind::Undef)
-        } else {
-            None
+        let int_width = || scalar::IntWidth::try_from_bits(self.int_or_float_type_bit_width()?);
+        match imms {
+            [] if opcode == mo.OpTypeBool => Some(scalar::Type::Bool.into()),
+            &[_, spv::Imm::Short(_, 0)] if opcode == mo.OpTypeInt => {
+                Some(scalar::Type::UInt(int_width()?).into())
+            }
+            &[_, spv::Imm::Short(_, 1)] if opcode == mo.OpTypeInt => {
+                Some(scalar::Type::SInt(int_width()?).into())
+            }
+            [_] if opcode == mo.OpTypeFloat => Some(
+                scalar::Type::Float(scalar::FloatWidth::try_from_bits(
+                    self.int_or_float_type_bit_width()?,
+                )?)
+                .into(),
+            ),
+            _ => None,
+        }
+    }
+
+    pub(super) fn from_canonical_type(type_kind: &TypeKind) -> Option<Self> {
+        let wk = &spec::Spec::get().well_known;
+        let mo = MappableOps::get();
+
+        match type_kind {
+            &TypeKind::Scalar(ty) => match ty {
+                scalar::Type::Bool => Some(mo.OpTypeBool.into()),
+                scalar::Type::SInt(w) | scalar::Type::UInt(w) => Some(spv::Inst {
+                    opcode: mo.OpTypeInt,
+                    imms: [
+                        spv::Imm::Short(wk.LiteralInteger, w.bits()),
+                        spv::Imm::Short(
+                            wk.LiteralInteger,
+                            matches!(ty, scalar::Type::SInt(_)) as u32,
+                        ),
+                    ]
+                    .into_iter()
+                    .collect(),
+                }),
+                scalar::Type::Float(w) => Some(spv::Inst {
+                    opcode: mo.OpTypeFloat,
+                    imms: [spv::Imm::Short(wk.LiteralInteger, w.bits())].into_iter().collect(),
+                }),
+            },
+
+            TypeKind::QPtr | TypeKind::SpvInst { .. } | TypeKind::SpvStringLiteralForExtInst => {
+                None
+            }
+        }
+    }
+
+    // HACK(eddyb) this only exists as a helper for `spv::lower`.
+    pub(super) fn always_lower_as_const(&self) -> bool {
+        let mo = MappableOps::get();
+        mo.OpUndef == self.opcode
+    }
+
+    // FIXME(eddyb) automate bidirectional mappings more (although the need
+    // for conditional, i.e. "partial", mappings, adds a lot of complexity).
+    pub(super) fn as_canonical_const(&self, cx: &Context, ty: Type) -> Option<ConstKind> {
+        let Self { opcode, imms } = self;
+        let (&opcode, imms) = (opcode, &imms[..]);
+
+        let mo = MappableOps::get();
+
+        match imms {
+            [] if opcode == mo.OpUndef => Some(ConstKind::Undef),
+            [] if opcode == mo.OpConstantFalse => Some(scalar::Const::FALSE.into()),
+            [] if opcode == mo.OpConstantTrue => Some(scalar::Const::TRUE.into()),
+            _ if opcode == mo.OpConstant => {
+                Some(scalar::Const::try_decode_from_spv_imms(ty.as_scalar(cx)?, imms)?.into())
+            }
+            _ => None,
         }
     }
 
@@ -61,6 +212,11 @@ impl spv::Inst {
 
         match const_kind {
             ConstKind::Undef => Some(mo.OpUndef.into()),
+            ConstKind::Scalar(scalar::Const::FALSE) => Some(mo.OpConstantFalse.into()),
+            ConstKind::Scalar(scalar::Const::TRUE) => Some(mo.OpConstantTrue.into()),
+            ConstKind::Scalar(ct) => {
+                Some(spv::Inst { opcode: mo.OpConstant, imms: ct.encode_as_spv_imms().collect() })
+            }
 
             ConstKind::PtrToGlobalVar(_)
             | ConstKind::SpvInst { .. }

--- a/src/spv/lift.rs
+++ b/src/spv/lift.rs
@@ -1309,6 +1309,14 @@ impl LazyInst<'_, '_> {
                 ids: [merge_label_id, continue_label_id].into_iter().collect(),
             },
             Self::Terminator { parent_func, terminator } => {
+                let mut ids: SmallVec<[_; 4]> = terminator
+                    .inputs
+                    .iter()
+                    .map(|&v| value_to_id(parent_func, v))
+                    .chain(terminator.targets.iter().map(|&target| parent_func.label_ids[&target]))
+                    .collect();
+
+                // FIXME(eddyb) move some of this to `spv::canonical`.
                 let inst = match &*terminator.kind {
                     cfg::ControlInstKind::Unreachable => wk.OpUnreachable.into(),
                     cfg::ControlInstKind::Return => {
@@ -1327,23 +1335,21 @@ impl LazyInst<'_, '_> {
                     cfg::ControlInstKind::SelectBranch(SelectionKind::BoolCond) => {
                         wk.OpBranchConditional.into()
                     }
-                    cfg::ControlInstKind::SelectBranch(SelectionKind::SpvInst(inst)) => {
-                        inst.clone()
+                    cfg::ControlInstKind::SelectBranch(SelectionKind::Switch { case_consts }) => {
+                        // HACK(eddyb) move the default case from last back to first.
+                        let default_target = ids.pop().unwrap();
+                        ids.insert(1, default_target);
+
+                        spv::Inst {
+                            opcode: wk.OpSwitch,
+                            imms: case_consts
+                                .iter()
+                                .flat_map(|ct| ct.encode_as_spv_imms())
+                                .collect(),
+                        }
                     }
                 };
-                spv::InstWithIds {
-                    without_ids: inst,
-                    result_type_id: None,
-                    result_id: None,
-                    ids: terminator
-                        .inputs
-                        .iter()
-                        .map(|&v| value_to_id(parent_func, v))
-                        .chain(
-                            terminator.targets.iter().map(|&target| parent_func.label_ids[&target]),
-                        )
-                        .collect(),
-                }
+                spv::InstWithIds { without_ids: inst, result_type_id: None, result_id: None, ids }
             }
             Self::OpFunctionEnd => spv::InstWithIds {
                 without_ids: wk.OpFunctionEnd.into(),

--- a/src/spv/lift.rs
+++ b/src/spv/lift.rs
@@ -121,8 +121,22 @@ impl Visitor<'_> for NeedsIdsCollector<'_> {
             return;
         }
         let ty_def = &self.cx[ty];
+
+        // HACK(eddyb) there isn't a great way to handle canonical types, but
+        // perhaps this result should be recorded in `self.globals`?
+        if let Some((_spv_inst, type_and_const_inputs)) =
+            spv::Inst::from_canonical_type(self.cx, &ty_def.kind)
+        {
+            for ty_or_ct in type_and_const_inputs {
+                match ty_or_ct {
+                    TypeOrConst::Type(ty) => self.visit_type_use(ty),
+                    TypeOrConst::Const(ct) => self.visit_const_use(ct),
+                }
+            }
+        }
+
         match ty_def.kind {
-            TypeKind::Scalar(_) | TypeKind::SpvInst { .. } => {}
+            TypeKind::Scalar(_) | TypeKind::Vector(_) | TypeKind::SpvInst { .. } => {}
 
             // FIXME(eddyb) this should be a proper `Result`-based error instead,
             // and/or `spv::lift` should mutate the module for legalization.
@@ -137,6 +151,7 @@ impl Visitor<'_> for NeedsIdsCollector<'_> {
                 );
             }
         }
+
         self.visit_type_def(ty_def);
         self.globals.insert(global);
     }
@@ -146,9 +161,21 @@ impl Visitor<'_> for NeedsIdsCollector<'_> {
             return;
         }
         let ct_def = &self.cx[ct];
+
+        // HACK(eddyb) there isn't a great way to handle canonical consts, but
+        // perhaps this result should be recorded in `self.globals`?
+        if let Some((_spv_inst, const_inputs)) =
+            spv::Inst::from_canonical_const(self.cx, &ct_def.kind)
+        {
+            for ct in const_inputs {
+                self.visit_const_use(ct);
+            }
+        }
+
         match ct_def.kind {
             ConstKind::Undef
             | ConstKind::Scalar(_)
+            | ConstKind::Vector(_)
             | ConstKind::PtrToGlobalVar(_)
             | ConstKind::SpvInst { .. } => {
                 self.visit_const_def(ct_def);
@@ -1030,9 +1057,10 @@ impl LazyInst<'_, '_> {
                                 (gv_decl.attrs, import)
                             }
 
-                            ConstKind::Undef | ConstKind::Scalar(_) | ConstKind::SpvInst { .. } => {
-                                (ct_def.attrs, None)
-                            }
+                            ConstKind::Undef
+                            | ConstKind::Scalar(_)
+                            | ConstKind::Vector(_)
+                            | ConstKind::SpvInst { .. } => (ct_def.attrs, None),
 
                             // Not inserted into `globals` while visiting.
                             ConstKind::SpvStringLiteralForExtInst(_) => unreachable!(),
@@ -1100,19 +1128,16 @@ impl LazyInst<'_, '_> {
             Self::Global(global) => match global {
                 Global::Type(ty) => {
                     let ty_def = &cx[ty];
-                    match spv::Inst::from_canonical_type(&ty_def.kind).ok_or(&ty_def.kind) {
-                        Ok(spv_inst) => spv::InstWithIds {
-                            without_ids: spv_inst,
-                            result_type_id: None,
-                            result_id,
-                            ids: [].into_iter().collect(),
-                        },
-
-                        Err(TypeKind::Scalar(_)) => {
+                    match spv::Inst::from_canonical_type(cx, &ty_def.kind)
+                        .as_ref()
+                        .ok_or(&ty_def.kind)
+                    {
+                        Err(TypeKind::Scalar(_) | TypeKind::Vector(_)) => {
                             unreachable!("should've been handled as canonical")
                         }
 
-                        Err(TypeKind::SpvInst { spv_inst, type_and_const_inputs }) => {
+                        Ok((spv_inst, type_and_const_inputs))
+                        | Err(TypeKind::SpvInst { spv_inst, type_and_const_inputs }) => {
                             spv::InstWithIds {
                                 without_ids: spv_inst.clone(),
                                 result_type_id: None,
@@ -1137,15 +1162,32 @@ impl LazyInst<'_, '_> {
                 }
                 Global::Const(ct) => {
                     let ct_def = &cx[ct];
-                    match spv::Inst::from_canonical_const(&ct_def.kind).ok_or(&ct_def.kind) {
-                        Ok(spv_inst) => spv::InstWithIds {
+                    match spv::Inst::from_canonical_const(cx, &ct_def.kind).ok_or(&ct_def.kind) {
+                        // FIXME(eddyb) this duplicates the `ConstKind::SpvInst`
+                        // case, only due to an inability to pattern-match `Rc`.
+                        Ok((spv_inst, const_inputs)) => spv::InstWithIds {
                             without_ids: spv_inst,
                             result_type_id: Some(ids.globals[&Global::Type(ct_def.ty)]),
                             result_id,
-                            ids: [].into_iter().collect(),
+                            ids: const_inputs
+                                .iter()
+                                .map(|&ct| ids.globals[&Global::Const(ct)])
+                                .collect(),
                         },
+                        Err(ConstKind::SpvInst { spv_inst_and_const_inputs }) => {
+                            let (spv_inst, const_inputs) = &**spv_inst_and_const_inputs;
+                            spv::InstWithIds {
+                                without_ids: spv_inst.clone(),
+                                result_type_id: Some(ids.globals[&Global::Type(ct_def.ty)]),
+                                result_id,
+                                ids: const_inputs
+                                    .iter()
+                                    .map(|&ct| ids.globals[&Global::Const(ct)])
+                                    .collect(),
+                            }
+                        }
 
-                        Err(ConstKind::Undef | ConstKind::Scalar(_)) => {
+                        Err(ConstKind::Undef | ConstKind::Scalar(_) | ConstKind::Vector(_)) => {
                             unreachable!("should've been handled as canonical")
                         }
 
@@ -1179,19 +1221,6 @@ impl LazyInst<'_, '_> {
                                 result_type_id: Some(ids.globals[&Global::Type(ct_def.ty)]),
                                 result_id,
                                 ids: initializer.into_iter().collect(),
-                            }
-                        }
-
-                        Err(ConstKind::SpvInst { spv_inst_and_const_inputs }) => {
-                            let (spv_inst, const_inputs) = &**spv_inst_and_const_inputs;
-                            spv::InstWithIds {
-                                without_ids: spv_inst.clone(),
-                                result_type_id: Some(ids.globals[&Global::Type(ct_def.ty)]),
-                                result_id,
-                                ids: const_inputs
-                                    .iter()
-                                    .map(|&ct| ids.globals[&Global::Const(ct)])
-                                    .collect(),
                             }
                         }
 

--- a/src/spv/lift.rs
+++ b/src/spv/lift.rs
@@ -254,7 +254,11 @@ impl Visitor<'_> for NeedsIdsCollector<'_> {
                 unreachable!("`DataInstKind::QPtr` should be legalized away before lifting");
             }
 
-            DataInstKind::Scalar(_) | DataInstKind::FuncCall(_) | DataInstKind::SpvInst(_) => {}
+            DataInstKind::Scalar(_)
+            | DataInstKind::Vector(_)
+            | DataInstKind::FuncCall(_)
+            | DataInstKind::SpvInst(_) => {}
+
             DataInstKind::SpvExtInst { ext_set, .. } => {
                 self.ext_inst_imports.insert(&self.cx[ext_set]);
             }
@@ -1286,7 +1290,7 @@ impl LazyInst<'_, '_> {
                     match spv::Inst::from_canonical_data_inst_kind(kind).ok_or(kind) {
                         Ok(spv_inst) => (spv_inst, None),
 
-                        Err(DataInstKind::Scalar(_)) => {
+                        Err(DataInstKind::Scalar(_) | DataInstKind::Vector(_)) => {
                             unreachable!("should've been handled as canonical")
                         }
 

--- a/src/spv/lower.rs
+++ b/src/spv/lower.rs
@@ -1292,7 +1292,13 @@ impl Module {
                     // some "structured regions" replacement for the CFG.
                 } else {
                     let mut ids = &ids[..];
-                    let kind = if opcode == wk.OpFunctionCall {
+                    let kind = if let Some(kind) = raw_inst.without_ids.as_canonical_data_inst_kind(
+                        &cx,
+                        result_type.map(|ty| [ty]).as_ref().map_or(&[][..], |tys| &tys[..]),
+                    ) {
+                        // FIXME(eddyb) sanity-check the number/types of inputs.
+                        kind
+                    } else if opcode == wk.OpFunctionCall {
                         assert!(imms.is_empty());
                         let callee_id = ids[0];
                         let maybe_callee = id_defs

--- a/src/spv/lower.rs
+++ b/src/spv/lower.rs
@@ -589,15 +589,9 @@ impl Module {
 
                 let ty = cx.intern(TypeDef {
                     attrs: mem::take(&mut attrs),
-                    kind: match inst.as_canonical_type() {
-                        Some(type_kind) => {
-                            assert_eq!(type_and_const_inputs.len(), 0);
-                            type_kind
-                        }
-                        None => {
-                            TypeKind::SpvInst { spv_inst: inst.without_ids, type_and_const_inputs }
-                        }
-                    },
+                    kind: inst.as_canonical_type(&cx, &type_and_const_inputs).unwrap_or(
+                        TypeKind::SpvInst { spv_inst: inst.without_ids, type_and_const_inputs },
+                    ),
                 });
                 id_defs.insert(id, IdDef::Type(ty));
 
@@ -626,15 +620,11 @@ impl Module {
                 let ct = cx.intern(ConstDef {
                     attrs: mem::take(&mut attrs),
                     ty,
-                    kind: match inst.as_canonical_const(&cx, ty) {
-                        Some(const_kind) => {
-                            assert_eq!(const_inputs.len(), 0);
-                            const_kind
-                        }
-                        None => ConstKind::SpvInst {
+                    kind: inst.as_canonical_const(&cx, ty, &const_inputs).unwrap_or_else(|| {
+                        ConstKind::SpvInst {
                             spv_inst_and_const_inputs: Rc::new((inst.without_ids, const_inputs)),
-                        },
-                    },
+                        }
+                    }),
                 });
                 id_defs.insert(id, IdDef::Const(ct));
 

--- a/src/spv/mod.rs
+++ b/src/spv/mod.rs
@@ -2,6 +2,7 @@
 
 // NOTE(eddyb) all the modules are declared here, but they're documented "inside"
 // (i.e. using inner doc comments).
+pub mod canonical;
 pub mod lift;
 pub mod lower;
 pub mod print;

--- a/src/spv/spec.rs
+++ b/src/spv/spec.rs
@@ -136,7 +136,6 @@ def_well_known! {
         OpConstantFalse,
         OpConstantTrue,
         OpConstant,
-        OpUndef,
 
         OpVariable,
 

--- a/src/spv/spec.rs
+++ b/src/spv/spec.rs
@@ -117,9 +117,6 @@ def_well_known! {
         OpNoLine,
 
         OpTypeVoid,
-        OpTypeBool,
-        OpTypeInt,
-        OpTypeFloat,
         OpTypeVector,
         OpTypeMatrix,
         OpTypeArray,
@@ -132,10 +129,6 @@ def_well_known! {
         OpTypeSampler,
         OpTypeSampledImage,
         OpTypeAccelerationStructureKHR,
-
-        OpConstantFalse,
-        OpConstantTrue,
-        OpConstant,
 
         OpVariable,
 

--- a/src/spv/spec.rs
+++ b/src/spv/spec.rs
@@ -129,6 +129,7 @@ def_well_known! {
         OpTypeSampledImage,
         OpTypeAccelerationStructureKHR,
 
+        // FIXME(eddyb) hide these from code, lowering should handle most cases.
         OpConstantComposite,
 
         OpVariable,
@@ -159,6 +160,11 @@ def_well_known! {
         OpPtrAccessChain,
         OpInBoundsPtrAccessChain,
         OpBitcast,
+
+        // FIXME(eddyb) hide these from code, lowering should handle most cases.
+        OpCompositeInsert,
+        OpCompositeExtract,
+        OpCompositeConstruct,
     ],
     operand_kind: OperandKind = [
         Capability,

--- a/src/spv/spec.rs
+++ b/src/spv/spec.rs
@@ -117,7 +117,6 @@ def_well_known! {
         OpNoLine,
 
         OpTypeVoid,
-        OpTypeVector,
         OpTypeMatrix,
         OpTypeArray,
         OpTypeRuntimeArray,
@@ -129,6 +128,8 @@ def_well_known! {
         OpTypeSampler,
         OpTypeSampledImage,
         OpTypeAccelerationStructureKHR,
+
+        OpConstantComposite,
 
         OpVariable,
 

--- a/src/spv/spec.rs
+++ b/src/spv/spec.rs
@@ -175,6 +175,7 @@ def_well_known! {
         LiteralExtInstInteger,
         LiteralString,
         LiteralContextDependentNumber,
+        LiteralSpecConstantOpInteger,
     ],
     // FIXME(eddyb) find a way to namespace these to avoid conflicts.
     addressing_model: u32 = [

--- a/src/transform.rs
+++ b/src/transform.rs
@@ -424,7 +424,9 @@ impl InnerTransform for TypeDef {
         transform!({
             attrs -> transformer.transform_attr_set_use(*attrs),
             kind -> match kind {
-                TypeKind::QPtr | TypeKind::SpvStringLiteralForExtInst => Transformed::Unchanged,
+                TypeKind::Scalar(_)
+                | TypeKind::QPtr
+                | TypeKind::SpvStringLiteralForExtInst => Transformed::Unchanged,
 
                 TypeKind::SpvInst { spv_inst, type_and_const_inputs } => Transformed::map_iter(
                     type_and_const_inputs.iter(),
@@ -458,6 +460,7 @@ impl InnerTransform for ConstDef {
             ty -> transformer.transform_type_use(*ty),
             kind -> match kind {
                 ConstKind::Undef
+                | ConstKind::Scalar(_)
                 | ConstKind::SpvStringLiteralForExtInst(_) => Transformed::Unchanged,
 
                 ConstKind::PtrToGlobalVar(gv) => transform!({

--- a/src/transform.rs
+++ b/src/transform.rs
@@ -425,6 +425,7 @@ impl InnerTransform for TypeDef {
             attrs -> transformer.transform_attr_set_use(*attrs),
             kind -> match kind {
                 TypeKind::Scalar(_)
+                | TypeKind::Vector(_)
                 | TypeKind::QPtr
                 | TypeKind::SpvStringLiteralForExtInst => Transformed::Unchanged,
 
@@ -461,6 +462,7 @@ impl InnerTransform for ConstDef {
             kind -> match kind {
                 ConstKind::Undef
                 | ConstKind::Scalar(_)
+                | ConstKind::Vector(_)
                 | ConstKind::SpvStringLiteralForExtInst(_) => Transformed::Unchanged,
 
                 ConstKind::PtrToGlobalVar(gv) => transform!({

--- a/src/transform.rs
+++ b/src/transform.rs
@@ -724,6 +724,7 @@ impl InnerTransform for DataInstFormDef {
                     | QPtrOp::Store => Transformed::Unchanged,
                 },
                 DataInstKind::Scalar(_)
+                | DataInstKind::Vector(_)
                 | DataInstKind::SpvInst(_)
                 | DataInstKind::SpvExtInst { .. } => Transformed::Unchanged,
             },

--- a/src/transform.rs
+++ b/src/transform.rs
@@ -457,6 +457,9 @@ impl InnerTransform for ConstDef {
             attrs -> transformer.transform_attr_set_use(*attrs),
             ty -> transformer.transform_type_use(*ty),
             kind -> match kind {
+                ConstKind::Undef
+                | ConstKind::SpvStringLiteralForExtInst(_) => Transformed::Unchanged,
+
                 ConstKind::PtrToGlobalVar(gv) => transform!({
                     gv -> transformer.transform_global_var_use(*gv),
                 } => ConstKind::PtrToGlobalVar(gv)),
@@ -470,7 +473,6 @@ impl InnerTransform for ConstDef {
                         spv_inst_and_const_inputs: Rc::new((spv_inst.clone(), new_iter.collect())),
                     })
                 }
-                ConstKind::SpvStringLiteralForExtInst(_) => Transformed::Unchanged
             },
         } => Self {
             attrs,

--- a/src/transform.rs
+++ b/src/transform.rs
@@ -721,7 +721,9 @@ impl InnerTransform for DataInstFormDef {
                     | QPtrOp::Load
                     | QPtrOp::Store => Transformed::Unchanged,
                 },
-                DataInstKind::SpvInst(_) | DataInstKind::SpvExtInst { .. } => Transformed::Unchanged,
+                DataInstKind::Scalar(_)
+                | DataInstKind::SpvInst(_)
+                | DataInstKind::SpvExtInst { .. } => Transformed::Unchanged,
             },
             // FIXME(eddyb) this should be replaced with an impl of `InnerTransform`
             // for `Option<T>` or some other helper, to avoid "manual transpose".

--- a/src/transform.rs
+++ b/src/transform.rs
@@ -640,7 +640,7 @@ impl InnerInPlaceTransform for FuncAtMut<'_, ControlNode> {
                 }
             }
             ControlNodeKind::Select {
-                kind: SelectionKind::BoolCond | SelectionKind::SpvInst(_),
+                kind: SelectionKind::BoolCond | SelectionKind::Switch { case_consts: _ },
                 scrutinee,
                 cases: _,
             } => {
@@ -747,7 +747,7 @@ impl InnerInPlaceTransform for cfg::ControlInst {
             | cfg::ControlInstKind::ExitInvocation(cfg::ExitInvocationKind::SpvInst(_))
             | cfg::ControlInstKind::Branch
             | cfg::ControlInstKind::SelectBranch(
-                SelectionKind::BoolCond | SelectionKind::SpvInst(_),
+                SelectionKind::BoolCond | SelectionKind::Switch { case_consts: _ },
             ) => {}
         }
         for v in inputs {

--- a/src/vector.rs
+++ b/src/vector.rs
@@ -1,0 +1,123 @@
+//! Vector types (small arrays of [`scalar`](crate::scalar)s) and associated functionality.
+//!
+//! **Note**: these are similar to SIMD types in other IRs, but SPIR-V often uses
+//! its `OpTypeVector` to represent geometrical vectors, colors, etc. without any
+//! expectation of SIMD execution (which most GPU execution models use implicitly,
+//! i.e. one non-uniform scalar becomes a hardware SIMD vector, while a high-level
+//! "vector" of N "lanes", becomes N separate hardware SIMD vectors).
+
+use crate::scalar;
+use smallvec::SmallVec;
+use std::num::NonZeroU8;
+use std::rc::Rc;
+
+// FIXME(eddyb) this entire module shorthands "element" as "elem", is that good?
+
+#[derive(Copy, Clone, PartialEq, Eq, Hash)]
+pub struct Type {
+    pub elem: scalar::Type,
+    // FIXME(eddyb) maybe wrap this in a type that abstracts away the encoding?
+    pub elem_count: NonZeroU8,
+}
+
+// FIXME(eddyb) document the 128-bit limitations inherited from `scalar::Const`.
+#[derive(Clone, PartialEq, Eq, Hash)]
+pub struct Const(ConstRepr);
+
+// HACK(eddyb) `#[repr(packed)]` not allowed on `enum`s themselves.
+#[repr(packed)]
+#[derive(Copy, Clone, PartialEq, Eq, Hash)]
+struct Packed<T>(T);
+
+// FIXME(eddyb) maybe build an abstraction for "N-dimensional" bit arrays?
+#[derive(Clone, PartialEq, Eq, Hash)]
+#[repr(u8)]
+enum ConstRepr {
+    // HACK(eddyb) `(Type, u128)` would waste almost half its size on padding, and
+    // packing will only impact accessing the bits, while allowing e.g. being
+    // wrapped in an outer `enum`, before reaching the same size as `(u128, u128)`.
+    Inline(Type, Packed<u128>),
+
+    // HACK(eddyb) this does raise the alignment, but the size and alignment are
+    // kept at one pointer (so likely half of `u128`) - `Packed<Rc<_>>` is sadly
+    // not an option because `#[derive(...)]` + `#[repr(packed)]` often requires
+    // `Copy` in order to be able to safely take references (to a copy of a field).
+    Boxed(Type, Rc<Vec<u128>>),
+}
+
+impl Const {
+    pub const fn ty(&self) -> Type {
+        match self.0 {
+            ConstRepr::Inline(ty, _) | ConstRepr::Boxed(ty, _) => ty,
+        }
+    }
+
+    pub fn from_elems(ty: Type, elems: impl IntoIterator<Item = scalar::Const>) -> Const {
+        let elem_width = ty.elem.bit_width();
+        assert!(elem_width <= 128);
+
+        let expected_elem_count = u32::from(ty.elem_count.get());
+
+        let num_limbs = elem_width.checked_mul(expected_elem_count).unwrap().div_ceil(128);
+        assert_ne!(num_limbs, 0);
+        let mut limbs = SmallVec::<[u128; 1]>::from_elem(0, usize::try_from(num_limbs).unwrap());
+
+        let mut found_elem_count = 0;
+        for ct in elems {
+            let i: u32 = found_elem_count;
+            found_elem_count = found_elem_count.checked_add(1).unwrap();
+            if i >= expected_elem_count {
+                continue;
+            }
+
+            // FIXME(eddyb) get better names (perhaps from miri-like memory?).
+            let first_bit_idx = i.checked_mul(elem_width).unwrap();
+            let limb_idx = first_bit_idx / 128;
+            let intra_limb_first_bit_idx = first_bit_idx % 128;
+            assert!(intra_limb_first_bit_idx + elem_width <= 128);
+
+            limbs[usize::try_from(limb_idx).unwrap()] |= ct.bits() << intra_limb_first_bit_idx;
+        }
+        assert_eq!(found_elem_count, expected_elem_count);
+
+        match limbs.into_inner() {
+            Ok([limb]) => Const(ConstRepr::Inline(ty, Packed(limb))),
+            Err(limbs) => Const(ConstRepr::Boxed(ty, Rc::new(limbs.into_vec()))),
+        }
+    }
+
+    pub fn get_elem(&self, i: usize) -> Option<scalar::Const> {
+        let ty = self.ty();
+        if i >= usize::from(ty.elem_count.get()) {
+            return None;
+        }
+        let i = u32::try_from(i).unwrap();
+        let elem_width = ty.elem.bit_width();
+        assert!(elem_width <= 128);
+
+        // FIXME(eddyb) get better names (perhaps from miri-like memory?).
+        let first_bit_idx = i.checked_mul(elem_width).unwrap();
+        let limb_idx = first_bit_idx / 128;
+        let intra_limb_first_bit_idx = first_bit_idx % 128;
+        assert!(intra_limb_first_bit_idx + elem_width <= 128);
+
+        let limb = match &self.0 {
+            ConstRepr::Inline(_, limb) => {
+                assert_eq!(limb_idx, 0);
+                limb.0
+            }
+            ConstRepr::Boxed(_, limbs) => limbs[usize::try_from(limb_idx).unwrap()],
+        };
+
+        Some(scalar::Const::from_bits(
+            ty.elem,
+            (limb >> intra_limb_first_bit_idx) & (!0 >> (128 - elem_width)),
+        ))
+    }
+
+    pub fn elems(&self) -> impl Iterator<Item = scalar::Const> + '_ {
+        let ty = self.ty();
+        // FIXME(eddyb) there should be a more efficient way to do this.
+        (0..usize::from(ty.elem_count.get())).map(|i| self.get_elem(i).unwrap())
+    }
+}

--- a/src/vector.rs
+++ b/src/vector.rs
@@ -121,3 +121,60 @@ impl Const {
         (0..usize::from(ty.elem_count.get())).map(|i| self.get_elem(i).unwrap())
     }
 }
+
+/// Pure operations with vector inputs and/or outputs.
+#[derive(Copy, Clone, PartialEq, Eq, Hash, derive_more::From)]
+pub enum Op {
+    Distribute(scalar::Op),
+    Reduce(ReduceOp),
+
+    // FIXME(eddyb) find a better name for this category of ops.
+    Whole(WholeOp),
+}
+
+#[derive(Copy, Clone, PartialEq, Eq, Hash)]
+pub enum ReduceOp {
+    // FIXME(eddyb) also support all the new integer dot product instructions.
+    Dot,
+    // FIXME(eddyb) model these using their respective `BoolBinOp`s?
+    Any,
+    All,
+}
+
+impl ReduceOp {
+    pub fn name(self) -> &'static str {
+        match self {
+            ReduceOp::Dot => "vec.dot",
+            ReduceOp::Any => "vec.any",
+            ReduceOp::All => "vec.all",
+        }
+    }
+}
+
+// FIXME(eddyb) find a better name for this category of ops.
+// FIXME(eddyb) also support `OpVectorShuffle`.
+#[derive(Copy, Clone, PartialEq, Eq, Hash)]
+pub enum WholeOp {
+    // FIXME(eddyb) better name for this (pack? make? "construct" is too long).
+    New,
+    Extract { elem_idx: u8 },
+    Insert { elem_idx: u8 },
+    DynExtract,
+    DynInsert,
+
+    // FIXME(eddyb) may need a better name to indicate "scalar product".
+    Mul,
+}
+
+impl WholeOp {
+    pub fn name(self) -> &'static str {
+        match self {
+            WholeOp::New => "vec.new",
+            WholeOp::Extract { .. } => "vec.extract",
+            WholeOp::Insert { .. } => "vec.insert",
+            WholeOp::DynExtract => "vec.dyn_extract",
+            WholeOp::DynInsert => "vec.dyn_insert",
+            WholeOp::Mul => "vec.mul",
+        }
+    }
+}

--- a/src/visit.rs
+++ b/src/visit.rs
@@ -542,6 +542,7 @@ impl InnerVisit for DataInstFormDef {
                 | QPtrOp::Store => {}
             },
             DataInstKind::Scalar(_)
+            | DataInstKind::Vector(_)
             | DataInstKind::SpvInst(_)
             | DataInstKind::SpvExtInst { .. } => {}
         }

--- a/src/visit.rs
+++ b/src/visit.rs
@@ -475,7 +475,7 @@ impl<'a> FuncAt<'a, ControlNode> {
                 }
             }
             ControlNodeKind::Select {
-                kind: SelectionKind::BoolCond | SelectionKind::SpvInst(_),
+                kind: SelectionKind::BoolCond | SelectionKind::Switch { case_consts: _ },
                 scrutinee,
                 cases,
             } => {
@@ -556,7 +556,7 @@ impl InnerVisit for cfg::ControlInst {
             | cfg::ControlInstKind::ExitInvocation(cfg::ExitInvocationKind::SpvInst(_))
             | cfg::ControlInstKind::Branch
             | cfg::ControlInstKind::SelectBranch(
-                SelectionKind::BoolCond | SelectionKind::SpvInst(_),
+                SelectionKind::BoolCond | SelectionKind::Switch { case_consts: _ },
             ) => {}
         }
         for v in inputs {

--- a/src/visit.rs
+++ b/src/visit.rs
@@ -315,7 +315,7 @@ impl InnerVisit for TypeDef {
 
         visitor.visit_attr_set_use(*attrs);
         match kind {
-            TypeKind::QPtr | TypeKind::SpvStringLiteralForExtInst => {}
+            TypeKind::Scalar(_) | TypeKind::QPtr | TypeKind::SpvStringLiteralForExtInst => {}
 
             TypeKind::SpvInst { spv_inst: _, type_and_const_inputs } => {
                 for &ty_or_ct in type_and_const_inputs {
@@ -336,7 +336,7 @@ impl InnerVisit for ConstDef {
         visitor.visit_attr_set_use(*attrs);
         visitor.visit_type_use(*ty);
         match kind {
-            ConstKind::Undef | ConstKind::SpvStringLiteralForExtInst(_) => {}
+            ConstKind::Undef | ConstKind::Scalar(_) | ConstKind::SpvStringLiteralForExtInst(_) => {}
 
             &ConstKind::PtrToGlobalVar(gv) => visitor.visit_global_var_use(gv),
             ConstKind::SpvInst { spv_inst_and_const_inputs } => {

--- a/src/visit.rs
+++ b/src/visit.rs
@@ -535,7 +535,9 @@ impl InnerVisit for DataInstFormDef {
                 | QPtrOp::Load
                 | QPtrOp::Store => {}
             },
-            DataInstKind::SpvInst(_) | DataInstKind::SpvExtInst { .. } => {}
+            DataInstKind::Scalar(_)
+            | DataInstKind::SpvInst(_)
+            | DataInstKind::SpvExtInst { .. } => {}
         }
         if let Some(ty) = *output_type {
             visitor.visit_type_use(ty);

--- a/src/visit.rs
+++ b/src/visit.rs
@@ -315,7 +315,10 @@ impl InnerVisit for TypeDef {
 
         visitor.visit_attr_set_use(*attrs);
         match kind {
-            TypeKind::Scalar(_) | TypeKind::QPtr | TypeKind::SpvStringLiteralForExtInst => {}
+            TypeKind::Scalar(_)
+            | TypeKind::Vector(_)
+            | TypeKind::QPtr
+            | TypeKind::SpvStringLiteralForExtInst => {}
 
             TypeKind::SpvInst { spv_inst: _, type_and_const_inputs } => {
                 for &ty_or_ct in type_and_const_inputs {
@@ -336,7 +339,10 @@ impl InnerVisit for ConstDef {
         visitor.visit_attr_set_use(*attrs);
         visitor.visit_type_use(*ty);
         match kind {
-            ConstKind::Undef | ConstKind::Scalar(_) | ConstKind::SpvStringLiteralForExtInst(_) => {}
+            ConstKind::Undef
+            | ConstKind::Scalar(_)
+            | ConstKind::Vector(_)
+            | ConstKind::SpvStringLiteralForExtInst(_) => {}
 
             &ConstKind::PtrToGlobalVar(gv) => visitor.visit_global_var_use(gv),
             ConstKind::SpvInst { spv_inst_and_const_inputs } => {

--- a/src/visit.rs
+++ b/src/visit.rs
@@ -336,6 +336,8 @@ impl InnerVisit for ConstDef {
         visitor.visit_attr_set_use(*attrs);
         visitor.visit_type_use(*ty);
         match kind {
+            ConstKind::Undef | ConstKind::SpvStringLiteralForExtInst(_) => {}
+
             &ConstKind::PtrToGlobalVar(gv) => visitor.visit_global_var_use(gv),
             ConstKind::SpvInst { spv_inst_and_const_inputs } => {
                 let (_spv_inst, const_inputs) = &**spv_inst_and_const_inputs;
@@ -343,7 +345,6 @@ impl InnerVisit for ConstDef {
                     visitor.visit_const_use(ct);
                 }
             }
-            ConstKind::SpvStringLiteralForExtInst(_) => {}
         }
     }
 }


### PR DESCRIPTION
Still very early prototype, needs a lot more features/polish, but I'm glad I finally got to it (been thinking about this idea once in a while, ever since it became obvious to me that a "miri for SPIR-V", and a relatively efficient one, at that, could be built).

As one may be able to tell from the limited amount of ops implemented, first test was Rust-GPU "sky shader":
<img src="https://github.com/EmbarkStudios/spirt/assets/77424/31b7e200-8c90-4d55-a8a4-c8661d797121" height="500">
