### PR TITLE
Update `SPIRV-Headers` to match Vulkan SDK 1.3.275.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,4 @@
 [submodule "khronos-spec/SPIRV-Headers"]
 	path = khronos-spec/SPIRV-Headers
 	url = https://github.com/KhronosGroup/SPIRV-Headers
+	branch = vulkan-sdk-1.3.275

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased] - ReleaseDate
 
 ### Changed 🛠
+- [PR#61](https://github.com/EmbarkStudios/spirt/pull/61) updated `SPIRV-Headers`
+  to match Vulkan SDK 1.3.275
 - [PR#55](https://github.com/EmbarkStudios/spirt/pull/55) fixed CFG structurization
   "region `children` list desync" assertion failures (e.g. [rust-gpu#1086](https://github.com/EmbarkStudios/rust-gpu/issues/1086))
   by tracking whole `ControlRegion`s instead of their `children`

--- a/src/spv/spec.rs
+++ b/src/spv/spec.rs
@@ -811,7 +811,8 @@ impl Spec {
                         let size = match o.kind {
                             "LiteralInteger"
                             | "LiteralExtInstInteger"
-                            | "LiteralSpecConstantOpInteger" => LiteralSize::Word,
+                            | "LiteralSpecConstantOpInteger"
+                            | "LiteralFloat" => LiteralSize::Word,
                             "LiteralString" => LiteralSize::NulTerminated,
                             "LiteralContextDependentNumber" => LiteralSize::FromContextualType,
                             _ => unreachable!(),


### PR DESCRIPTION
No big surprises, some nice cleanups and clarifications (some ray-tracing ops are no longer "Reserved" but sadly the SPIR-V spec page itself doesn't seem to have been regenerated since).

Mostly included it if we cut `spirt 0.4.0` now, don't want our `SPIRV-Headers` submodule to hold anything back.