### PR TITLE
Combine `TypeCtor`/`ConstCtor` and "ctor args" into a single `TypeKind`/`ConstKind`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased] - ReleaseDate
 
 ### Changed 🛠
+- [PR#51](https://github.com/EmbarkStudios/spirt/pull/51) combined `TypeCtor`/`ConstCtor`
+  and their respective "ctor args", into a single unified `TypeKind`/`ConstKind`
 - [PR#48](https://github.com/EmbarkStudios/spirt/pull/48) changed CFG structurization
   from "maximal loops" to "minimal loops" (computed using Tarjan's SCC algorithm),
   and added `OpLoopMerge` support on top (by extending a "minimal loop" as needed)

--- a/src/cfg.rs
+++ b/src/cfg.rs
@@ -1,13 +1,15 @@
 //! Control-flow graph (CFG) abstractions and utilities.
 
 use crate::{
-    spv, AttrSet, Const, ConstCtor, ConstDef, Context, ControlNode, ControlNodeDef,
+    spv, AttrSet, Const, ConstDef, ConstKind, Context, ControlNode, ControlNodeDef,
     ControlNodeKind, ControlNodeOutputDecl, ControlRegion, ControlRegionDef, EntityList,
     EntityOrientedDenseMap, FuncDefBody, FxIndexMap, FxIndexSet, SelectionKind, Type, TypeCtor,
     TypeDef, Value,
 };
+use itertools::Either;
 use smallvec::SmallVec;
 use std::mem;
+use std::rc::Rc;
 
 /// The control-flow graph (CFG) of a function, as control-flow instructions
 /// ([`ControlInst`]s) attached to [`ControlRegion`]s, as an "action on exit", i.e.
@@ -128,7 +130,6 @@ mod sealed {
         }
     }
 }
-use itertools::Either;
 use sealed::IncomingEdgeCount;
 
 struct TraversalState<PreVisit: FnMut(ControlRegion), PostVisit: FnMut(ControlRegion)> {
@@ -552,14 +553,22 @@ impl<'a> Structurizer<'a> {
         let const_true = cx.intern(ConstDef {
             attrs: AttrSet::default(),
             ty: type_bool,
-            ctor: ConstCtor::SpvInst(wk.OpConstantTrue.into()),
-            ctor_args: [].into_iter().collect(),
+            kind: ConstKind::SpvInst {
+                spv_inst_and_const_inputs: Rc::new((
+                    wk.OpConstantTrue.into(),
+                    [].into_iter().collect(),
+                )),
+            },
         });
         let const_false = cx.intern(ConstDef {
             attrs: AttrSet::default(),
             ty: type_bool,
-            ctor: ConstCtor::SpvInst(wk.OpConstantFalse.into()),
-            ctor_args: [].into_iter().collect(),
+            kind: ConstKind::SpvInst {
+                spv_inst_and_const_inputs: Rc::new((
+                    wk.OpConstantFalse.into(),
+                    [].into_iter().collect(),
+                )),
+            },
         });
 
         let (loop_header_to_exit_targets, incoming_edge_counts_including_loop_exits) =
@@ -1435,8 +1444,9 @@ impl<'a> Structurizer<'a> {
         self.cx.intern(ConstDef {
             attrs: AttrSet::default(),
             ty,
-            ctor: ConstCtor::SpvInst(wk.OpUndef.into()),
-            ctor_args: [].into_iter().collect(),
+            kind: ConstKind::SpvInst {
+                spv_inst_and_const_inputs: Rc::new((wk.OpUndef.into(), [].into_iter().collect())),
+            },
         })
     }
 }

--- a/src/cfg.rs
+++ b/src/cfg.rs
@@ -3,8 +3,8 @@
 use crate::{
     spv, AttrSet, Const, ConstDef, ConstKind, Context, ControlNode, ControlNodeDef,
     ControlNodeKind, ControlNodeOutputDecl, ControlRegion, ControlRegionDef, EntityList,
-    EntityOrientedDenseMap, FuncDefBody, FxIndexMap, FxIndexSet, SelectionKind, Type, TypeCtor,
-    TypeDef, Value,
+    EntityOrientedDenseMap, FuncDefBody, FxIndexMap, FxIndexSet, SelectionKind, Type, TypeKind,
+    Value,
 };
 use itertools::Either;
 use smallvec::SmallVec;
@@ -545,10 +545,9 @@ impl<'a> Structurizer<'a> {
     pub fn new(cx: &'a Context, func_def_body: &'a mut FuncDefBody) -> Self {
         // FIXME(eddyb) SPIR-T should have native booleans itself.
         let wk = &spv::spec::Spec::get().well_known;
-        let type_bool = cx.intern(TypeDef {
-            attrs: AttrSet::default(),
-            ctor: TypeCtor::SpvInst(wk.OpTypeBool.into()),
-            ctor_args: [].into_iter().collect(),
+        let type_bool = cx.intern(TypeKind::SpvInst {
+            spv_inst: wk.OpTypeBool.into(),
+            type_and_const_inputs: [].into_iter().collect(),
         });
         let const_true = cx.intern(ConstDef {
             attrs: AttrSet::default(),

--- a/src/passes/qptr.rs
+++ b/src/passes/qptr.rs
@@ -1,4 +1,4 @@
-//! [`QPtr`](crate::TypeCtor::QPtr) transforms.
+//! [`QPtr`](crate::TypeKind::QPtr) transforms.
 
 use crate::visit::{InnerVisit, Visitor};
 use crate::{qptr, DataInstForm};

--- a/src/print/mod.rs
+++ b/src/print/mod.rs
@@ -728,7 +728,7 @@ impl<'a> Printer<'a> {
                     .collect::<Option<SmallVec<[_; 4]>>>()
                     .filter(|all_names| all_names.iter().map(|(_, spv_name)| spv_name).all_equal())
                     .and_then(|all_names| {
-                        let &(_, spv_name) = all_names.get(0)?;
+                        let &(_, spv_name) = all_names.first()?;
                         let name = spv::extract_literal_string(&spv_name.imms).ok()?;
 
                         // This is the point of no return: these `insert`s will
@@ -3118,7 +3118,7 @@ impl Print for FuncAt<'_, DataInst> {
                                 ]),
                             ]
                             .into_iter()
-                            .chain(extra_inputs.get(0).map(|&init| {
+                            .chain(extra_inputs.first().map(|&init| {
                                 pretty::Fragment::new([
                                     printer.pretty_named_argument_prefix("initializer"),
                                     init.print(printer),

--- a/src/qptr/analyze.rs
+++ b/src/qptr/analyze.rs
@@ -7,7 +7,7 @@ use super::{shapes, QPtrAttr, QPtrMemUsage, QPtrOp, QPtrUsage};
 use crate::func_at::FuncAt;
 use crate::visit::{InnerVisit, Visitor};
 use crate::{
-    AddrSpace, Attr, AttrSet, AttrSetDef, Const, ConstCtor, Context, ControlNode, ControlNodeKind,
+    AddrSpace, Attr, AttrSet, AttrSetDef, Const, ConstKind, Context, ControlNode, ControlNodeKind,
     DataInst, DataInstForm, DataInstKind, DeclDef, Diag, EntityList, ExportKey, Exportee, Func,
     FxIndexMap, GlobalVar, Module, OrdAssertEq, Type, TypeCtor, Value,
 };
@@ -872,8 +872,8 @@ impl<'a> InferUsage<'a> {
 
                 let mut generate_usage = |this: &mut Self, ptr: Value, new_usage| {
                     let slot = match ptr {
-                        Value::Const(ct) => match cx[ct].ctor {
-                            ConstCtor::PtrToGlobalVar(gv) => {
+                        Value::Const(ct) => match cx[ct].kind {
+                            ConstKind::PtrToGlobalVar(gv) => {
                                 this.global_var_usages.entry(gv).or_default()
                             }
                             // FIXME(eddyb) may be relevant?

--- a/src/qptr/analyze.rs
+++ b/src/qptr/analyze.rs
@@ -1,4 +1,4 @@
-//! [`QPtr`](crate::TypeCtor::QPtr) usage analysis (for legalizing/lifting).
+//! [`QPtr`](crate::TypeKind::QPtr) usage analysis (for legalizing/lifting).
 
 // HACK(eddyb) sharing layout code with other modules.
 use super::{layout::*, QPtrMemUsageKind};
@@ -9,7 +9,7 @@ use crate::visit::{InnerVisit, Visitor};
 use crate::{
     AddrSpace, Attr, AttrSet, AttrSetDef, Const, ConstKind, Context, ControlNode, ControlNodeKind,
     DataInst, DataInstForm, DataInstKind, DeclDef, Diag, EntityList, ExportKey, Exportee, Func,
-    FxIndexMap, GlobalVar, Module, OrdAssertEq, Type, TypeCtor, Value,
+    FxIndexMap, GlobalVar, Module, OrdAssertEq, Type, TypeKind, Value,
 };
 use itertools::Either;
 use rustc_hash::FxHashMap;
@@ -838,7 +838,7 @@ impl<'a> InferUsage<'a> {
         func: Func,
     ) -> FuncInferUsageResults {
         let cx = self.cx.clone();
-        let is_qptr = |ty: Type| matches!(cx[ty].ctor, TypeCtor::QPtr);
+        let is_qptr = |ty: Type| matches!(cx[ty].kind, TypeKind::QPtr);
 
         let func_decl = &module.funcs[func];
         let mut param_usages: SmallVec<[_; 2]> =

--- a/src/qptr/mod.rs
+++ b/src/qptr/mod.rs
@@ -1,6 +1,6 @@
-//! [`QPtr`](crate::TypeCtor::QPtr)-related type definitions and passes.
+//! [`QPtr`](crate::TypeKind::QPtr)-related type definitions and passes.
 //
-// FIXME(eddyb) consider `#[cfg(doc)] use crate::TypeCtor::QPtr;` for doc comments.
+// FIXME(eddyb) consider `#[cfg(doc)] use crate::TypeKind::QPtr;` for doc comments.
 // FIXME(eddyb) PR description of https://github.com/EmbarkStudios/spirt/pull/24
 // has more useful docs that could be copied here.
 

--- a/src/spv/read.rs
+++ b/src/spv/read.rs
@@ -168,7 +168,7 @@ impl InstParser<'_> {
                     .result_type_id
                     .or_else(|| {
                         // `OpSwitch` takes its literal type from the first operand.
-                        let &id = self.inst.ids.get(0)?;
+                        let &id = self.inst.ids.first()?;
                         self.known_ids.get(&id)?.result_type_id()
                     })
                     .and_then(|id| self.known_ids.get(&id))


### PR DESCRIPTION
The "constructor" idea was cute, but a mistake. At the end of the day (see #1, #50, #29), the direction to move into is simpler and/or flatter types and constants, *not* favoring the hierarchical ones.