### PR TITLE
Ensure compatibility with rust-gpu nightly rust in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,6 +37,12 @@ jobs:
           rustup component add clippy
           cargo clippy --all-targets --all-features -- -D warnings
 
+      - name: Ensure compatibility with rust-gpu nightly rust version
+        run: |
+          curl -sSL https://github.com/EmbarkStudios/rust-gpu/raw/main/rust-toolchain.toml | grep -v '^components = ' > rust-toolchain.toml
+          cargo check --workspace --all-targets
+          rm rust-toolchain.toml
+
   test:
     name: Test
     strategy:


### PR DESCRIPTION
https://github.com/EmbarkStudios/spirt/pull/57#pullrequestreview-1805470744

It means we don't really have repeatable CI checks, but the practical benefits probably outweighs that (and if someone would like to pick up an old branch to work with an old rust-gpu version for whatever strange reason, this check can easily be modified or removed).