### PR TITLE
Add a Vulkan layer for injecting SPIR-V -> SPIR-T -> SPIR-V into any Vulkan users.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,3 +1,6 @@
+[workspace]
+members = ["vk-layer"]
+
 [package]
 name = "spirt"
 description = "Shader-focused IR to target, transform and translate from."

--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ func F0() -> spv.OpTypeVoid {
       v6 = spv.OpIAdd(v1, 1s32): s32
       (v5, v6)
     } else {
-      (spv.OpUndef: s32, spv.OpUndef: s32)
+      (undef: s32, undef: s32)
     }
     (v3, v4) -> (v0, v1)
   } while v2

--- a/README.md
+++ b/README.md
@@ -139,10 +139,10 @@ global_var GV0 in spv.StorageClass.Output: s32
 
 func F0() -> spv.OpTypeVoid {
   loop(v0: s32 <- 1s32, v1: s32 <- 1s32) {
-    v2 = spv.OpSLessThan(v1, 10s32): bool
+    v2 = s.lt(v1, 10s32): bool
     (v3: s32, v4: s32) = if v2 {
-      v5 = spv.OpIMul(v0, v1): s32
-      v6 = spv.OpIAdd(v1, 1s32): s32
+      v5 = i.mul(v0, v1): s32
+      v6 = i.add(v1, 1s32): s32
       (v5, v6)
     } else {
       (undef: s32, undef: s32)

--- a/src/cfg.rs
+++ b/src/cfg.rs
@@ -1568,14 +1568,6 @@ impl<'a> Structurizer<'a> {
     /// Create an undefined constant (as a placeholder where a value needs to be
     /// present, but won't actually be used), of type `ty`.
     fn const_undef(&self, ty: Type) -> Const {
-        // FIXME(eddyb) SPIR-T should have native undef itself.
-        let wk = &spv::spec::Spec::get().well_known;
-        self.cx.intern(ConstDef {
-            attrs: AttrSet::default(),
-            ty,
-            kind: ConstKind::SpvInst {
-                spv_inst_and_const_inputs: Rc::new((wk.OpUndef.into(), [].into_iter().collect())),
-            },
-        })
+        self.cx.intern(ConstDef { attrs: AttrSet::default(), ty, kind: ConstKind::Undef })
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -987,6 +987,12 @@ pub enum DataInstKind {
     #[from]
     Scalar(scalar::Op),
 
+    /// Vector (small array of [`scalar`]s) pure operations.
+    ///
+    /// See also the [`vector`] module for more documentation and definitions.
+    #[from]
+    Vector(vector::Op),
+
     // FIXME(eddyb) try to split this into recursive and non-recursive calls,
     // to avoid needing special handling for recursion where it's impossible.
     FuncCall(Func),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -938,6 +938,12 @@ pub struct DataInstFormDef {
 
 #[derive(Clone, PartialEq, Eq, Hash, derive_more::From)]
 pub enum DataInstKind {
+    /// Scalar (`bool`, integer, and floating-point) pure operations.
+    ///
+    /// See also the [`scalar`] module for more documentation and definitions.
+    #[from]
+    Scalar(scalar::Op),
+
     // FIXME(eddyb) try to split this into recursive and non-recursive calls,
     // to avoid needing special handling for recursion where it's impossible.
     FuncCall(Func),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -168,6 +168,7 @@ pub mod passes {
     pub mod qptr;
 }
 pub mod qptr;
+pub mod scalar;
 pub mod spv;
 
 use smallvec::SmallVec;
@@ -453,16 +454,23 @@ impl<T: Eq> Ord for OrdAssertEq<T> {
 pub use context::Type;
 
 /// Definition for a [`Type`].
-//
-// FIXME(eddyb) maybe special-case some basic types like integers.
 #[derive(PartialEq, Eq, Hash)]
 pub struct TypeDef {
     pub attrs: AttrSet,
     pub kind: TypeKind,
 }
 
-#[derive(Clone, PartialEq, Eq, Hash)]
+#[derive(Clone, PartialEq, Eq, Hash, derive_more::From)]
 pub enum TypeKind {
+    /// Scalar (`bool`, integer, and floating-point) type, with limitations
+    /// on the supported bit-widths (power-of-two multiples of a byte).
+    ///
+    /// **Note**: pointers are never scalars (like SPIR-V, but unlike other IRs).
+    ///
+    /// See also the [`scalar`] module for more documentation and definitions.
+    #[from]
+    Scalar(scalar::Type),
+
     /// "Quasi-pointer", an untyped pointer-like abstract scalar that can represent
     /// both memory locations (in any address space) and other kinds of locations
     /// (e.g. SPIR-V `OpVariable`s in non-memory "storage classes").
@@ -490,12 +498,18 @@ pub enum TypeKind {
     SpvStringLiteralForExtInst,
 }
 
-// HACK(eddyb) this behaves like an implicit conversion for `cx.intern(...)`.
-impl context::InternInCx<Type> for TypeKind {
-    fn intern_in_cx(self, cx: &Context) -> Type {
-        cx.intern(TypeDef { attrs: Default::default(), kind: self })
+// HACK(eddyb) this behaves like an implicit conversion for `cx.intern(...)`,
+// and the macro is only used because coherence bans `impl<T: Into<TypeKind>>`.
+macro_rules! impl_intern_type_kind {
+    ($($kind:ty),+ $(,)?) => {
+        $(impl context::InternInCx<Type> for $kind {
+            fn intern_in_cx(self, cx: &Context) -> Type {
+                cx.intern(TypeDef { attrs: Default::default(), kind: self.into() })
+            }
+        })+
     }
 }
+impl_intern_type_kind!(TypeKind, scalar::Type);
 
 // HACK(eddyb) this is like `Either<Type, Const>`, only used in `TypeKind::SpvInst`,
 // and only because SPIR-V type definitions can references both types and consts.
@@ -503,6 +517,16 @@ impl context::InternInCx<Type> for TypeKind {
 pub enum TypeOrConst {
     Type(Type),
     Const(Const),
+}
+
+// HACK(eddyb) on `Type` instead of `TypeDef` for ergonomics reasons.
+impl Type {
+    pub fn as_scalar(self, cx: &Context) -> Option<scalar::Type> {
+        match cx[self].kind {
+            TypeKind::Scalar(ty) => Some(ty),
+            _ => None,
+        }
+    }
 }
 
 /// Interned handle for a [`ConstDef`](crate::ConstDef) (a constant value).
@@ -518,13 +542,25 @@ pub struct ConstDef {
     pub kind: ConstKind,
 }
 
-#[derive(Clone, PartialEq, Eq, Hash)]
+#[derive(Clone, PartialEq, Eq, Hash, derive_more::From)]
 pub enum ConstKind {
     /// Undeterminate value (i.e. SPIR-V `OpUndef`, LLVM `undef`).
     //
     // FIXME(eddyb) could it be possible to adopt LLVM's newer `poison`+`freeze`
     // model, without being forced to never lift back to `OpUndef`?
     Undef,
+
+    /// Scalar (`bool`, integer, and floating-point) constant, which must have
+    /// a type of [`TypeKind::Scalar`] (of the same [`scalar::Type`]).
+    ///
+    /// See also the [`scalar`] module for more documentation and definitions.
+    //
+    // FIXME(eddyb) maybe document the 128-bit limitation?.
+    // FIXME(eddyb) this technically makes the `scalar::Type` redundant, could
+    // it get out of sync? (perhaps "forced canonicalization" could be used to
+    // enforce that interning simply doesn't allow such scenarios?).
+    #[from]
+    Scalar(scalar::Const),
 
     PtrToGlobalVar(GlobalVar),
 
@@ -538,6 +574,34 @@ pub enum ConstKind {
     /// which can't have literals itself - for non-string literals `OpConstant*`
     /// are readily usable, but only `OpString` is supported for string literals.
     SpvStringLiteralForExtInst(InternedStr),
+}
+
+// HACK(eddyb) this behaves like an implicit conversion for `cx.intern(...)`,
+// like the `TypeKind` one, but this one is even weirder because it also interns
+// the inherent type of the constant, as a `Type` (with empty attributes).
+macro_rules! impl_intern_const_kind {
+    ($($kind:ty),+ $(,)?) => {
+        $(impl context::InternInCx<Const> for $kind {
+            fn intern_in_cx(self, cx: &Context) -> Const {
+                cx.intern(ConstDef {
+                    attrs: Default::default(),
+                    ty: cx.intern(self.ty()),
+                    kind: self.into(),
+                })
+            }
+        })+
+    }
+}
+impl_intern_const_kind!(scalar::Const);
+
+// HACK(eddyb) on `Const` instead of `ConstDef` for ergonomics reasons.
+impl Const {
+    pub fn as_scalar(self, cx: &Context) -> Option<&scalar::Const> {
+        match &cx[self].kind {
+            ConstKind::Scalar(ct) => Some(ct),
+            _ => None,
+        }
+    }
 }
 
 /// Declarations ([`GlobalVarDecl`], [`FuncDecl`]) can contain a full definition,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -520,6 +520,12 @@ pub struct ConstDef {
 
 #[derive(Clone, PartialEq, Eq, Hash)]
 pub enum ConstKind {
+    /// Undeterminate value (i.e. SPIR-V `OpUndef`, LLVM `undef`).
+    //
+    // FIXME(eddyb) could it be possible to adopt LLVM's newer `poison`+`freeze`
+    // model, without being forced to never lift back to `OpUndef`?
+    Undef,
+
     PtrToGlobalVar(GlobalVar),
 
     // HACK(eddyb) this is a fallback case that should become increasingly rare

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -895,13 +895,24 @@ pub enum ControlNodeKind {
     },
 }
 
+// FIXME(eddyb) consider interning this, perhaps in a similar vein to `DataInstForm`.
 #[derive(Clone)]
 pub enum SelectionKind {
     /// Two-case selection based on boolean condition, i.e. `if`-`else`, with
     /// the two cases being "then" and "else" (in that order).
     BoolCond,
 
-    SpvInst(spv::Inst),
+    /// `N+1`-case selection based on comparing an integer scrutinee against
+    /// `N` constants, i.e. `switch`, with the last case being the "default"
+    /// (making it the only case without a matching entry in `case_consts`).
+    Switch {
+        // FIXME(eddyb) avoid some of the `scalar::Const` overhead here, as there
+        // is only a single type and we shouldn't need to store more bits per case,
+        // than the actual width of the integer type.
+        // FIXME(eddyb) consider storing this more like sorted compressed keyset,
+        // as there can be no duplicates, and in many cases it may be contiguous.
+        case_consts: Vec<scalar::Const>,
+    },
 }
 
 /// Entity handle for a [`DataInstDef`](crate::DataInstDef) (an SSA instruction).

--- a/src/print/mod.rs
+++ b/src/print/mod.rs
@@ -24,7 +24,7 @@ use crate::print::multiversion::Versions;
 use crate::qptr::{self, QPtrAttr, QPtrMemUsage, QPtrMemUsageKind, QPtrOp, QPtrUsage};
 use crate::visit::{InnerVisit, Visit, Visitor};
 use crate::{
-    cfg, spv, AddrSpace, Attr, AttrSet, AttrSetDef, Const, ConstDef, ConstKind, Context,
+    cfg, scalar, spv, AddrSpace, Attr, AttrSet, AttrSetDef, Const, ConstDef, ConstKind, Context,
     ControlNode, ControlNodeDef, ControlNodeKind, ControlNodeOutputDecl, ControlRegion,
     ControlRegionDef, ControlRegionInputDecl, DataInst, DataInstDef, DataInstForm, DataInstFormDef,
     DataInstKind, DeclDef, Diag, DiagLevel, DiagMsgPart, EntityListIter, ExportKey, Exportee, Func,
@@ -817,19 +817,13 @@ impl<'a> Printer<'a> {
                                     // here and `TypeDef`'s `Print` impl.
                                     let has_compact_print_or_is_leaf = match &ty_def.kind {
                                         TypeKind::SpvInst { spv_inst, type_and_const_inputs } => {
-                                            [
-                                                wk.OpTypeBool,
-                                                wk.OpTypeInt,
-                                                wk.OpTypeFloat,
-                                                wk.OpTypeVector,
-                                            ]
-                                            .contains(&spv_inst.opcode)
+                                            spv_inst.opcode == wk.OpTypeVector
                                                 || type_and_const_inputs.is_empty()
                                         }
 
-                                        TypeKind::QPtr | TypeKind::SpvStringLiteralForExtInst => {
-                                            true
-                                        }
+                                        TypeKind::Scalar(_)
+                                        | TypeKind::QPtr
+                                        | TypeKind::SpvStringLiteralForExtInst => true,
                                     };
 
                                     ty_def.attrs == AttrSet::default()
@@ -838,28 +832,16 @@ impl<'a> Printer<'a> {
                                 CxInterned::Const(ct) => {
                                     let ct_def = &cx[ct];
 
-                                    // FIXME(eddyb) remove the duplication between
-                                    // here and `ConstDef`'s `Print` impl.
-                                    let (has_compact_print, has_nested_consts) = match &ct_def.kind
-                                    {
+                                    let has_nested_consts = match &ct_def.kind {
                                         ConstKind::SpvInst { spv_inst_and_const_inputs } => {
-                                            let (spv_inst, const_inputs) =
+                                            let (_spv_inst, const_inputs) =
                                                 &**spv_inst_and_const_inputs;
-                                            (
-                                                [
-                                                    wk.OpConstantFalse,
-                                                    wk.OpConstantTrue,
-                                                    wk.OpConstant,
-                                                ]
-                                                .contains(&spv_inst.opcode),
-                                                !const_inputs.is_empty(),
-                                            )
+                                            !const_inputs.is_empty()
                                         }
-                                        _ => (false, false),
+                                        _ => false,
                                     };
 
-                                    ct_def.attrs == AttrSet::default()
-                                        && (has_compact_print || !has_nested_consts)
+                                    ct_def.attrs == AttrSet::default() && !has_nested_consts
                                 }
                             }
                     }
@@ -2380,30 +2362,13 @@ impl Print for TypeDef {
 
         // FIXME(eddyb) should this be done by lowering SPIR-V types to SPIR-T?
         let kw = |kw| printer.declarative_keyword_style().apply(kw).into();
+        #[allow(irrefutable_let_patterns)]
         let compact_def = if let &TypeKind::SpvInst {
             spv_inst: spv::Inst { opcode, ref imms },
             ref type_and_const_inputs,
         } = kind
         {
-            if opcode == wk.OpTypeBool {
-                Some(kw("bool".into()))
-            } else if opcode == wk.OpTypeInt {
-                let (width, signed) = match imms[..] {
-                    [spv::Imm::Short(_, width), spv::Imm::Short(_, signedness)] => {
-                        (width, signedness != 0)
-                    }
-                    _ => unreachable!(),
-                };
-
-                Some(if signed { kw(format!("s{width}")) } else { kw(format!("u{width}")) })
-            } else if opcode == wk.OpTypeFloat {
-                let width = match imms[..] {
-                    [spv::Imm::Short(_, width)] => width,
-                    _ => unreachable!(),
-                };
-
-                Some(kw(format!("f{width}")))
-            } else if opcode == wk.OpTypeVector {
+            if opcode == wk.OpTypeVector {
                 let (elem_ty, elem_count) = match (&imms[..], &type_and_const_inputs[..]) {
                     (&[spv::Imm::Short(_, elem_count)], &[TypeOrConst::Type(elem_ty)]) => {
                         (elem_ty, elem_count)
@@ -2429,6 +2394,16 @@ impl Print for TypeDef {
                 def
             } else {
                 match kind {
+                    TypeKind::Scalar(ty) => {
+                        let width = ty.bit_width();
+                        kw(match ty {
+                            scalar::Type::Bool => "bool".into(),
+                            scalar::Type::SInt(_) => format!("s{width}"),
+                            scalar::Type::UInt(_) => format!("u{width}"),
+                            scalar::Type::Float(_) => format!("f{width}"),
+                        })
+                    }
+
                     // FIXME(eddyb) should this be shortened to `qtr`?
                     TypeKind::QPtr => printer.declarative_keyword_style().apply("qptr").into(),
 
@@ -2462,71 +2437,22 @@ impl Print for ConstDef {
         let wk = &spv::spec::Spec::get().well_known;
 
         let kw = |kw| printer.declarative_keyword_style().apply(kw).into();
-        let literal_ty_suffix = |ty| {
-            pretty::Styles {
-                // HACK(eddyb) the exact type detracts from the value.
-                color_opacity: Some(0.4),
-                subscript: true,
-                ..printer.declarative_keyword_style()
-            }
-            .apply(ty)
-        };
-        let compact_def = if let ConstKind::SpvInst { spv_inst_and_const_inputs } = kind {
-            let (spv_inst, _const_inputs) = &**spv_inst_and_const_inputs;
-            let &spv::Inst { opcode, ref imms } = spv_inst;
 
-            if opcode == wk.OpConstantFalse {
-                Some(kw("false"))
-            } else if opcode == wk.OpConstantTrue {
-                Some(kw("true"))
-            } else if opcode == wk.OpConstant {
-                // HACK(eddyb) it's simpler to only handle a limited subset of
-                // integer/float bit-widths, for now.
-                let raw_bits = match imms[..] {
-                    [spv::Imm::Short(_, x)] => Some(u64::from(x)),
-                    [spv::Imm::LongStart(_, lo), spv::Imm::LongCont(_, hi)] => {
-                        Some(u64::from(lo) | (u64::from(hi) << 32))
-                    }
-                    _ => None,
-                };
-
-                if let (
-                    Some(raw_bits),
-                    &TypeKind::SpvInst {
-                        spv_inst: spv::Inst { opcode: ty_opcode, imms: ref ty_imms },
-                        ..
-                    },
-                ) = (raw_bits, &printer.cx[*ty].kind)
-                {
-                    if ty_opcode == wk.OpTypeInt {
-                        let (width, signed) = match ty_imms[..] {
-                            [spv::Imm::Short(_, width), spv::Imm::Short(_, signedness)] => {
-                                (width, signedness != 0)
-                            }
-                            _ => unreachable!(),
-                        };
-
-                        if width <= 64 {
-                            let (printed_value, ty) = if signed {
-                                let sext_raw_bits =
-                                    (raw_bits as u128 as i128) << (128 - width) >> (128 - width);
-                                (format!("{sext_raw_bits}"), format!("s{width}"))
-                            } else {
-                                (format!("{raw_bits}"), format!("u{width}"))
-                            };
-                            Some(pretty::Fragment::new([
-                                printer.numeric_literal_style().apply(printed_value),
-                                literal_ty_suffix(ty),
-                            ]))
-                        } else {
-                            None
-                        }
-                    } else if ty_opcode == wk.OpTypeFloat {
-                        let width = match ty_imms[..] {
-                            [spv::Imm::Short(_, width)] => width,
-                            _ => unreachable!(),
-                        };
-
+        let def_without_name = match kind {
+            ConstKind::Undef => pretty::Fragment::new([
+                printer.imperative_keyword_style().apply("undef").into(),
+                printer.pretty_type_ascription_suffix(*ty),
+            ]),
+            ConstKind::Scalar(scalar::Const::FALSE) => kw("false"),
+            ConstKind::Scalar(scalar::Const::TRUE) => kw("true"),
+            ConstKind::Scalar(ct) => {
+                let ty = ct.ty();
+                let width = ty.bit_width();
+                let (maybe_printed_value, ty_prefix) = match ty {
+                    scalar::Type::Bool => unreachable!(),
+                    scalar::Type::SInt(_) => (ct.int_as_i128().map(|x| x.to_string()), 's'),
+                    scalar::Type::UInt(_) => (ct.int_as_u128().map(|x| x.to_string()), 'u'),
+                    scalar::Type::Float(_) => {
                         /// Check that parsing the result of printing produces
                         /// the original bits of the floating-point value, and
                         /// only return `Some` if that is the case.
@@ -2546,69 +2472,81 @@ impl Print for ConstDef {
                             })
                         }
 
-                        let printed_value = match width {
-                            32 => bitwise_roundtrip_float_print(
-                                raw_bits as u32,
-                                f32::from_bits,
-                                f32::to_bits,
-                            ),
-                            64 => bitwise_roundtrip_float_print(
-                                raw_bits,
-                                f64::from_bits,
-                                f64::to_bits,
-                            ),
-                            _ => None,
-                        };
-                        printed_value.map(|s| {
-                            pretty::Fragment::new([
-                                printer.numeric_literal_style().apply(s),
-                                literal_ty_suffix(format!("f{width}")),
-                            ])
-                        })
-                    } else {
-                        None
+                        (
+                            match width {
+                                32 => bitwise_roundtrip_float_print(
+                                    ct.bits() as u32,
+                                    f32::from_bits,
+                                    f32::to_bits,
+                                ),
+                                64 => bitwise_roundtrip_float_print(
+                                    ct.bits() as u64,
+                                    f64::from_bits,
+                                    f64::to_bits,
+                                ),
+                                _ => None,
+                            },
+                            'f',
+                        )
                     }
-                } else {
-                    None
-                }
-            } else {
-                None
-            }
-        } else {
-            None
-        };
-
-        AttrsAndDef {
-            attrs: attrs.print(printer),
-            def_without_name: compact_def.unwrap_or_else(|| match kind {
-                ConstKind::Undef => pretty::Fragment::new([
-                    printer.imperative_keyword_style().apply("undef").into(),
-                    printer.pretty_type_ascription_suffix(*ty),
-                ]),
-                &ConstKind::PtrToGlobalVar(gv) => {
-                    pretty::Fragment::new(["&".into(), gv.print(printer)])
-                }
-
-                ConstKind::SpvInst { spv_inst_and_const_inputs } => {
-                    let (spv_inst, const_inputs) = &**spv_inst_and_const_inputs;
-                    pretty::Fragment::new([
-                        printer.pretty_spv_inst(
-                            printer.spv_op_style(),
-                            spv_inst.opcode,
-                            &spv_inst.imms,
-                            const_inputs.iter().map(|ct| ct.print(printer)),
+                };
+                match maybe_printed_value {
+                    Some(printed_value) => {
+                        let literal_ty_suffix = pretty::Styles {
+                            // HACK(eddyb) the exact type detracts from the value.
+                            color_opacity: Some(0.4),
+                            subscript: true,
+                            ..printer.declarative_keyword_style()
+                        }
+                        .apply(format!("{ty_prefix}{width}"));
+                        pretty::Fragment::new([
+                            printer.numeric_literal_style().apply(printed_value),
+                            literal_ty_suffix,
+                        ])
+                    }
+                    // HACK(eddyb) fallback using the bitwise representation.
+                    None => pretty::Fragment::new([
+                        printer
+                            .demote_style_for_namespace_prefix(printer.declarative_keyword_style())
+                            .apply(format!("{ty_prefix}{width}."))
+                            .into(),
+                        printer.declarative_keyword_style().apply("from_bits").into(),
+                        pretty::join_comma_sep(
+                            "(",
+                            [
+                                // FIXME(eddyb) consider padding this with enough
+                                // leading zeroes for its respective width.
+                                printer.numeric_literal_style().apply(format!("0x{:x}", ct.bits())),
+                            ],
+                            ")",
                         ),
-                        printer.pretty_type_ascription_suffix(*ty),
-                    ])
+                    ]),
                 }
-                &ConstKind::SpvStringLiteralForExtInst(s) => pretty::Fragment::new([
-                    printer.pretty_spv_opcode(printer.spv_op_style(), wk.OpString),
-                    "(".into(),
-                    printer.pretty_string_literal(&printer.cx[s]),
-                    ")".into(),
-                ]),
-            }),
-        }
+            }
+            &ConstKind::PtrToGlobalVar(gv) => {
+                pretty::Fragment::new(["&".into(), gv.print(printer)])
+            }
+
+            ConstKind::SpvInst { spv_inst_and_const_inputs } => {
+                let (spv_inst, const_inputs) = &**spv_inst_and_const_inputs;
+                pretty::Fragment::new([
+                    printer.pretty_spv_inst(
+                        printer.spv_op_style(),
+                        spv_inst.opcode,
+                        &spv_inst.imms,
+                        const_inputs.iter().map(|ct| ct.print(printer)),
+                    ),
+                    printer.pretty_type_ascription_suffix(*ty),
+                ])
+            }
+            &ConstKind::SpvStringLiteralForExtInst(s) => pretty::Fragment::new([
+                printer.pretty_spv_opcode(printer.spv_op_style(), wk.OpString),
+                "(".into(),
+                printer.pretty_string_literal(&printer.cx[s]),
+                ")".into(),
+            ]),
+        };
+        AttrsAndDef { attrs: attrs.print(printer), def_without_name }
     }
 }
 
@@ -3299,21 +3237,17 @@ impl Print for FuncAt<'_, DataInst> {
                 let pseudo_imm_from_value = |v: Value| {
                     if let Value::Const(ct) = v {
                         match &printer.cx[ct].kind {
-                            ConstKind::Undef | ConstKind::PtrToGlobalVar(_) => {}
+                            ConstKind::Undef
+                            | ConstKind::PtrToGlobalVar(_)
+                            | ConstKind::SpvInst { .. } => {}
 
                             &ConstKind::SpvStringLiteralForExtInst(s) => {
                                 return Some(PseudoImm::Str(&printer.cx[s]));
                             }
-                            ConstKind::SpvInst { spv_inst_and_const_inputs } => {
-                                let (spv_inst, _const_inputs) = &**spv_inst_and_const_inputs;
-                                if spv_inst.opcode == wk.OpConstant {
-                                    if let [spv::Imm::Short(_, x)] = spv_inst.imms[..] {
-                                        // HACK(eddyb) only allow unambiguously positive values.
-                                        if i32::try_from(x).and_then(u32::try_from) == Ok(x) {
-                                            return Some(PseudoImm::U32(x));
-                                        }
-                                    }
-                                }
+                            // HACK(eddyb) lossless roundtrip through `i32` is most conservative
+                            // option (only `0..=i32::MAX`, i.e. `0 <= x < 2**32, is allowed).
+                            ConstKind::Scalar(ct) => {
+                                return Some(PseudoImm::U32(u32::try_from(ct.int_as_i32()?).ok()?));
                             }
                         }
                     }

--- a/src/print/mod.rs
+++ b/src/print/mod.rs
@@ -2581,9 +2581,14 @@ impl Print for ConstDef {
         AttrsAndDef {
             attrs: attrs.print(printer),
             def_without_name: compact_def.unwrap_or_else(|| match kind {
+                ConstKind::Undef => pretty::Fragment::new([
+                    printer.imperative_keyword_style().apply("undef").into(),
+                    printer.pretty_type_ascription_suffix(*ty),
+                ]),
                 &ConstKind::PtrToGlobalVar(gv) => {
                     pretty::Fragment::new(["&".into(), gv.print(printer)])
                 }
+
                 ConstKind::SpvInst { spv_inst_and_const_inputs } => {
                     let (spv_inst, const_inputs) = &**spv_inst_and_const_inputs;
                     pretty::Fragment::new([
@@ -3294,6 +3299,8 @@ impl Print for FuncAt<'_, DataInst> {
                 let pseudo_imm_from_value = |v: Value| {
                     if let Value::Const(ct) = v {
                         match &printer.cx[ct].kind {
+                            ConstKind::Undef | ConstKind::PtrToGlobalVar(_) => {}
+
                             &ConstKind::SpvStringLiteralForExtInst(s) => {
                                 return Some(PseudoImm::Str(&printer.cx[s]));
                             }
@@ -3308,7 +3315,6 @@ impl Print for FuncAt<'_, DataInst> {
                                     }
                                 }
                             }
-                            ConstKind::PtrToGlobalVar(_) => {}
                         }
                     }
                     None

--- a/src/print/mod.rs
+++ b/src/print/mod.rs
@@ -24,8 +24,8 @@ use crate::print::multiversion::Versions;
 use crate::qptr::{self, QPtrAttr, QPtrMemUsage, QPtrMemUsageKind, QPtrOp, QPtrUsage};
 use crate::visit::{InnerVisit, Visit, Visitor};
 use crate::{
-    cfg, scalar, spv, AddrSpace, Attr, AttrSet, AttrSetDef, Const, ConstDef, ConstKind, Context,
-    ControlNode, ControlNodeDef, ControlNodeKind, ControlNodeOutputDecl, ControlRegion,
+    cfg, scalar, spv, vector, AddrSpace, Attr, AttrSet, AttrSetDef, Const, ConstDef, ConstKind,
+    Context, ControlNode, ControlNodeDef, ControlNodeKind, ControlNodeOutputDecl, ControlRegion,
     ControlRegionDef, ControlRegionInputDecl, DataInst, DataInstDef, DataInstForm, DataInstFormDef,
     DataInstKind, DeclDef, Diag, DiagLevel, DiagMsgPart, EntityListIter, ExportKey, Exportee, Func,
     FuncDecl, FuncParam, FxIndexMap, FxIndexSet, GlobalVar, GlobalVarDecl, GlobalVarDefBody,
@@ -2407,7 +2407,7 @@ impl Print for ConstDef {
 
         let kw = |kw| printer.declarative_keyword_style().apply(kw).into();
 
-        // FIXME(eddyb) should this just a method on `scalar::Const` instead?
+        // FIXME(eddyb) should this be a method on `scalar::Const` instead?
         let print_scalar = |ct: scalar::Const, include_type_suffix: bool| match ct {
             scalar::Const::FALSE => kw("false"),
             scalar::Const::TRUE => kw("true"),
@@ -3023,17 +3023,62 @@ impl Print for FuncAt<'_, DataInst> {
 
         let mut output_type_to_print = *output_type;
 
+        // FIXME(eddyb) should this be a method on `scalar::Op` instead?
+        let print_scalar = |op: scalar::Op| {
+            let name = op.name();
+            let (namespace_prefix, name) = name.split_at(name.find('.').unwrap() + 1);
+            pretty::Fragment::new([
+                printer
+                    .demote_style_for_namespace_prefix(printer.declarative_keyword_style())
+                    .apply(namespace_prefix),
+                printer.declarative_keyword_style().apply(name),
+            ])
+        };
+
         let def_without_type = match kind {
-            &DataInstKind::Scalar(op) => {
-                let name = op.name();
+            &DataInstKind::Scalar(op) => pretty::Fragment::new([
+                print_scalar(op),
+                pretty::join_comma_sep("(", inputs.iter().map(|v| v.print(printer)), ")"),
+            ]),
+
+            &DataInstKind::Vector(op) => {
+                let (name, extra_last_input) = match op {
+                    vector::Op::Distribute(_) => ("vec.distribute", None),
+                    vector::Op::Reduce(op) => (op.name(), None),
+                    vector::Op::Whole(op) => (
+                        op.name(),
+                        match op {
+                            vector::WholeOp::Extract { elem_idx }
+                            | vector::WholeOp::Insert { elem_idx } => Some(
+                                printer.numeric_literal_style().apply(elem_idx.to_string()).into(),
+                            ),
+                            vector::WholeOp::New
+                            | vector::WholeOp::DynExtract
+                            | vector::WholeOp::DynInsert
+                            | vector::WholeOp::Mul => None,
+                        },
+                    ),
+                };
                 let (namespace_prefix, name) = name.split_at(name.find('.').unwrap() + 1);
-                pretty::Fragment::new([
+                let mut pretty_name = pretty::Fragment::new([
                     printer
                         .demote_style_for_namespace_prefix(printer.declarative_keyword_style())
-                        .apply(namespace_prefix)
-                        .into(),
-                    printer.declarative_keyword_style().apply(name).into(),
-                    pretty::join_comma_sep("(", inputs.iter().map(|v| v.print(printer)), ")"),
+                        .apply(namespace_prefix),
+                    printer.declarative_keyword_style().apply(name),
+                ]);
+                if let vector::Op::Distribute(op) = op {
+                    pretty_name = pretty::Fragment::new([
+                        pretty_name,
+                        pretty::join_comma_sep("(", [print_scalar(op)], ")"),
+                    ]);
+                }
+                pretty::Fragment::new([
+                    pretty_name,
+                    pretty::join_comma_sep(
+                        "(",
+                        inputs.iter().map(|v| v.print(printer)).chain(extra_last_input),
+                        ")",
+                    ),
                 ])
             }
 

--- a/src/print/mod.rs
+++ b/src/print/mod.rs
@@ -3044,6 +3044,19 @@ impl Print for FuncAt<'_, DataInst> {
         let mut output_type_to_print = *output_type;
 
         let def_without_type = match kind {
+            &DataInstKind::Scalar(op) => {
+                let name = op.name();
+                let (namespace_prefix, name) = name.split_at(name.find('.').unwrap() + 1);
+                pretty::Fragment::new([
+                    printer
+                        .demote_style_for_namespace_prefix(printer.declarative_keyword_style())
+                        .apply(namespace_prefix)
+                        .into(),
+                    printer.declarative_keyword_style().apply(name).into(),
+                    pretty::join_comma_sep("(", inputs.iter().map(|v| v.print(printer)), ")"),
+                ])
+            }
+
             &DataInstKind::FuncCall(func) => pretty::Fragment::new([
                 printer.declarative_keyword_style().apply("call").into(),
                 " ".into(),

--- a/src/qptr/analyze.rs
+++ b/src/qptr/analyze.rs
@@ -906,6 +906,8 @@ impl<'a> InferUsage<'a> {
                     });
                 };
                 match &data_inst_form_def.kind {
+                    DataInstKind::Scalar(_) => {}
+
                     &DataInstKind::FuncCall(callee) => {
                         match self.infer_usage_in_func(module, callee) {
                             FuncInferUsageState::Complete(callee_results) => {

--- a/src/qptr/analyze.rs
+++ b/src/qptr/analyze.rs
@@ -906,7 +906,7 @@ impl<'a> InferUsage<'a> {
                     });
                 };
                 match &data_inst_form_def.kind {
-                    DataInstKind::Scalar(_) => {}
+                    DataInstKind::Scalar(_) | DataInstKind::Vector(_) => {}
 
                     &DataInstKind::FuncCall(callee) => {
                         match self.infer_usage_in_func(module, callee) {

--- a/src/qptr/layout.rs
+++ b/src/qptr/layout.rs
@@ -2,7 +2,7 @@
 
 use crate::qptr::shapes;
 use crate::{
-    spv, AddrSpace, Attr, Const, ConstKind, Context, Diag, FxIndexMap, Type, TypeKind, TypeOrConst,
+    scalar, spv, AddrSpace, Attr, Const, Context, Diag, FxIndexMap, Type, TypeKind, TypeOrConst,
 };
 use itertools::Either;
 use smallvec::SmallVec;
@@ -182,18 +182,10 @@ impl<'a> LayoutCache<'a> {
         Self { cx, wk: &spv::spec::Spec::get().well_known, config, cache: Default::default() }
     }
 
-    // FIXME(eddyb) properly distinguish between zero-extension and sign-extension.
     fn const_as_u32(&self, ct: Const) -> Option<u32> {
-        if let ConstKind::SpvInst { spv_inst_and_const_inputs } = &self.cx[ct].kind {
-            let (spv_inst, _const_inputs) = &**spv_inst_and_const_inputs;
-            if spv_inst.opcode == self.wk.OpConstant && spv_inst.imms.len() == 1 {
-                match spv_inst.imms[..] {
-                    [spv::Imm::Short(_, x)] => return Some(x),
-                    _ => unreachable!(),
-                }
-            }
-        }
-        None
+        // HACK(eddyb) lossless roundtrip through `i32` is most conservative
+        // option (only `0..=i32::MAX`, i.e. `0 <= x < 2**32, is allowed).
+        u32::try_from(ct.as_scalar(&self.cx)?.int_as_i32()?).ok()
     }
 
     /// Attempt to compute a `TypeLayout` for a given (SPIR-V) `Type`.
@@ -202,26 +194,16 @@ impl<'a> LayoutCache<'a> {
             return Ok(cached);
         }
 
+        let layout = self.layout_of_uncached(ty)?;
+        self.cache.borrow_mut().insert(ty, layout.clone());
+        Ok(layout)
+    }
+
+    fn layout_of_uncached(&self, ty: Type) -> Result<TypeLayout, LayoutError> {
         let cx = &self.cx;
         let wk = self.wk;
 
         let ty_def = &cx[ty];
-        let (spv_inst, type_and_const_inputs) = match &ty_def.kind {
-            // FIXME(eddyb) treat `QPtr`s as scalars.
-            TypeKind::QPtr => {
-                return Err(LayoutError(Diag::bug(
-                    ["`layout_of(qptr)` (already lowered?)".into()],
-                )));
-            }
-            TypeKind::SpvInst { spv_inst, type_and_const_inputs } => {
-                (spv_inst, type_and_const_inputs)
-            }
-            TypeKind::SpvStringLiteralForExtInst => {
-                return Err(LayoutError(Diag::bug([
-                    "`layout_of(type_of(OpString<\"...\">))`".into()
-                ])));
-            }
-        };
 
         let scalar_with_size_and_align = |(size, align)| {
             TypeLayout::Concrete(Rc::new(MemTypeLayout {
@@ -340,25 +322,43 @@ impl<'a> LayoutCache<'a> {
                 }
             }
         };
-        let short_imm_at = |i| match spv_inst.imms[i] {
-            spv::Imm::Short(_, x) => x,
-            _ => unreachable!(),
-        };
 
         // FIXME(eddyb) !!! what if... types had a min/max size and then...
         // that would allow surrounding offsets to limit their size... but... ugh...
         // ugh this doesn't make any sense. maybe if the front-end specifies
         // offsets with "abstract types", it must configure `qptr::layout`?
-        let layout = if spv_inst.opcode == wk.OpTypeBool {
-            // FIXME(eddyb) make this properly abstract instead of only configurable.
-            scalar_with_size_and_align(self.config.abstract_bool_size_align)
-        } else if spv_inst.opcode == wk.OpTypePointer {
+
+        let (spv_inst, type_and_const_inputs) = match &ty_def.kind {
+            TypeKind::Scalar(scalar::Type::Bool) => {
+                // FIXME(eddyb) make this properly abstract instead of only configurable.
+                return Ok(scalar_with_size_and_align(self.config.abstract_bool_size_align));
+            }
+            TypeKind::Scalar(ty) => return Ok(scalar(ty.bit_width())),
+
+            // FIXME(eddyb) treat `QPtr`s as scalars.
+            TypeKind::QPtr => {
+                return Err(LayoutError(Diag::bug(
+                    ["`layout_of(qptr)` (already lowered?)".into()],
+                )));
+            }
+            TypeKind::SpvInst { spv_inst, type_and_const_inputs } => {
+                (spv_inst, type_and_const_inputs)
+            }
+            TypeKind::SpvStringLiteralForExtInst => {
+                return Err(LayoutError(Diag::bug([
+                    "`layout_of(type_of(OpString<\"...\">))`".into()
+                ])));
+            }
+        };
+        let short_imm_at = |i| match spv_inst.imms[i] {
+            spv::Imm::Short(_, x) => x,
+            _ => unreachable!(),
+        };
+        Ok(if spv_inst.opcode == wk.OpTypePointer {
             // FIXME(eddyb) make this properly abstract instead of only configurable.
             // FIXME(eddyb) categorize `OpTypePointer` by storage class and split on
             // logical vs physical here.
             scalar_with_size_and_align(self.config.logical_ptr_size_align)
-        } else if [wk.OpTypeInt, wk.OpTypeFloat].contains(&spv_inst.opcode) {
-            scalar(short_imm_at(0))
         } else if [wk.OpTypeVector, wk.OpTypeMatrix].contains(&spv_inst.opcode) {
             let len = short_imm_at(0);
             let (min_legacy_align, legacy_align_multiplier) = if spv_inst.opcode == wk.OpTypeVector
@@ -642,8 +642,6 @@ impl<'a> LayoutCache<'a> {
                 spv_inst.opcode.name()
             )
             .into()])));
-        };
-        self.cache.borrow_mut().insert(ty, layout.clone());
-        Ok(layout)
+        })
     }
 }

--- a/src/qptr/lift.rs
+++ b/src/qptr/lift.rs
@@ -7,13 +7,12 @@ use crate::func_at::FuncAtMut;
 use crate::qptr::{shapes, QPtrAttr, QPtrMemUsage, QPtrMemUsageKind, QPtrOp, QPtrUsage};
 use crate::transform::{InnerInPlaceTransform, InnerTransform, Transformed, Transformer};
 use crate::{
-    spv, AddrSpace, Attr, AttrSet, AttrSetDef, Const, ConstDef, ConstKind, Context, ControlNode,
-    ControlNodeKind, DataInst, DataInstDef, DataInstFormDef, DataInstKind, DeclDef, Diag,
-    DiagLevel, EntityDefs, EntityOrientedDenseMap, Func, FuncDecl, FxIndexMap, GlobalVar,
+    scalar, spv, AddrSpace, Attr, AttrSet, AttrSetDef, Const, ConstDef, ConstKind, Context,
+    ControlNode, ControlNodeKind, DataInst, DataInstDef, DataInstFormDef, DataInstKind, DeclDef,
+    Diag, DiagLevel, EntityDefs, EntityOrientedDenseMap, Func, FuncDecl, FxIndexMap, GlobalVar,
     GlobalVarDecl, Module, Type, TypeDef, TypeKind, TypeOrConst, Value,
 };
 use smallvec::SmallVec;
-use std::cell::Cell;
 use std::mem;
 use std::num::NonZeroU32;
 use std::rc::Rc;
@@ -27,8 +26,6 @@ pub struct LiftToSpvPtrs<'a> {
     cx: Rc<Context>,
     wk: &'static spv::spec::WellKnown,
     layout_cache: LayoutCache<'a>,
-
-    cached_u32_type: Cell<Option<Type>>,
 }
 
 impl<'a> LiftToSpvPtrs<'a> {
@@ -37,7 +34,6 @@ impl<'a> LiftToSpvPtrs<'a> {
             cx: cx.clone(),
             wk: &spv::spec::Spec::get().well_known,
             layout_cache: LayoutCache::new(cx, layout_config),
-            cached_u32_type: Default::default(),
         }
     }
 
@@ -291,7 +287,9 @@ impl<'a> LiftToSpvPtrs<'a> {
                 spv_inst: spv_opcode.into(),
                 type_and_const_inputs: [TypeOrConst::Type(element_type)]
                     .into_iter()
-                    .chain(fixed_len.map(|len| TypeOrConst::Const(self.const_u32(len))))
+                    .chain(fixed_len.map(|len| {
+                        TypeOrConst::Const(self.cx.intern(scalar::Const::from_u32(len)))
+                    }))
                     .collect(),
             },
         }))
@@ -327,48 +325,6 @@ impl<'a> LiftToSpvPtrs<'a> {
             attrs: self.cx.intern(attrs),
             kind: TypeKind::SpvInst { spv_inst: wk.OpTypeStruct.into(), type_and_const_inputs },
         }))
-    }
-
-    /// Get the (likely cached) `u32` type.
-    fn u32_type(&self) -> Type {
-        if let Some(cached) = self.cached_u32_type.get() {
-            return cached;
-        }
-        let wk = self.wk;
-        let ty = self.cx.intern(TypeKind::SpvInst {
-            spv_inst: spv::Inst {
-                opcode: wk.OpTypeInt,
-                imms: [
-                    spv::Imm::Short(wk.LiteralInteger, 32),
-                    spv::Imm::Short(wk.LiteralInteger, 0),
-                ]
-                .into_iter()
-                .collect(),
-            },
-            type_and_const_inputs: [].into_iter().collect(),
-        });
-        self.cached_u32_type.set(Some(ty));
-        ty
-    }
-
-    fn const_u32(&self, x: u32) -> Const {
-        let wk = self.wk;
-
-        self.cx.intern(ConstDef {
-            attrs: AttrSet::default(),
-            ty: self.u32_type(),
-            kind: ConstKind::SpvInst {
-                spv_inst_and_const_inputs: Rc::new((
-                    spv::Inst {
-                        opcode: wk.OpConstant,
-                        imms: [spv::Imm::Short(wk.LiteralContextDependentNumber, x)]
-                            .into_iter()
-                            .collect(),
-                    },
-                    [].into_iter().collect(),
-                )),
-            },
-        })
     }
 
     /// Attempt to compute a `TypeLayout` for a given (SPIR-V) `Type`.
@@ -644,7 +600,7 @@ impl LiftToSpvPtrInstsInFunc<'_> {
                         ]))
                     })?;
                     access_chain_inputs
-                        .push(Value::Const(self.lifter.const_u32(idx_as_i32 as u32)));
+                        .push(Value::Const(cx.intern(scalar::Const::from_u32(idx_as_i32 as u32))));
 
                     match &layout.components {
                         Components::Scalar => unreachable!(),
@@ -757,7 +713,7 @@ impl LiftToSpvPtrInstsInFunc<'_> {
                         ]))
                     })?;
                     access_chain_inputs
-                        .push(Value::Const(self.lifter.const_u32(idx_as_i32 as u32)));
+                        .push(Value::Const(cx.intern(scalar::Const::from_u32(idx_as_i32 as u32))));
 
                     layout = match &layout.components {
                         Components::Scalar => unreachable!(),
@@ -945,7 +901,8 @@ impl LiftToSpvPtrInstsInFunc<'_> {
         let mut access_chain_inputs: SmallVec<_> = [ptr].into_iter().collect();
 
         if let TypeLayout::HandleArray(handle, _) = pointee_layout {
-            access_chain_inputs.push(Value::Const(self.lifter.const_u32(0)));
+            access_chain_inputs
+                .push(Value::Const(self.lifter.cx.intern(scalar::Const::from_u32(0))));
             pointee_layout = TypeLayout::Handle(handle);
         }
         match (pointee_layout, access_layout) {
@@ -1014,8 +971,9 @@ impl LiftToSpvPtrInstsInFunc<'_> {
                             format!("{idx} not representable as a positive s32").into()
                         ]))
                     })?;
-                    access_chain_inputs
-                        .push(Value::Const(self.lifter.const_u32(idx_as_i32 as u32)));
+                    access_chain_inputs.push(Value::Const(
+                        self.lifter.cx.intern(scalar::Const::from_u32(idx_as_i32 as u32)),
+                    ));
 
                     pointee_layout = match &pointee_layout.components {
                         Components::Scalar => unreachable!(),

--- a/src/qptr/lift.rs
+++ b/src/qptr/lift.rs
@@ -404,6 +404,8 @@ impl LiftToSpvPtrInstsInFunc<'_> {
             Ok((addr_space, self.lifter.layout_of(pointee_type)?))
         };
         let replacement_data_inst_def = match &data_inst_form_def.kind {
+            DataInstKind::Scalar(_) => return Ok(Transformed::Unchanged),
+
             &DataInstKind::FuncCall(_callee) => {
                 for &v in &data_inst_def.inputs {
                     if self.lifter.as_spv_ptr_type(type_of_val(v)).is_some() {

--- a/src/qptr/lift.rs
+++ b/src/qptr/lift.rs
@@ -404,7 +404,7 @@ impl LiftToSpvPtrInstsInFunc<'_> {
             Ok((addr_space, self.lifter.layout_of(pointee_type)?))
         };
         let replacement_data_inst_def = match &data_inst_form_def.kind {
-            DataInstKind::Scalar(_) => return Ok(Transformed::Unchanged),
+            DataInstKind::Scalar(_) | DataInstKind::Vector(_) => return Ok(Transformed::Unchanged),
 
             &DataInstKind::FuncCall(_callee) => {
                 for &v in &data_inst_def.inputs {

--- a/src/qptr/lower.rs
+++ b/src/qptr/lower.rs
@@ -616,7 +616,7 @@ impl LowerFromSpvPtrInstsInFunc<'_> {
 
         match data_inst_form_def.kind {
             // Known semantics, no need to preserve SPIR-V pointer information.
-            DataInstKind::FuncCall(_) | DataInstKind::QPtr(_) => return,
+            DataInstKind::Scalar(_) | DataInstKind::FuncCall(_) | DataInstKind::QPtr(_) => return,
 
             DataInstKind::SpvInst(_) | DataInstKind::SpvExtInst { .. } => {}
         }

--- a/src/qptr/lower.rs
+++ b/src/qptr/lower.rs
@@ -616,7 +616,10 @@ impl LowerFromSpvPtrInstsInFunc<'_> {
 
         match data_inst_form_def.kind {
             // Known semantics, no need to preserve SPIR-V pointer information.
-            DataInstKind::Scalar(_) | DataInstKind::FuncCall(_) | DataInstKind::QPtr(_) => return,
+            DataInstKind::Scalar(_)
+            | DataInstKind::Vector(_)
+            | DataInstKind::FuncCall(_)
+            | DataInstKind::QPtr(_) => return,
 
             DataInstKind::SpvInst(_) | DataInstKind::SpvExtInst { .. } => {}
         }

--- a/src/scalar.rs
+++ b/src/scalar.rs
@@ -1,0 +1,198 @@
+//! Scalar (`bool`, integer, and floating-point) types and associated functionality.
+//!
+//! **Note**: pointers are never scalars (like SPIR-V, but unlike other IRs).
+
+// HACK(eddyb) this could be some `struct` with private fields, but this `enum`
+// is only 2 bytes in size, and has better ergonomics overall.
+#[derive(Copy, Clone, PartialEq, Eq, Hash)]
+pub enum Type {
+    Bool,
+    SInt(IntWidth),
+    UInt(IntWidth),
+    Float(FloatWidth),
+}
+
+impl Type {
+    // HACK(eddyb) only common widths, as a convenience, expand as-needed.
+    pub const S32: Type = Type::SInt(IntWidth::I32);
+    pub const U32: Type = Type::UInt(IntWidth::I32);
+    pub const F32: Type = Type::Float(FloatWidth::F32);
+    pub const F64: Type = Type::Float(FloatWidth::F64);
+
+    pub const fn bit_width(self) -> u32 {
+        match self {
+            Type::Bool => 1,
+            Type::SInt(w) | Type::UInt(w) => w.bits(),
+            Type::Float(w) => w.bits(),
+        }
+    }
+}
+
+/// Bit-width of a supported integer type (only power-of-two multiples of a byte).
+#[derive(Copy, Clone, PartialEq, Eq, Hash)]
+pub struct IntWidth {
+    // HACK(eddyb) this is so compact that only 3 bits of this byte are used
+    // to encode integer types from `i8` to `i128`, and so `Type` could all fit
+    // in one byte, but that'd need a new `enum` for `Bool`/`{S,U}Int`/`Float`.
+    log2_bytes: u8,
+}
+
+impl IntWidth {
+    pub const I8: Self = Self::try_from_bits_unwrap(8);
+    pub const I16: Self = Self::try_from_bits_unwrap(16);
+    pub const I32: Self = Self::try_from_bits_unwrap(32);
+    pub const I64: Self = Self::try_from_bits_unwrap(64);
+    pub const I128: Self = Self::try_from_bits_unwrap(128);
+
+    // FIXME(eddyb) remove when `Option::unwrap` is stabilized.
+    const fn try_from_bits_unwrap(bits: u32) -> Self {
+        match Self::try_from_bits(bits) {
+            Some(w) => w,
+            None => unreachable!(),
+        }
+    }
+
+    pub const fn try_from_bits(bits: u32) -> Option<Self> {
+        if bits % 8 != 0 {
+            return None;
+        }
+        let bytes = bits / 8;
+        match bytes.checked_ilog2() {
+            Some(log2_bytes_u32) => {
+                let log2_bytes = log2_bytes_u32 as u8;
+                assert!(log2_bytes as u32 == log2_bytes_u32);
+                Some(Self { log2_bytes })
+            }
+            None => None,
+        }
+    }
+
+    pub const fn bits(self) -> u32 {
+        8 * (1 << self.log2_bytes)
+    }
+}
+
+/// Bit-width of a supported floating-point type (only power-of-two multiples of a byte).
+#[derive(Copy, Clone, PartialEq, Eq, Hash)]
+pub struct FloatWidth(IntWidth);
+
+impl FloatWidth {
+    pub const F32: Self = Self::try_from_bits_unwrap(32);
+    pub const F64: Self = Self::try_from_bits_unwrap(64);
+
+    // FIXME(eddyb) remove when `Option::unwrap` is stabilized.
+    const fn try_from_bits_unwrap(bits: u32) -> Self {
+        match Self::try_from_bits(bits) {
+            Some(w) => w,
+            None => unreachable!(),
+        }
+    }
+
+    pub const fn try_from_bits(bits: u32) -> Option<Self> {
+        match IntWidth::try_from_bits(bits) {
+            Some(w) => Some(Self(w)),
+            None => None,
+        }
+    }
+
+    pub const fn bits(self) -> u32 {
+        self.0.bits()
+    }
+}
+
+// FIXME(eddyb) document the 128-bit limitations.
+// HACK(eddyb) `(Type, u128)` would waste almost half its size on padding, and
+// packing will only impact accessing the `bits`, while allowing e.g. being
+// wrapped in an outer `enum`, before reaching the same size as `(u128, u128)`.
+#[repr(packed)]
+#[derive(Copy, Clone, PartialEq, Eq, Hash)]
+pub struct Const {
+    ty: Type,
+    bits: u128,
+}
+
+impl Const {
+    pub const FALSE: Const = Const::from_bool(false);
+    pub const TRUE: Const = Const::from_bool(true);
+
+    // FIXME(eddyb) document the panic conditions.
+    // FIXME(eddyb) make this public?
+    const fn from_bits_trunc(ty: Type, bits: u128) -> Const {
+        // FIXME(eddyb) this ensures `Const`s cannot be created when that could
+        // potentially need more than 128 bits for e.g. constant-folding.
+        let width = ty.bit_width();
+        assert!(width <= 128);
+
+        Const { ty, bits: bits & (!0u128 >> (128 - width)) }
+    }
+
+    // FIXME(eddyb) document the panic conditions.
+    pub const fn from_bits(ty: Type, bits: u128) -> Const {
+        let ct_trunc = Const::from_bits_trunc(ty, bits);
+        assert!(ct_trunc.bits == bits);
+        ct_trunc
+    }
+
+    pub const fn try_from_bits(ty: Type, bits: u128) -> Option<Const> {
+        let ct_trunc = Const::from_bits_trunc(ty, bits);
+        if ct_trunc.bits == bits { Some(ct_trunc) } else { None }
+    }
+
+    pub const fn from_bool(v: bool) -> Const {
+        Const::from_bits(Type::Bool, v as u128)
+    }
+
+    pub const fn from_u32(v: u32) -> Const {
+        Const::from_bits(Type::U32, v as u128)
+    }
+
+    /// Returns `Some(ct)` iff `ty` is `{S,U}Int` and can represent `v: i128`
+    /// (i.e. `ct` has the same sign and absolute value as `v` does).
+    pub fn int_try_from_i128(ty: Type, v: i128) -> Option<Const> {
+        let ct_trunc = Const::from_bits_trunc(ty, v as u128);
+        (ct_trunc.int_as_i128() == Some(v)).then_some(ct_trunc)
+    }
+
+    pub const fn ty(&self) -> Type {
+        self.ty
+    }
+
+    pub const fn bits(&self) -> u128 {
+        self.bits
+    }
+
+    /// Returns `Some(v)` iff `self` is `{S,U}Int` and representable by `v: i128`
+    /// (i.e. `self` has the same sign and absolute value as `v` does).
+    pub fn int_as_i128(&self) -> Option<i128> {
+        match self.ty {
+            Type::Bool | Type::Float(_) => None,
+            Type::SInt(_) => {
+                let width = self.ty.bit_width();
+                Some((self.bits as i128) << (128 - width) >> (128 - width))
+            }
+            Type::UInt(_) => self.bits.try_into().ok(),
+        }
+    }
+
+    /// Returns `Some(v)` iff `self` is `{S,U}Int` and representable by `v: u128`
+    /// (i.e. `self` is positive and has the same absolute value as `v` does).
+    pub fn int_as_u128(&self) -> Option<u128> {
+        match self.ty {
+            Type::Bool | Type::Float(_) => None,
+            Type::SInt(_) => self.int_as_i128()?.try_into().ok(),
+            Type::UInt(_) => Some(self.bits),
+        }
+    }
+
+    /// Returns `Some(v)` iff `self` is `{S,U}Int` and representable by `v: i32`
+    /// (i.e. `self` has the same sign and absolute value as `v` does).
+    pub fn int_as_i32(&self) -> Option<i32> {
+        self.int_as_i128()?.try_into().ok()
+    }
+
+    /// Returns `Some(v)` iff `self` is `{S,U}Int` and representable by `v: u32`
+    /// (i.e. `self` is positive and has the same absolute value as `v` does).
+    pub fn int_as_u32(&self) -> Option<u32> {
+        self.int_as_u128()?.try_into().ok()
+    }
+}

--- a/src/spv/canonical.rs
+++ b/src/spv/canonical.rs
@@ -165,7 +165,11 @@ def_mappable_ops! {
 }
 
 impl scalar::Const {
-    fn try_decode_from_spv_imms(ty: scalar::Type, imms: &[spv::Imm]) -> Option<scalar::Const> {
+    // HACK(eddyb) this is not private so `spv::lower` can use it for `OpSwitch`.
+    pub(super) fn try_decode_from_spv_imms(
+        ty: scalar::Type,
+        imms: &[spv::Imm],
+    ) -> Option<scalar::Const> {
         // FIXME(eddyb) don't hardcode the 128-bit limitation,
         // but query `scalar::Const` somehow instead.
         if ty.bit_width() > 128 {
@@ -198,7 +202,8 @@ impl scalar::Const {
         }
     }
 
-    fn encode_as_spv_imms(&self) -> impl Iterator<Item = spv::Imm> {
+    // HACK(eddyb) this is not private so `spv::lift` can use it for `OpSwitch`.
+    pub(super) fn encode_as_spv_imms(&self) -> impl Iterator<Item = spv::Imm> {
         let wk = &spec::Spec::get().well_known;
 
         let ty = self.ty();

--- a/src/spv/canonical.rs
+++ b/src/spv/canonical.rs
@@ -1,0 +1,70 @@
+//! Bidirectional (SPIR-V <-> SPIR-T) "canonical mappings".
+//!
+//! Both directions are defined close together as much as possible, to:
+//! - limit code duplication, making it easy to add more mappings
+//! - limit how much they could even go out of sync over time
+//! - prevent naming e.g. SPIR-V opcodes, outside canonicalization
+//
+// FIXME(eddyb) should interning attempts check/apply these canonicalizations?
+
+use crate::spv::{self, spec};
+use crate::ConstKind;
+use lazy_static::lazy_static;
+
+// FIXME(eddyb) these ones could maybe make use of build script generation.
+macro_rules! def_mappable_ops {
+    ($($op:ident),+ $(,)?) => {
+        #[allow(non_snake_case)]
+        struct MappableOps {
+            $($op: spec::Opcode,)+
+        }
+        impl MappableOps {
+            #[inline(always)]
+            #[must_use]
+            pub fn get() -> &'static MappableOps {
+                lazy_static! {
+                    static ref MAPPABLE_OPS: MappableOps = {
+                        let spv_spec = spec::Spec::get();
+                        MappableOps {
+                            $($op: spv_spec.instructions.lookup(stringify!($op)).unwrap(),)+
+                        }
+                    };
+                }
+                &MAPPABLE_OPS
+            }
+        }
+    };
+}
+def_mappable_ops! {
+    OpUndef,
+}
+
+// FIXME(eddyb) decide on a visibility scope - `pub(super)` avoids some mistakes
+// (using these methods outside of `spv::{lower,lift}`), but may be too restrictive.
+impl spv::Inst {
+    pub(super) fn as_canonical_const(&self) -> Option<ConstKind> {
+        let Self { opcode, imms } = self;
+        let (&opcode, imms) = (opcode, &imms[..]);
+
+        let mo = MappableOps::get();
+
+        if opcode == mo.OpUndef {
+            assert_eq!(imms.len(), 0);
+            Some(ConstKind::Undef)
+        } else {
+            None
+        }
+    }
+
+    pub(super) fn from_canonical_const(const_kind: &ConstKind) -> Option<Self> {
+        let mo = MappableOps::get();
+
+        match const_kind {
+            ConstKind::Undef => Some(mo.OpUndef.into()),
+
+            ConstKind::PtrToGlobalVar(_)
+            | ConstKind::SpvInst { .. }
+            | ConstKind::SpvStringLiteralForExtInst(_) => None,
+        }
+    }
+}

--- a/src/spv/canonical.rs
+++ b/src/spv/canonical.rs
@@ -8,7 +8,7 @@
 // FIXME(eddyb) should interning attempts check/apply these canonicalizations?
 
 use crate::spv::{self, spec};
-use crate::ConstKind;
+use crate::{scalar, ConstKind, Context, Type, TypeKind};
 use lazy_static::lazy_static;
 
 // FIXME(eddyb) these ones could maybe make use of build script generation.
@@ -36,23 +36,174 @@ macro_rules! def_mappable_ops {
     };
 }
 def_mappable_ops! {
+    OpTypeBool,
+    OpTypeInt,
+    OpTypeFloat,
+
     OpUndef,
+    OpConstantFalse,
+    OpConstantTrue,
+    OpConstant,
+}
+
+impl scalar::Const {
+    fn try_decode_from_spv_imms(ty: scalar::Type, imms: &[spv::Imm]) -> Option<scalar::Const> {
+        // FIXME(eddyb) don't hardcode the 128-bit limitation,
+        // but query `scalar::Const` somehow instead.
+        if ty.bit_width() > 128 {
+            return None;
+        }
+        let imm_words = usize::try_from(ty.bit_width().div_ceil(32)).unwrap();
+        if imms.len() != imm_words {
+            return None;
+        }
+        let mut bits = 0;
+        for (i, &imm) in imms.iter().enumerate() {
+            let w = match imm {
+                spv::Imm::Short(_, w) if imm_words == 1 => w,
+                spv::Imm::LongStart(_, w) if i == 0 && imm_words > 1 => w,
+                spv::Imm::LongCont(_, w) if i > 0 => w,
+                _ => return None,
+            };
+            bits |= (w as u128) << (i * 32);
+        }
+
+        // HACK(eddyb) signed integers are encoded sign-extended into immediates.
+        if let scalar::Type::SInt(_) = ty {
+            let imm_width = imm_words * 32;
+            scalar::Const::int_try_from_i128(
+                ty,
+                (bits as i128) << (128 - imm_width) >> (128 - imm_width),
+            )
+        } else {
+            scalar::Const::try_from_bits(ty, bits)
+        }
+    }
+
+    fn encode_as_spv_imms(&self) -> impl Iterator<Item = spv::Imm> {
+        let wk = &spec::Spec::get().well_known;
+
+        let ty = self.ty();
+        let imm_words = ty.bit_width().div_ceil(32);
+
+        let bits = self.bits();
+
+        // HACK(eddyb) signed integers are encoded sign-extended into immediates.
+        let bits = if let scalar::Type::SInt(_) = ty {
+            let imm_width = imm_words * 32;
+            (self.int_as_i128().unwrap() as u128) & (!0 >> (128 - imm_width))
+        } else {
+            bits
+        };
+
+        (0..imm_words).map(move |i| {
+            let k = wk.LiteralContextDependentNumber;
+            let w = (bits >> (i * 32)) as u32;
+            if imm_words == 1 {
+                spv::Imm::Short(k, w)
+            } else if i == 0 {
+                spv::Imm::LongStart(k, w)
+            } else {
+                spv::Imm::LongCont(k, w)
+            }
+        })
+    }
 }
 
 // FIXME(eddyb) decide on a visibility scope - `pub(super)` avoids some mistakes
 // (using these methods outside of `spv::{lower,lift}`), but may be too restrictive.
 impl spv::Inst {
-    pub(super) fn as_canonical_const(&self) -> Option<ConstKind> {
+    // HACK(eddyb) exported only for `spv::read`/`LiteralContextDependentNumber`.
+    pub(super) fn int_or_float_type_bit_width(&self) -> Option<u32> {
+        let mo = MappableOps::get();
+
+        match self.imms[..] {
+            [spv::Imm::Short(_, bit_width), _] if self.opcode == mo.OpTypeInt => Some(bit_width),
+            [spv::Imm::Short(_, bit_width)] if self.opcode == mo.OpTypeFloat => Some(bit_width),
+            _ => None,
+        }
+    }
+
+    // FIXME(eddyb) automate bidirectional mappings more (although the need
+    // for conditional, i.e. "partial", mappings, adds a lot of complexity).
+    pub(super) fn as_canonical_type(&self) -> Option<TypeKind> {
         let Self { opcode, imms } = self;
         let (&opcode, imms) = (opcode, &imms[..]);
 
         let mo = MappableOps::get();
 
-        if opcode == mo.OpUndef {
-            assert_eq!(imms.len(), 0);
-            Some(ConstKind::Undef)
-        } else {
-            None
+        let int_width = || scalar::IntWidth::try_from_bits(self.int_or_float_type_bit_width()?);
+        match imms {
+            [] if opcode == mo.OpTypeBool => Some(scalar::Type::Bool.into()),
+            &[_, spv::Imm::Short(_, 0)] if opcode == mo.OpTypeInt => {
+                Some(scalar::Type::UInt(int_width()?).into())
+            }
+            &[_, spv::Imm::Short(_, 1)] if opcode == mo.OpTypeInt => {
+                Some(scalar::Type::SInt(int_width()?).into())
+            }
+            [_] if opcode == mo.OpTypeFloat => Some(
+                scalar::Type::Float(scalar::FloatWidth::try_from_bits(
+                    self.int_or_float_type_bit_width()?,
+                )?)
+                .into(),
+            ),
+            _ => None,
+        }
+    }
+
+    pub(super) fn from_canonical_type(type_kind: &TypeKind) -> Option<Self> {
+        let wk = &spec::Spec::get().well_known;
+        let mo = MappableOps::get();
+
+        match type_kind {
+            &TypeKind::Scalar(ty) => match ty {
+                scalar::Type::Bool => Some(mo.OpTypeBool.into()),
+                scalar::Type::SInt(w) | scalar::Type::UInt(w) => Some(spv::Inst {
+                    opcode: mo.OpTypeInt,
+                    imms: [
+                        spv::Imm::Short(wk.LiteralInteger, w.bits()),
+                        spv::Imm::Short(
+                            wk.LiteralInteger,
+                            matches!(ty, scalar::Type::SInt(_)) as u32,
+                        ),
+                    ]
+                    .into_iter()
+                    .collect(),
+                }),
+                scalar::Type::Float(w) => Some(spv::Inst {
+                    opcode: mo.OpTypeFloat,
+                    imms: [spv::Imm::Short(wk.LiteralInteger, w.bits())].into_iter().collect(),
+                }),
+            },
+
+            TypeKind::QPtr | TypeKind::SpvInst { .. } | TypeKind::SpvStringLiteralForExtInst => {
+                None
+            }
+        }
+    }
+
+    // HACK(eddyb) this only exists as a helper for `spv::lower`.
+    pub(super) fn always_lower_as_const(&self) -> bool {
+        let mo = MappableOps::get();
+        mo.OpUndef == self.opcode
+    }
+
+    // FIXME(eddyb) automate bidirectional mappings more (although the need
+    // for conditional, i.e. "partial", mappings, adds a lot of complexity).
+    pub(super) fn as_canonical_const(&self, cx: &Context, ty: Type) -> Option<ConstKind> {
+        let Self { opcode, imms } = self;
+        let (&opcode, imms) = (opcode, &imms[..]);
+
+        let mo = MappableOps::get();
+
+        match imms {
+            [] if opcode == mo.OpUndef => Some(ConstKind::Undef),
+            [] if opcode == mo.OpConstantFalse => Some(scalar::Const::FALSE.into()),
+            [] if opcode == mo.OpConstantTrue => Some(scalar::Const::TRUE.into()),
+            _ if opcode == mo.OpConstant => {
+                Some(scalar::Const::try_decode_from_spv_imms(ty.as_scalar(cx)?, imms)?.into())
+            }
+            _ => None,
         }
     }
 
@@ -61,6 +212,11 @@ impl spv::Inst {
 
         match const_kind {
             ConstKind::Undef => Some(mo.OpUndef.into()),
+            ConstKind::Scalar(scalar::Const::FALSE) => Some(mo.OpConstantFalse.into()),
+            ConstKind::Scalar(scalar::Const::TRUE) => Some(mo.OpConstantTrue.into()),
+            ConstKind::Scalar(ct) => {
+                Some(spv::Inst { opcode: mo.OpConstant, imms: ct.encode_as_spv_imms().collect() })
+            }
 
             ConstKind::PtrToGlobalVar(_)
             | ConstKind::SpvInst { .. }

--- a/src/spv/lift.rs
+++ b/src/spv/lift.rs
@@ -1309,6 +1309,14 @@ impl LazyInst<'_, '_> {
                 ids: [merge_label_id, continue_label_id].into_iter().collect(),
             },
             Self::Terminator { parent_func, terminator } => {
+                let mut ids: SmallVec<[_; 4]> = terminator
+                    .inputs
+                    .iter()
+                    .map(|&v| value_to_id(parent_func, v))
+                    .chain(terminator.targets.iter().map(|&target| parent_func.label_ids[&target]))
+                    .collect();
+
+                // FIXME(eddyb) move some of this to `spv::canonical`.
                 let inst = match &*terminator.kind {
                     cfg::ControlInstKind::Unreachable => wk.OpUnreachable.into(),
                     cfg::ControlInstKind::Return => {
@@ -1327,23 +1335,21 @@ impl LazyInst<'_, '_> {
                     cfg::ControlInstKind::SelectBranch(SelectionKind::BoolCond) => {
                         wk.OpBranchConditional.into()
                     }
-                    cfg::ControlInstKind::SelectBranch(SelectionKind::SpvInst(inst)) => {
-                        inst.clone()
+                    cfg::ControlInstKind::SelectBranch(SelectionKind::Switch { case_consts }) => {
+                        // HACK(eddyb) move the default case from last back to first.
+                        let default_target = ids.pop().unwrap();
+                        ids.insert(1, default_target);
+
+                        spv::Inst {
+                            opcode: wk.OpSwitch,
+                            imms: case_consts
+                                .iter()
+                                .flat_map(|ct| ct.encode_as_spv_imms())
+                                .collect(),
+                        }
                     }
                 };
-                spv::InstWithIds {
-                    without_ids: inst,
-                    result_type_id: None,
-                    result_id: None,
-                    ids: terminator
-                        .inputs
-                        .iter()
-                        .map(|&v| value_to_id(parent_func, v))
-                        .chain(
-                            terminator.targets.iter().map(|&target| parent_func.label_ids[&target]),
-                        )
-                        .collect(),
-                }
+                spv::InstWithIds { without_ids: inst, result_type_id: None, result_id: None, ids }
             }
             Self::OpFunctionEnd => spv::InstWithIds {
                 without_ids: wk.OpFunctionEnd.into(),

--- a/src/spv/lift.rs
+++ b/src/spv/lift.rs
@@ -121,8 +121,22 @@ impl Visitor<'_> for NeedsIdsCollector<'_> {
             return;
         }
         let ty_def = &self.cx[ty];
+
+        // HACK(eddyb) there isn't a great way to handle canonical types, but
+        // perhaps this result should be recorded in `self.globals`?
+        if let Some((_spv_inst, type_and_const_inputs)) =
+            spv::Inst::from_canonical_type(self.cx, &ty_def.kind)
+        {
+            for ty_or_ct in type_and_const_inputs {
+                match ty_or_ct {
+                    TypeOrConst::Type(ty) => self.visit_type_use(ty),
+                    TypeOrConst::Const(ct) => self.visit_const_use(ct),
+                }
+            }
+        }
+
         match ty_def.kind {
-            TypeKind::Scalar(_) | TypeKind::SpvInst { .. } => {}
+            TypeKind::Scalar(_) | TypeKind::Vector(_) | TypeKind::SpvInst { .. } => {}
 
             // FIXME(eddyb) this should be a proper `Result`-based error instead,
             // and/or `spv::lift` should mutate the module for legalization.
@@ -137,6 +151,7 @@ impl Visitor<'_> for NeedsIdsCollector<'_> {
                 );
             }
         }
+
         self.visit_type_def(ty_def);
         self.globals.insert(global);
     }
@@ -146,9 +161,21 @@ impl Visitor<'_> for NeedsIdsCollector<'_> {
             return;
         }
         let ct_def = &self.cx[ct];
+
+        // HACK(eddyb) there isn't a great way to handle canonical consts, but
+        // perhaps this result should be recorded in `self.globals`?
+        if let Some((_spv_inst, const_inputs)) =
+            spv::Inst::from_canonical_const(self.cx, &ct_def.kind)
+        {
+            for ct in const_inputs {
+                self.visit_const_use(ct);
+            }
+        }
+
         match ct_def.kind {
             ConstKind::Undef
             | ConstKind::Scalar(_)
+            | ConstKind::Vector(_)
             | ConstKind::PtrToGlobalVar(_)
             | ConstKind::SpvInst { .. } => {
                 self.visit_const_def(ct_def);
@@ -1030,9 +1057,10 @@ impl LazyInst<'_, '_> {
                                 (gv_decl.attrs, import)
                             }
 
-                            ConstKind::Undef | ConstKind::Scalar(_) | ConstKind::SpvInst { .. } => {
-                                (ct_def.attrs, None)
-                            }
+                            ConstKind::Undef
+                            | ConstKind::Scalar(_)
+                            | ConstKind::Vector(_)
+                            | ConstKind::SpvInst { .. } => (ct_def.attrs, None),
 
                             // Not inserted into `globals` while visiting.
                             ConstKind::SpvStringLiteralForExtInst(_) => unreachable!(),
@@ -1100,19 +1128,16 @@ impl LazyInst<'_, '_> {
             Self::Global(global) => match global {
                 Global::Type(ty) => {
                     let ty_def = &cx[ty];
-                    match spv::Inst::from_canonical_type(&ty_def.kind).ok_or(&ty_def.kind) {
-                        Ok(spv_inst) => spv::InstWithIds {
-                            without_ids: spv_inst,
-                            result_type_id: None,
-                            result_id,
-                            ids: [].into_iter().collect(),
-                        },
-
-                        Err(TypeKind::Scalar(_)) => {
+                    match spv::Inst::from_canonical_type(cx, &ty_def.kind)
+                        .as_ref()
+                        .ok_or(&ty_def.kind)
+                    {
+                        Err(TypeKind::Scalar(_) | TypeKind::Vector(_)) => {
                             unreachable!("should've been handled as canonical")
                         }
 
-                        Err(TypeKind::SpvInst { spv_inst, type_and_const_inputs }) => {
+                        Ok((spv_inst, type_and_const_inputs))
+                        | Err(TypeKind::SpvInst { spv_inst, type_and_const_inputs }) => {
                             spv::InstWithIds {
                                 without_ids: spv_inst.clone(),
                                 result_type_id: None,
@@ -1137,15 +1162,32 @@ impl LazyInst<'_, '_> {
                 }
                 Global::Const(ct) => {
                     let ct_def = &cx[ct];
-                    match spv::Inst::from_canonical_const(&ct_def.kind).ok_or(&ct_def.kind) {
-                        Ok(spv_inst) => spv::InstWithIds {
+                    match spv::Inst::from_canonical_const(cx, &ct_def.kind).ok_or(&ct_def.kind) {
+                        // FIXME(eddyb) this duplicates the `ConstKind::SpvInst`
+                        // case, only due to an inability to pattern-match `Rc`.
+                        Ok((spv_inst, const_inputs)) => spv::InstWithIds {
                             without_ids: spv_inst,
                             result_type_id: Some(ids.globals[&Global::Type(ct_def.ty)]),
                             result_id,
-                            ids: [].into_iter().collect(),
+                            ids: const_inputs
+                                .iter()
+                                .map(|&ct| ids.globals[&Global::Const(ct)])
+                                .collect(),
                         },
+                        Err(ConstKind::SpvInst { spv_inst_and_const_inputs }) => {
+                            let (spv_inst, const_inputs) = &**spv_inst_and_const_inputs;
+                            spv::InstWithIds {
+                                without_ids: spv_inst.clone(),
+                                result_type_id: Some(ids.globals[&Global::Type(ct_def.ty)]),
+                                result_id,
+                                ids: const_inputs
+                                    .iter()
+                                    .map(|&ct| ids.globals[&Global::Const(ct)])
+                                    .collect(),
+                            }
+                        }
 
-                        Err(ConstKind::Undef | ConstKind::Scalar(_)) => {
+                        Err(ConstKind::Undef | ConstKind::Scalar(_) | ConstKind::Vector(_)) => {
                             unreachable!("should've been handled as canonical")
                         }
 
@@ -1179,19 +1221,6 @@ impl LazyInst<'_, '_> {
                                 result_type_id: Some(ids.globals[&Global::Type(ct_def.ty)]),
                                 result_id,
                                 ids: initializer.into_iter().collect(),
-                            }
-                        }
-
-                        Err(ConstKind::SpvInst { spv_inst_and_const_inputs }) => {
-                            let (spv_inst, const_inputs) = &**spv_inst_and_const_inputs;
-                            spv::InstWithIds {
-                                without_ids: spv_inst.clone(),
-                                result_type_id: Some(ids.globals[&Global::Type(ct_def.ty)]),
-                                result_id,
-                                ids: const_inputs
-                                    .iter()
-                                    .map(|&ct| ids.globals[&Global::Const(ct)])
-                                    .collect(),
                             }
                         }
 

--- a/src/spv/lift.rs
+++ b/src/spv/lift.rs
@@ -254,7 +254,11 @@ impl Visitor<'_> for NeedsIdsCollector<'_> {
                 unreachable!("`DataInstKind::QPtr` should be legalized away before lifting");
             }
 
-            DataInstKind::Scalar(_) | DataInstKind::FuncCall(_) | DataInstKind::SpvInst(_) => {}
+            DataInstKind::Scalar(_)
+            | DataInstKind::Vector(_)
+            | DataInstKind::FuncCall(_)
+            | DataInstKind::SpvInst(_) => {}
+
             DataInstKind::SpvExtInst { ext_set, .. } => {
                 self.ext_inst_imports.insert(&self.cx[ext_set]);
             }
@@ -1286,7 +1290,7 @@ impl LazyInst<'_, '_> {
                     match spv::Inst::from_canonical_data_inst_kind(kind).ok_or(kind) {
                         Ok(spv_inst) => (spv_inst, None),
 
-                        Err(DataInstKind::Scalar(_)) => {
+                        Err(DataInstKind::Scalar(_) | DataInstKind::Vector(_)) => {
                             unreachable!("should've been handled as canonical")
                         }
 

--- a/src/spv/lower.rs
+++ b/src/spv/lower.rs
@@ -1292,7 +1292,13 @@ impl Module {
                     // some "structured regions" replacement for the CFG.
                 } else {
                     let mut ids = &ids[..];
-                    let kind = if opcode == wk.OpFunctionCall {
+                    let kind = if let Some(kind) = raw_inst.without_ids.as_canonical_data_inst_kind(
+                        &cx,
+                        result_type.map(|ty| [ty]).as_ref().map_or(&[][..], |tys| &tys[..]),
+                    ) {
+                        // FIXME(eddyb) sanity-check the number/types of inputs.
+                        kind
+                    } else if opcode == wk.OpFunctionCall {
                         assert!(imms.is_empty());
                         let callee_id = ids[0];
                         let maybe_callee = id_defs

--- a/src/spv/lower.rs
+++ b/src/spv/lower.rs
@@ -589,15 +589,9 @@ impl Module {
 
                 let ty = cx.intern(TypeDef {
                     attrs: mem::take(&mut attrs),
-                    kind: match inst.as_canonical_type() {
-                        Some(type_kind) => {
-                            assert_eq!(type_and_const_inputs.len(), 0);
-                            type_kind
-                        }
-                        None => {
-                            TypeKind::SpvInst { spv_inst: inst.without_ids, type_and_const_inputs }
-                        }
-                    },
+                    kind: inst.as_canonical_type(&cx, &type_and_const_inputs).unwrap_or(
+                        TypeKind::SpvInst { spv_inst: inst.without_ids, type_and_const_inputs },
+                    ),
                 });
                 id_defs.insert(id, IdDef::Type(ty));
 
@@ -626,15 +620,11 @@ impl Module {
                 let ct = cx.intern(ConstDef {
                     attrs: mem::take(&mut attrs),
                     ty,
-                    kind: match inst.as_canonical_const(&cx, ty) {
-                        Some(const_kind) => {
-                            assert_eq!(const_inputs.len(), 0);
-                            const_kind
-                        }
-                        None => ConstKind::SpvInst {
+                    kind: inst.as_canonical_const(&cx, ty, &const_inputs).unwrap_or_else(|| {
+                        ConstKind::SpvInst {
                             spv_inst_and_const_inputs: Rc::new((inst.without_ids, const_inputs)),
-                        },
-                    },
+                        }
+                    }),
                 });
                 id_defs.insert(id, IdDef::Const(ct));
 

--- a/src/spv/mod.rs
+++ b/src/spv/mod.rs
@@ -2,6 +2,7 @@
 
 // NOTE(eddyb) all the modules are declared here, but they're documented "inside"
 // (i.e. using inner doc comments).
+pub mod canonical;
 pub mod lift;
 pub mod lower;
 pub mod print;

--- a/src/spv/spec.rs
+++ b/src/spv/spec.rs
@@ -136,7 +136,6 @@ def_well_known! {
         OpConstantFalse,
         OpConstantTrue,
         OpConstant,
-        OpUndef,
 
         OpVariable,
 

--- a/src/spv/spec.rs
+++ b/src/spv/spec.rs
@@ -117,9 +117,6 @@ def_well_known! {
         OpNoLine,
 
         OpTypeVoid,
-        OpTypeBool,
-        OpTypeInt,
-        OpTypeFloat,
         OpTypeVector,
         OpTypeMatrix,
         OpTypeArray,
@@ -132,10 +129,6 @@ def_well_known! {
         OpTypeSampler,
         OpTypeSampledImage,
         OpTypeAccelerationStructureKHR,
-
-        OpConstantFalse,
-        OpConstantTrue,
-        OpConstant,
 
         OpVariable,
 

--- a/src/spv/spec.rs
+++ b/src/spv/spec.rs
@@ -129,6 +129,7 @@ def_well_known! {
         OpTypeSampledImage,
         OpTypeAccelerationStructureKHR,
 
+        // FIXME(eddyb) hide these from code, lowering should handle most cases.
         OpConstantComposite,
 
         OpVariable,
@@ -159,6 +160,11 @@ def_well_known! {
         OpPtrAccessChain,
         OpInBoundsPtrAccessChain,
         OpBitcast,
+
+        // FIXME(eddyb) hide these from code, lowering should handle most cases.
+        OpCompositeInsert,
+        OpCompositeExtract,
+        OpCompositeConstruct,
     ],
     operand_kind: OperandKind = [
         Capability,

--- a/src/spv/spec.rs
+++ b/src/spv/spec.rs
@@ -117,7 +117,6 @@ def_well_known! {
         OpNoLine,
 
         OpTypeVoid,
-        OpTypeVector,
         OpTypeMatrix,
         OpTypeArray,
         OpTypeRuntimeArray,
@@ -129,6 +128,8 @@ def_well_known! {
         OpTypeSampler,
         OpTypeSampledImage,
         OpTypeAccelerationStructureKHR,
+
+        OpConstantComposite,
 
         OpVariable,
 

--- a/src/spv/spec.rs
+++ b/src/spv/spec.rs
@@ -175,6 +175,7 @@ def_well_known! {
         LiteralExtInstInteger,
         LiteralString,
         LiteralContextDependentNumber,
+        LiteralSpecConstantOpInteger,
     ],
     // FIXME(eddyb) find a way to namespace these to avoid conflicts.
     addressing_model: u32 = [

--- a/src/transform.rs
+++ b/src/transform.rs
@@ -424,7 +424,9 @@ impl InnerTransform for TypeDef {
         transform!({
             attrs -> transformer.transform_attr_set_use(*attrs),
             kind -> match kind {
-                TypeKind::QPtr | TypeKind::SpvStringLiteralForExtInst => Transformed::Unchanged,
+                TypeKind::Scalar(_)
+                | TypeKind::QPtr
+                | TypeKind::SpvStringLiteralForExtInst => Transformed::Unchanged,
 
                 TypeKind::SpvInst { spv_inst, type_and_const_inputs } => Transformed::map_iter(
                     type_and_const_inputs.iter(),
@@ -458,6 +460,7 @@ impl InnerTransform for ConstDef {
             ty -> transformer.transform_type_use(*ty),
             kind -> match kind {
                 ConstKind::Undef
+                | ConstKind::Scalar(_)
                 | ConstKind::SpvStringLiteralForExtInst(_) => Transformed::Unchanged,
 
                 ConstKind::PtrToGlobalVar(gv) => transform!({

--- a/src/transform.rs
+++ b/src/transform.rs
@@ -425,6 +425,7 @@ impl InnerTransform for TypeDef {
             attrs -> transformer.transform_attr_set_use(*attrs),
             kind -> match kind {
                 TypeKind::Scalar(_)
+                | TypeKind::Vector(_)
                 | TypeKind::QPtr
                 | TypeKind::SpvStringLiteralForExtInst => Transformed::Unchanged,
 
@@ -461,6 +462,7 @@ impl InnerTransform for ConstDef {
             kind -> match kind {
                 ConstKind::Undef
                 | ConstKind::Scalar(_)
+                | ConstKind::Vector(_)
                 | ConstKind::SpvStringLiteralForExtInst(_) => Transformed::Unchanged,
 
                 ConstKind::PtrToGlobalVar(gv) => transform!({

--- a/src/transform.rs
+++ b/src/transform.rs
@@ -724,6 +724,7 @@ impl InnerTransform for DataInstFormDef {
                     | QPtrOp::Store => Transformed::Unchanged,
                 },
                 DataInstKind::Scalar(_)
+                | DataInstKind::Vector(_)
                 | DataInstKind::SpvInst(_)
                 | DataInstKind::SpvExtInst { .. } => Transformed::Unchanged,
             },

--- a/src/transform.rs
+++ b/src/transform.rs
@@ -457,6 +457,9 @@ impl InnerTransform for ConstDef {
             attrs -> transformer.transform_attr_set_use(*attrs),
             ty -> transformer.transform_type_use(*ty),
             kind -> match kind {
+                ConstKind::Undef
+                | ConstKind::SpvStringLiteralForExtInst(_) => Transformed::Unchanged,
+
                 ConstKind::PtrToGlobalVar(gv) => transform!({
                     gv -> transformer.transform_global_var_use(*gv),
                 } => ConstKind::PtrToGlobalVar(gv)),
@@ -470,7 +473,6 @@ impl InnerTransform for ConstDef {
                         spv_inst_and_const_inputs: Rc::new((spv_inst.clone(), new_iter.collect())),
                     })
                 }
-                ConstKind::SpvStringLiteralForExtInst(_) => Transformed::Unchanged
             },
         } => Self {
             attrs,

--- a/src/transform.rs
+++ b/src/transform.rs
@@ -721,7 +721,9 @@ impl InnerTransform for DataInstFormDef {
                     | QPtrOp::Load
                     | QPtrOp::Store => Transformed::Unchanged,
                 },
-                DataInstKind::SpvInst(_) | DataInstKind::SpvExtInst { .. } => Transformed::Unchanged,
+                DataInstKind::Scalar(_)
+                | DataInstKind::SpvInst(_)
+                | DataInstKind::SpvExtInst { .. } => Transformed::Unchanged,
             },
             // FIXME(eddyb) this should be replaced with an impl of `InnerTransform`
             // for `Option<T>` or some other helper, to avoid "manual transpose".

--- a/src/transform.rs
+++ b/src/transform.rs
@@ -640,7 +640,7 @@ impl InnerInPlaceTransform for FuncAtMut<'_, ControlNode> {
                 }
             }
             ControlNodeKind::Select {
-                kind: SelectionKind::BoolCond | SelectionKind::SpvInst(_),
+                kind: SelectionKind::BoolCond | SelectionKind::Switch { case_consts: _ },
                 scrutinee,
                 cases: _,
             } => {
@@ -747,7 +747,7 @@ impl InnerInPlaceTransform for cfg::ControlInst {
             | cfg::ControlInstKind::ExitInvocation(cfg::ExitInvocationKind::SpvInst(_))
             | cfg::ControlInstKind::Branch
             | cfg::ControlInstKind::SelectBranch(
-                SelectionKind::BoolCond | SelectionKind::SpvInst(_),
+                SelectionKind::BoolCond | SelectionKind::Switch { case_consts: _ },
             ) => {}
         }
         for v in inputs {

--- a/src/vector.rs
+++ b/src/vector.rs
@@ -1,0 +1,123 @@
+//! Vector types (small arrays of [`scalar`](crate::scalar)s) and associated functionality.
+//!
+//! **Note**: these are similar to SIMD types in other IRs, but SPIR-V often uses
+//! its `OpTypeVector` to represent geometrical vectors, colors, etc. without any
+//! expectation of SIMD execution (which most GPU execution models use implicitly,
+//! i.e. one non-uniform scalar becomes a hardware SIMD vector, while a high-level
+//! "vector" of N "lanes", becomes N separate hardware SIMD vectors).
+
+use crate::scalar;
+use smallvec::SmallVec;
+use std::num::NonZeroU8;
+use std::rc::Rc;
+
+// FIXME(eddyb) this entire module shorthands "element" as "elem", is that good?
+
+#[derive(Copy, Clone, PartialEq, Eq, Hash)]
+pub struct Type {
+    pub elem: scalar::Type,
+    // FIXME(eddyb) maybe wrap this in a type that abstracts away the encoding?
+    pub elem_count: NonZeroU8,
+}
+
+// FIXME(eddyb) document the 128-bit limitations inherited from `scalar::Const`.
+#[derive(Clone, PartialEq, Eq, Hash)]
+pub struct Const(ConstRepr);
+
+// HACK(eddyb) `#[repr(packed)]` not allowed on `enum`s themselves.
+#[repr(packed)]
+#[derive(Copy, Clone, PartialEq, Eq, Hash)]
+struct Packed<T>(T);
+
+// FIXME(eddyb) maybe build an abstraction for "N-dimensional" bit arrays?
+#[derive(Clone, PartialEq, Eq, Hash)]
+#[repr(u8)]
+enum ConstRepr {
+    // HACK(eddyb) `(Type, u128)` would waste almost half its size on padding, and
+    // packing will only impact accessing the bits, while allowing e.g. being
+    // wrapped in an outer `enum`, before reaching the same size as `(u128, u128)`.
+    Inline(Type, Packed<u128>),
+
+    // HACK(eddyb) this does raise the alignment, but the size and alignment are
+    // kept at one pointer (so likely half of `u128`) - `Packed<Rc<_>>` is sadly
+    // not an option because `#[derive(...)]` + `#[repr(packed)]` often requires
+    // `Copy` in order to be able to safely take references (to a copy of a field).
+    Boxed(Type, Rc<Vec<u128>>),
+}
+
+impl Const {
+    pub const fn ty(&self) -> Type {
+        match self.0 {
+            ConstRepr::Inline(ty, _) | ConstRepr::Boxed(ty, _) => ty,
+        }
+    }
+
+    pub fn from_elems(ty: Type, elems: impl IntoIterator<Item = scalar::Const>) -> Const {
+        let elem_width = ty.elem.bit_width();
+        assert!(elem_width <= 128);
+
+        let expected_elem_count = u32::from(ty.elem_count.get());
+
+        let num_limbs = elem_width.checked_mul(expected_elem_count).unwrap().div_ceil(128);
+        assert_ne!(num_limbs, 0);
+        let mut limbs = SmallVec::<[u128; 1]>::from_elem(0, usize::try_from(num_limbs).unwrap());
+
+        let mut found_elem_count = 0;
+        for ct in elems {
+            let i: u32 = found_elem_count;
+            found_elem_count = found_elem_count.checked_add(1).unwrap();
+            if i >= expected_elem_count {
+                continue;
+            }
+
+            // FIXME(eddyb) get better names (perhaps from miri-like memory?).
+            let first_bit_idx = i.checked_mul(elem_width).unwrap();
+            let limb_idx = first_bit_idx / 128;
+            let intra_limb_first_bit_idx = first_bit_idx % 128;
+            assert!(intra_limb_first_bit_idx + elem_width <= 128);
+
+            limbs[usize::try_from(limb_idx).unwrap()] |= ct.bits() << intra_limb_first_bit_idx;
+        }
+        assert_eq!(found_elem_count, expected_elem_count);
+
+        match limbs.into_inner() {
+            Ok([limb]) => Const(ConstRepr::Inline(ty, Packed(limb))),
+            Err(limbs) => Const(ConstRepr::Boxed(ty, Rc::new(limbs.into_vec()))),
+        }
+    }
+
+    pub fn get_elem(&self, i: usize) -> Option<scalar::Const> {
+        let ty = self.ty();
+        if i >= usize::from(ty.elem_count.get()) {
+            return None;
+        }
+        let i = u32::try_from(i).unwrap();
+        let elem_width = ty.elem.bit_width();
+        assert!(elem_width <= 128);
+
+        // FIXME(eddyb) get better names (perhaps from miri-like memory?).
+        let first_bit_idx = i.checked_mul(elem_width).unwrap();
+        let limb_idx = first_bit_idx / 128;
+        let intra_limb_first_bit_idx = first_bit_idx % 128;
+        assert!(intra_limb_first_bit_idx + elem_width <= 128);
+
+        let limb = match &self.0 {
+            ConstRepr::Inline(_, limb) => {
+                assert_eq!(limb_idx, 0);
+                limb.0
+            }
+            ConstRepr::Boxed(_, limbs) => limbs[usize::try_from(limb_idx).unwrap()],
+        };
+
+        Some(scalar::Const::from_bits(
+            ty.elem,
+            (limb >> intra_limb_first_bit_idx) & (!0 >> (128 - elem_width)),
+        ))
+    }
+
+    pub fn elems(&self) -> impl Iterator<Item = scalar::Const> + '_ {
+        let ty = self.ty();
+        // FIXME(eddyb) there should be a more efficient way to do this.
+        (0..usize::from(ty.elem_count.get())).map(|i| self.get_elem(i).unwrap())
+    }
+}

--- a/src/vector.rs
+++ b/src/vector.rs
@@ -121,3 +121,60 @@ impl Const {
         (0..usize::from(ty.elem_count.get())).map(|i| self.get_elem(i).unwrap())
     }
 }
+
+/// Pure operations with vector inputs and/or outputs.
+#[derive(Copy, Clone, PartialEq, Eq, Hash, derive_more::From)]
+pub enum Op {
+    Distribute(scalar::Op),
+    Reduce(ReduceOp),
+
+    // FIXME(eddyb) find a better name for this category of ops.
+    Whole(WholeOp),
+}
+
+#[derive(Copy, Clone, PartialEq, Eq, Hash)]
+pub enum ReduceOp {
+    // FIXME(eddyb) also support all the new integer dot product instructions.
+    Dot,
+    // FIXME(eddyb) model these using their respective `BoolBinOp`s?
+    Any,
+    All,
+}
+
+impl ReduceOp {
+    pub fn name(self) -> &'static str {
+        match self {
+            ReduceOp::Dot => "vec.dot",
+            ReduceOp::Any => "vec.any",
+            ReduceOp::All => "vec.all",
+        }
+    }
+}
+
+// FIXME(eddyb) find a better name for this category of ops.
+// FIXME(eddyb) also support `OpVectorShuffle`.
+#[derive(Copy, Clone, PartialEq, Eq, Hash)]
+pub enum WholeOp {
+    // FIXME(eddyb) better name for this (pack? make? "construct" is too long).
+    New,
+    Extract { elem_idx: u8 },
+    Insert { elem_idx: u8 },
+    DynExtract,
+    DynInsert,
+
+    // FIXME(eddyb) may need a better name to indicate "scalar product".
+    Mul,
+}
+
+impl WholeOp {
+    pub fn name(self) -> &'static str {
+        match self {
+            WholeOp::New => "vec.new",
+            WholeOp::Extract { .. } => "vec.extract",
+            WholeOp::Insert { .. } => "vec.insert",
+            WholeOp::DynExtract => "vec.dyn_extract",
+            WholeOp::DynInsert => "vec.dyn_insert",
+            WholeOp::Mul => "vec.mul",
+        }
+    }
+}

--- a/src/visit.rs
+++ b/src/visit.rs
@@ -542,6 +542,7 @@ impl InnerVisit for DataInstFormDef {
                 | QPtrOp::Store => {}
             },
             DataInstKind::Scalar(_)
+            | DataInstKind::Vector(_)
             | DataInstKind::SpvInst(_)
             | DataInstKind::SpvExtInst { .. } => {}
         }

--- a/src/visit.rs
+++ b/src/visit.rs
@@ -475,7 +475,7 @@ impl<'a> FuncAt<'a, ControlNode> {
                 }
             }
             ControlNodeKind::Select {
-                kind: SelectionKind::BoolCond | SelectionKind::SpvInst(_),
+                kind: SelectionKind::BoolCond | SelectionKind::Switch { case_consts: _ },
                 scrutinee,
                 cases,
             } => {
@@ -556,7 +556,7 @@ impl InnerVisit for cfg::ControlInst {
             | cfg::ControlInstKind::ExitInvocation(cfg::ExitInvocationKind::SpvInst(_))
             | cfg::ControlInstKind::Branch
             | cfg::ControlInstKind::SelectBranch(
-                SelectionKind::BoolCond | SelectionKind::SpvInst(_),
+                SelectionKind::BoolCond | SelectionKind::Switch { case_consts: _ },
             ) => {}
         }
         for v in inputs {

--- a/src/visit.rs
+++ b/src/visit.rs
@@ -315,7 +315,7 @@ impl InnerVisit for TypeDef {
 
         visitor.visit_attr_set_use(*attrs);
         match kind {
-            TypeKind::QPtr | TypeKind::SpvStringLiteralForExtInst => {}
+            TypeKind::Scalar(_) | TypeKind::QPtr | TypeKind::SpvStringLiteralForExtInst => {}
 
             TypeKind::SpvInst { spv_inst: _, type_and_const_inputs } => {
                 for &ty_or_ct in type_and_const_inputs {
@@ -336,7 +336,7 @@ impl InnerVisit for ConstDef {
         visitor.visit_attr_set_use(*attrs);
         visitor.visit_type_use(*ty);
         match kind {
-            ConstKind::Undef | ConstKind::SpvStringLiteralForExtInst(_) => {}
+            ConstKind::Undef | ConstKind::Scalar(_) | ConstKind::SpvStringLiteralForExtInst(_) => {}
 
             &ConstKind::PtrToGlobalVar(gv) => visitor.visit_global_var_use(gv),
             ConstKind::SpvInst { spv_inst_and_const_inputs } => {

--- a/src/visit.rs
+++ b/src/visit.rs
@@ -535,7 +535,9 @@ impl InnerVisit for DataInstFormDef {
                 | QPtrOp::Load
                 | QPtrOp::Store => {}
             },
-            DataInstKind::SpvInst(_) | DataInstKind::SpvExtInst { .. } => {}
+            DataInstKind::Scalar(_)
+            | DataInstKind::SpvInst(_)
+            | DataInstKind::SpvExtInst { .. } => {}
         }
         if let Some(ty) = *output_type {
             visitor.visit_type_use(ty);

--- a/src/visit.rs
+++ b/src/visit.rs
@@ -315,7 +315,10 @@ impl InnerVisit for TypeDef {
 
         visitor.visit_attr_set_use(*attrs);
         match kind {
-            TypeKind::Scalar(_) | TypeKind::QPtr | TypeKind::SpvStringLiteralForExtInst => {}
+            TypeKind::Scalar(_)
+            | TypeKind::Vector(_)
+            | TypeKind::QPtr
+            | TypeKind::SpvStringLiteralForExtInst => {}
 
             TypeKind::SpvInst { spv_inst: _, type_and_const_inputs } => {
                 for &ty_or_ct in type_and_const_inputs {
@@ -336,7 +339,10 @@ impl InnerVisit for ConstDef {
         visitor.visit_attr_set_use(*attrs);
         visitor.visit_type_use(*ty);
         match kind {
-            ConstKind::Undef | ConstKind::Scalar(_) | ConstKind::SpvStringLiteralForExtInst(_) => {}
+            ConstKind::Undef
+            | ConstKind::Scalar(_)
+            | ConstKind::Vector(_)
+            | ConstKind::SpvStringLiteralForExtInst(_) => {}
 
             &ConstKind::PtrToGlobalVar(gv) => visitor.visit_global_var_use(gv),
             ConstKind::SpvInst { spv_inst_and_const_inputs } => {

--- a/src/visit.rs
+++ b/src/visit.rs
@@ -336,6 +336,8 @@ impl InnerVisit for ConstDef {
         visitor.visit_attr_set_use(*attrs);
         visitor.visit_type_use(*ty);
         match kind {
+            ConstKind::Undef | ConstKind::SpvStringLiteralForExtInst(_) => {}
+
             &ConstKind::PtrToGlobalVar(gv) => visitor.visit_global_var_use(gv),
             ConstKind::SpvInst { spv_inst_and_const_inputs } => {
                 let (_spv_inst, const_inputs) = &**spv_inst_and_const_inputs;
@@ -343,7 +345,6 @@ impl InnerVisit for ConstDef {
                     visitor.visit_const_use(ct);
                 }
             }
-            ConstKind::SpvStringLiteralForExtInst(_) => {}
         }
     }
 }

--- a/vk-layer/Cargo.toml
+++ b/vk-layer/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "spirt-vk-layer"
+description = "Vulkan layer injecting SPIR-T passes into the Vulkan CTS/apps/etc."
+version = "0.0.0"
+edition = "2021"
+publish = false
+
+[lib]
+name = 'VkLayer_spirt_shaders'
+crate-type = ["cdylib"]
+
+[dependencies]
+spirt = { path = ".." }
+
+ash = "0.37.2"
+vulkan-layer = { git = "https://github.com/google/vk-layer-for-rust", rev = "a236360" }
+
+# FIXME(eddyb) deduplicate these by the workspace inheritance feature.
+bytemuck = "1.12.3"
+lazy_static = "1.4.0"

--- a/vk-layer/manifests/target_debug_lib.so/VkLayer_spirt_shaders.json
+++ b/vk-layer/manifests/target_debug_lib.so/VkLayer_spirt_shaders.json
@@ -1,0 +1,15 @@
+{
+    "_comments": [
+        "HACK(eddyb) the weird directory this JSON is in encodes the `library_path` choice",
+        "FIXME(eddyb) these JSON files should be auto-generated instead (via artifact deps?)"
+    ],
+    "file_format_version": "1.2.1",
+    "layer": {
+        "name": "VK_LAYER_SPIRT_shaders",
+        "type": "INSTANCE",
+        "library_path": "../../../target/debug/libVkLayer_spirt_shaders.so",
+        "api_version": "1.1.0",
+        "implementation_version": "0",
+        "description": "SPIR-T-based shader rewriter layer"
+    }
+}

--- a/vk-layer/manifests/target_i686-unknown-linux-gnu_debug_lib.so/VkLayer_spirt_shaders.json
+++ b/vk-layer/manifests/target_i686-unknown-linux-gnu_debug_lib.so/VkLayer_spirt_shaders.json
@@ -1,0 +1,15 @@
+{
+    "_comments": [
+        "HACK(eddyb) the weird directory this JSON is in encodes the `library_path` choice",
+        "FIXME(eddyb) these JSON files should be auto-generated instead (via artifact deps?)"
+    ],
+    "file_format_version": "1.2.1",
+    "layer": {
+        "name": "VK_LAYER_SPIRT_shaders",
+        "type": "INSTANCE",
+        "library_path": "../../../target/i686-unknown-linux-gnu/debug/libVkLayer_spirt_shaders.so",
+        "api_version": "1.1.0",
+        "implementation_version": "0",
+        "description": "SPIR-T-based shader rewriter layer"
+    }
+}

--- a/vk-layer/manifests/target_i686-unknown-linux-gnu_release_lib.so/VkLayer_spirt_shaders.json
+++ b/vk-layer/manifests/target_i686-unknown-linux-gnu_release_lib.so/VkLayer_spirt_shaders.json
@@ -1,0 +1,15 @@
+{
+    "_comments": [
+        "HACK(eddyb) the weird directory this JSON is in encodes the `library_path` choice",
+        "FIXME(eddyb) these JSON files should be auto-generated instead (via artifact deps?)"
+    ],
+    "file_format_version": "1.2.1",
+    "layer": {
+        "name": "VK_LAYER_SPIRT_shaders",
+        "type": "INSTANCE",
+        "library_path": "../../../target/i686-unknown-linux-gnu/release/libVkLayer_spirt_shaders.so",
+        "api_version": "1.1.0",
+        "implementation_version": "0",
+        "description": "SPIR-T-based shader rewriter layer"
+    }
+}

--- a/vk-layer/manifests/target_release_lib.so/VkLayer_spirt_shaders.json
+++ b/vk-layer/manifests/target_release_lib.so/VkLayer_spirt_shaders.json
@@ -1,0 +1,15 @@
+{
+    "_comments": [
+        "HACK(eddyb) the weird directory this JSON is in encodes the `library_path` choice",
+        "FIXME(eddyb) these JSON files should be auto-generated instead (via artifact deps?)"
+    ],
+    "file_format_version": "1.2.1",
+    "layer": {
+        "name": "VK_LAYER_SPIRT_shaders",
+        "type": "INSTANCE",
+        "library_path": "../../../target/release/libVkLayer_spirt_shaders.so",
+        "api_version": "1.1.0",
+        "implementation_version": "0",
+        "description": "SPIR-T-based shader rewriter layer"
+    }
+}

--- a/vk-layer/src/lib.rs
+++ b/vk-layer/src/lib.rs
@@ -1,0 +1,7 @@
+//! Vulkan layer injecting SPIR-T passes into the Vulkan CTS/apps/etc.
+
+// HACK(eddyb) this is really only about the crate itself.
+#![allow(non_snake_case)]
+
+#[warn(non_snake_case)]
+mod shaders_layer;

--- a/vk-layer/src/shaders_layer.rs
+++ b/vk-layer/src/shaders_layer.rs
@@ -1,0 +1,238 @@
+//! Vulkan layer that can rewrite SPIR-V shaders passed to Vulkan commands.
+
+use ash::{self, prelude::*, vk};
+use lazy_static::lazy_static;
+use std::rc::Rc;
+use std::sync::Arc;
+use vulkan_layer::auto_deviceinfo_impl;
+use vulkan_layer::DeviceHooks;
+use vulkan_layer::LayerResult;
+use vulkan_layer::{
+    declare_introspection_queries, Global, Layer, LayerManifest, StubGlobalHooks, StubInstanceInfo,
+};
+
+#[derive(Default)]
+struct Config {
+    verbose: bool,
+    spv_copy: bool,
+    spirt_passes: Option<Vec<String>>,
+}
+
+lazy_static! {
+    static ref CONFIG: Config = {
+        let var_name = "VK_LAYER_SPIRT_CONFIG";
+        let var_contents = std::env::var(var_name)
+            .unwrap_or_else(|e| panic!("env var `{var_name}` is required: {e:?}"));
+
+        let mut config = Config::default();
+        for part in var_contents.split('+') {
+            if part == "verbose" {
+                config.verbose = true;
+            } else if part == "spv-copy" {
+                config.spv_copy = true;
+            } else if let Some(passes) = part.strip_prefix("spirt-passes=") {
+                config.spirt_passes = Some(
+                    passes.split(',').filter(|s| !s.is_empty()).map(|s| s.to_string()).collect(),
+                );
+            } else {
+                panic!(
+                    "`{var_name}` should contain `+`-separated `verbose`/`spv-copy`/`spirt-passes=...`"
+                );
+            }
+        }
+        if config.spv_copy == config.spirt_passes.is_some() {
+            panic!("`{var_name}` should have exactly one of `spv-copy` or `spirt-passes=...`");
+        }
+        config
+    };
+}
+
+#[derive(Default)]
+struct ShadersLayer(StubGlobalHooks);
+
+struct ShadersDeviceHooks {
+    config: &'static Config,
+    spv_spec: &'static spirt::spv::spec::Spec,
+    device_as_next: Arc<ash::Device>,
+}
+
+impl Layer for ShadersLayer {
+    type GlobalHooksInfo = StubGlobalHooks;
+    type InstanceInfo = StubInstanceInfo;
+    type DeviceInfo = ShadersDeviceHooks;
+    type InstanceInfoContainer = Self::InstanceInfo;
+    type DeviceInfoContainer = Self::DeviceInfo;
+
+    fn global_instance() -> &'static Global<Self> {
+        lazy_static! {
+            static ref GLOBAL: Global<ShadersLayer> = Default::default();
+        }
+        &GLOBAL
+    }
+
+    fn manifest() -> LayerManifest {
+        let mut manifest = LayerManifest::default();
+        manifest.name = "VK_LAYER_SPIRT_shaders";
+        manifest.spec_version = vk::API_VERSION_1_1;
+        manifest.description = "SPIR-T-based shader rewriter layer";
+        manifest
+    }
+
+    fn global_hooks_info(&self) -> &Self::GlobalHooksInfo {
+        &self.0
+    }
+
+    fn create_instance_info(
+        &self,
+        _: &vk::InstanceCreateInfo,
+        _: Option<&vk::AllocationCallbacks>,
+        _: Arc<ash::Instance>,
+        _next_get_instance_proc_addr: vk::PFN_vkGetInstanceProcAddr,
+    ) -> Self::InstanceInfoContainer {
+        Default::default()
+    }
+
+    fn create_device_info(
+        &self,
+        _: vk::PhysicalDevice,
+        _: &vk::DeviceCreateInfo,
+        _: Option<&vk::AllocationCallbacks>,
+        device_as_next: Arc<ash::Device>,
+        _next_get_device_proc_addr: vk::PFN_vkGetDeviceProcAddr,
+    ) -> ShadersDeviceHooks {
+        ShadersDeviceHooks {
+            config: &CONFIG,
+            spv_spec: spirt::spv::spec::Spec::get(),
+            device_as_next,
+        }
+    }
+}
+
+declare_introspection_queries!(Global::<ShadersLayer>);
+
+// FIXME(eddyb) stop abusing `io::Error` for error reporting.
+fn invalid(reason: &str) -> std::io::Error {
+    std::io::Error::new(std::io::ErrorKind::InvalidData, format!("malformed SPIR-V ({reason})"))
+}
+
+impl ShadersDeviceHooks {
+    fn timed_pass<R>(&self, name: &str, f: impl FnOnce() -> R) -> R {
+        if !self.config.verbose {
+            return f();
+        }
+
+        let start = std::time::Instant::now();
+        let r = f();
+        eprintln!("[{:8.3}ms] {name}", start.elapsed().as_secs_f64() * 1000.0);
+        r
+    }
+
+    fn process_shader(&self, in_spv_bytes: &[u8]) -> std::io::Result<Vec<u32>> {
+        let in_spv_words = bytemuck::cast_slice::<u8, u32>(in_spv_bytes);
+
+        if self.config.spv_copy {
+            if !in_spv_words.starts_with(&[self.spv_spec.magic]) {
+                return Err(invalid("does not start with SPIR-V magic number"));
+            }
+            return Ok(in_spv_words.to_vec());
+        }
+        let spirt_passes = self.config.spirt_passes.as_ref().unwrap();
+
+        if self.config.verbose {
+            eprintln!();
+        }
+
+        // FIXME(eddyb) there should be no conversion necessary to use `&[u32]`.
+        let mut module = self.timed_pass("Module::lower_from_spv_bytes", || {
+            spirt::Module::lower_from_spv_bytes(
+                Rc::new(spirt::Context::new()),
+                bytemuck::cast_slice(in_spv_words).to_vec(),
+            )
+        })?;
+
+        // FIXME(eddyb) this should be its own
+        if self.config.verbose {
+            let (printed_deps, printed_exports) =
+                spirt::print::Plan::for_module(&module).pretty_print_deps_and_root_separately();
+            let printed_deps = printed_deps.to_string();
+            let printed_deps_lines = printed_deps.lines().collect::<Vec<_>>();
+            const CONTEXT: usize = 100;
+            eprintln!("```spirt");
+            if printed_deps_lines.len() <= CONTEXT * 2 {
+                eprintln!("{}", printed_deps_lines.join("\n"));
+            } else {
+                eprintln!("{}", printed_deps_lines[..CONTEXT].join("\n"));
+                eprintln!("··· {} lines skipped ···", printed_deps_lines.len() - CONTEXT * 2);
+                eprintln!(
+                    "{}",
+                    printed_deps_lines[printed_deps_lines.len() - CONTEXT..].join("\n")
+                );
+            }
+            eprintln!("{printed_exports}");
+            eprintln!("```");
+        }
+
+        self.timed_pass("legalize::structurize_func_cfgs", || {
+            spirt::passes::legalize::structurize_func_cfgs(&mut module)
+        });
+
+        for pass in spirt_passes {
+            match &pass[..] {
+                "qptr" => {
+                    let layout_config = &spirt::qptr::LayoutConfig {
+                        abstract_bool_size_align: (1, 1),
+                        logical_ptr_size_align: (8, 8),
+                        ..spirt::qptr::LayoutConfig::VULKAN_SCALAR_LAYOUT
+                    };
+
+                    self.timed_pass("qptr::lower_from_spv_ptrs", || {
+                        spirt::passes::qptr::lower_from_spv_ptrs(&mut module, layout_config)
+                    });
+                    self.timed_pass("qptr::analyze_uses", || {
+                        spirt::passes::qptr::analyze_uses(&mut module, layout_config)
+                    });
+                    self.timed_pass("qptr::lift_to_spv_ptrs", || {
+                        spirt::passes::qptr::lift_to_spv_ptrs(&mut module, layout_config)
+                    });
+                }
+                _ => unimplemented!("unknown pass {pass}"),
+            }
+        }
+
+        let out_spv_module_emitter = self.timed_pass("Module::lift_to_spv_module_emitter", || {
+            module.lift_to_spv_module_emitter()
+        });
+        Ok(out_spv_module_emitter.unwrap().words)
+    }
+}
+
+#[auto_deviceinfo_impl]
+impl DeviceHooks for ShadersDeviceHooks {
+    fn create_shader_module(
+        &self,
+        create_info: &vk::ShaderModuleCreateInfo,
+        allocation_callbacks: Option<&vk::AllocationCallbacks>,
+    ) -> LayerResult<VkResult<vk::ShaderModule>> {
+        let mut create_info = *create_info;
+        let in_spv_bytes = unsafe {
+            std::slice::from_raw_parts(create_info.p_code as *const u8, create_info.code_size)
+        };
+
+        let out_spv_words = match self.process_shader(in_spv_bytes) {
+            Ok(spv_words) => spv_words,
+            Err(e) => {
+                eprintln!("[VK_LAYER_SPIRT_shaders] ERROR in vkCreateShaderModule: {e}");
+                return LayerResult::Handled(Err(vk::Result::ERROR_INITIALIZATION_FAILED));
+            }
+        };
+
+        // FIXME(eddyb) can we use the builder here somehow?
+        create_info.p_code = out_spv_words.as_ptr();
+        create_info.code_size = out_spv_words.len() * 4;
+
+        let result =
+            unsafe { self.device_as_next.create_shader_module(&create_info, allocation_callbacks) };
+
+        LayerResult::Handled(result)
+    }
+}


### PR DESCRIPTION
* based on `vector` aka #52

Behavior is kind of arbitrary right now (mostly a demo), and ergonomics are lacking.
The main goal will be to run the full Vulkan CTS ("Conformance Test Suite") with it enabled.

Both of these should work (where `vkapp` is e.g. `vkcube`) on Linux:
```sh
VK_LAYER_PATH=$PWD/vk-layer/manifests/target_debug_lib.so VK_LOADER_LAYERS_ENABLE=VK_LAYER_SPIRT_shaders vkapp
```
```sh
cargo build -p spirt-vk-layer --target=i686-unknown-linux-gnu
VK_LAYER_PATH=$PWD/vk-layer/manifests/target_i686-unknown-linux-gnu_debug_lib.so VK_LOADER_LAYERS_ENABLE=VK_LAYER_SPIRT_shaders vkapp32
```

On Linux/Mesa, by setting `MESA_LOADER_DRIVER_OVERRIDE=zink` as well, it ends up affecting OpenGL too:
<img src="https://github.com/EmbarkStudios/spirt/assets/77424/acc54cca-4d64-4260-996b-cf807b625946" height="444">
